### PR TITLE
Add GitHub Actions workflows for Unity 2022.3.61f1

### DIFF
--- a/.github/workflows/2022.3.61f1_editmode.yml
+++ b/.github/workflows/2022.3.61f1_editmode.yml
@@ -1,0 +1,18 @@
+name: 2022.3.61f1-editmode
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  editor-tests:
+    uses: ./.github/workflows/main.yml
+    with:
+      projectPath: './'
+      unityVersion: '2022.3.61f1'
+      testMode: 'editmode'
+    secrets: inherit

--- a/.github/workflows/2022.3.61f1_playmode.yml
+++ b/.github/workflows/2022.3.61f1_playmode.yml
@@ -1,0 +1,18 @@
+name: 2022.3.61f1-playmode
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  editor-tests:
+    uses: ./.github/workflows/main.yml
+    with:
+      projectPath: './'
+      unityVersion: '2022.3.61f1'
+      testMode: 'playmode'
+    secrets: inherit

--- a/.github/workflows/2022.3.61f1_standalone.yml
+++ b/.github/workflows/2022.3.61f1_standalone.yml
@@ -1,0 +1,18 @@
+name: 2022.3.61f1-standalone
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  editor-tests:
+    uses: ./.github/workflows/main.yml
+    with:
+      projectPath: './'
+      unityVersion: '2022.3.61f1'
+      testMode: 'standalone'
+    secrets: inherit


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows for different Unity test modes. The changes add three separate workflows for edit mode, play mode, and standalone mode, all using Unity version 2022.3.61f1.

New GitHub Actions workflows:

* [`.github/workflows/2022.3.61f1_editmode.yml`](diffhunk://#diff-e6993351528c95a93365aeb6362073ab63dfbbeab5ca796d684ccbed07190a06R1-R18): Added a workflow for running Unity editor tests in edit mode.
* [`.github/workflows/2022.3.61f1_playmode.yml`](diffhunk://#diff-76c2fdd0597bf7b9308dfad58397528f57d96c6445276dda3cae2e0fc015604dR1-R18): Added a workflow for running Unity editor tests in play mode.
* [`.github/workflows/2022.3.61f1_standalone.yml`](diffhunk://#diff-1a02c2710487d37a4a1c74dbb76cb670514c4769b7d882f902b48135a2dc63aaR1-R18): Added a workflow for running Unity editor tests in standalone mode.