### PR TITLE
Add GitHub Actions workflows for Unity 6000.0.46f1

### DIFF
--- a/.github/workflows/6000.0.46f1_editmode.yml
+++ b/.github/workflows/6000.0.46f1_editmode.yml
@@ -1,4 +1,4 @@
-name: 6000.0.37f1-standalone
+name: 6000.0.46f1-editmode
 
 on:
   pull_request:
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/main.yml
     with:
       projectPath: './'
-      unityVersion: '6000.0.37f1'
-      testMode: 'standalone'
+      unityVersion: '6000.0.46f1'
+      testMode: 'editmode'
     secrets: inherit

--- a/.github/workflows/6000.0.46f1_playmode.yml
+++ b/.github/workflows/6000.0.46f1_playmode.yml
@@ -1,4 +1,4 @@
-name: 6000.0.37f1-editmode
+name: 6000.0.46f1-playmode
 
 on:
   pull_request:
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/main.yml
     with:
       projectPath: './'
-      unityVersion: '6000.0.37f1'
-      testMode: 'editmode'
+      unityVersion: '6000.0.46f1'
+      testMode: 'playmode'
     secrets: inherit

--- a/.github/workflows/6000.0.46f1_standalone.yml
+++ b/.github/workflows/6000.0.46f1_standalone.yml
@@ -1,4 +1,4 @@
-name: 6000.0.37f1-playmode
+name: 6000.0.46f1-standalone
 
 on:
   pull_request:
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/main.yml
     with:
       projectPath: './'
-      unityVersion: '6000.0.37f1'
-      testMode: 'playmode'
+      unityVersion: '6000.0.46f1'
+      testMode: 'standalone'
     secrets: inherit


### PR DESCRIPTION
This pull request includes updates to the workflow files to reflect the new Unity version `6000.0.46f1`. The most important changes involve renaming the workflow files and updating the Unity version used in the jobs.

Updates to workflow files:

* [`.github/workflows/6000.0.46f1_editmode.yml`](diffhunk://#diff-9c8d547d8d28be1b62832572b91ebdc9a8fbcb6c96aad3e8f34cc6ae45d32572L1-R1): Renamed from `.github/workflows/6000.0.37f1_editmode.yml` and updated Unity version to `6000.0.46f1`. [[1]](diffhunk://#diff-9c8d547d8d28be1b62832572b91ebdc9a8fbcb6c96aad3e8f34cc6ae45d32572L1-R1) [[2]](diffhunk://#diff-9c8d547d8d28be1b62832572b91ebdc9a8fbcb6c96aad3e8f34cc6ae45d32572L16-R16)
* [`.github/workflows/6000.0.46f1_playmode.yml`](diffhunk://#diff-db91b781c0702a2a49a1226166241f05fc89f2dce0c262a0de63c3008f5fb312L1-R1): Renamed from `.github/workflows/6000.0.37f1_playmode.yml` and updated Unity version to `6000.0.46f1`. [[1]](diffhunk://#diff-db91b781c0702a2a49a1226166241f05fc89f2dce0c262a0de63c3008f5fb312L1-R1) [[2]](diffhunk://#diff-db91b781c0702a2a49a1226166241f05fc89f2dce0c262a0de63c3008f5fb312L16-R16)
* [`.github/workflows/6000.0.46f1_standalone.yml`](diffhunk://#diff-a70fab852714ad464d6b8c9b5424917084275b042b03614cfaf38ddb8044ea5aL1-R1): Renamed from `.github/workflows/6000.0.37f1_standalone.yml` and updated Unity version to `6000.0.46f1`. [[1]](diffhunk://#diff-a70fab852714ad464d6b8c9b5424917084275b042b03614cfaf38ddb8044ea5aL1-R1) [[2]](diffhunk://#diff-a70fab852714ad464d6b8c9b5424917084275b042b03614cfaf38ddb8044ea5aL16-R16)