### PR TITLE
Updated MCP C# SDK to version 0.1.0-preview.8

### DIFF
--- a/Assets/root/Server/Common/Data/Request/Tool/Call/IRequestCallTool.cs
+++ b/Assets/root/Server/Common/Data/Request/Tool/Call/IRequestCallTool.cs
@@ -8,6 +8,6 @@ namespace com.IvanMurzak.Unity.MCP.Common.Data
     public interface IRequestCallTool : IRequestID, IDisposable
     {
         string Name { get; set; }
-        Dictionary<string, JsonElement> Arguments { get; set; }
+        IReadOnlyDictionary<string, JsonElement> Arguments { get; set; }
     }
 }

--- a/Assets/root/Server/Common/Data/Request/Tool/Call/RequestCallTool.cs
+++ b/Assets/root/Server/Common/Data/Request/Tool/Call/RequestCallTool.cs
@@ -9,12 +9,12 @@ namespace com.IvanMurzak.Unity.MCP.Common.Data
     {
         public string RequestID { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
-        public Dictionary<string, JsonElement> Arguments { get; set; } = new();
+        public IReadOnlyDictionary<string, JsonElement> Arguments { get; set; } = new Dictionary<string, JsonElement>();
 
         public RequestCallTool() { }
-        public RequestCallTool(string name, Dictionary<string, JsonElement> arguments)
+        public RequestCallTool(string name, IReadOnlyDictionary<string, JsonElement> arguments)
             : this(Guid.NewGuid().ToString(), name, arguments) { }
-        public RequestCallTool(string requestId, string name, Dictionary<string, JsonElement> arguments)
+        public RequestCallTool(string requestId, string name, IReadOnlyDictionary<string, JsonElement> arguments)
         {
             RequestID = requestId ?? throw new ArgumentNullException(nameof(requestId));
             Name = name ?? throw new ArgumentNullException(nameof(name));
@@ -23,7 +23,7 @@ namespace com.IvanMurzak.Unity.MCP.Common.Data
 
         public virtual void Dispose()
         {
-            Arguments.Clear();
+            // Arguments.Clear();
         }
         ~RequestCallTool() => Dispose();
     }

--- a/Assets/root/Server/Common/Runner/Tool/IRunTool.cs
+++ b/Assets/root/Server/Common/Runner/Tool/IRunTool.cs
@@ -18,6 +18,6 @@ namespace com.IvanMurzak.Unity.MCP.Common
         /// </summary>
         /// <param name="namedParameters">A dictionary mapping parameter names to their values.</param>
         /// <returns>The result of the method execution, or null if the method is void.</returns>
-        Task<ResponseCallTool> Run(IDictionary<string, JsonElement>? namedParameters);
+        Task<ResponseCallTool> Run(IReadOnlyDictionary<string, JsonElement>? namedParameters);
     }
 }

--- a/Assets/root/Server/Common/Runner/Tool/RunTool.cs
+++ b/Assets/root/Server/Common/Runner/Tool/RunTool.cs
@@ -61,7 +61,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
         /// </summary>
         /// <param name="namedParameters">A dictionary mapping parameter names to their values.</param>
         /// <returns>The result of the method execution, or null if the method is void.</returns>
-        public async Task<ResponseCallTool> Run(IDictionary<string, JsonElement>? namedParameters)
+        public async Task<ResponseCallTool> Run(IReadOnlyDictionary<string, JsonElement>? namedParameters)
         {
             var result = await Invoke(namedParameters);
             return result as ResponseCallTool ?? ResponseCallTool.Success(result?.ToString());

--- a/Assets/root/Server/Common/Utils/RequestCallToolExtensions.cs
+++ b/Assets/root/Server/Common/Utils/RequestCallToolExtensions.cs
@@ -14,8 +14,10 @@ namespace com.IvanMurzak.Unity.MCP.Common
         }
         public static IRequestCallTool SetOrAddParameter(this IRequestCallTool data, string name, object? value)
         {
-            data.Arguments ??= new Dictionary<string, JsonElement>();
-            data.Arguments[name] = JsonSerializer.SerializeToElement(value);
+            data.Arguments ??= new Dictionary<string, JsonElement>()
+            {
+                [name] = JsonSerializer.SerializeToElement(value)
+            };
             return data;
         }
         // public static IRequestData BuildRequest(this IRequestTool data)

--- a/Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj
+++ b/Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.6" />
+    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.8" />
     <PackageReference Include="NLog.Config" Version="4.7.15" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
     <PackageReference Include="R3" Version="1.3.0" />


### PR DESCRIPTION
This pull request includes changes to improve the immutability and safety of the `Arguments` property in various classes and interfaces by switching from mutable dictionaries to read-only dictionaries. Additionally, it includes an update to a package reference.

Improvements to immutability and safety:

* [`Assets/root/Server/Common/Data/Request/Tool/Call/IRequestCallTool.cs`](diffhunk://#diff-78ca8b57eebc6b6c581bc645d6b9f1bbbaa548b07670b4917a61bc29c6178eecL11-R11): Changed `Arguments` property type from `Dictionary<string, JsonElement>` to `IReadOnlyDictionary<string, JsonElement>`.
* [`Assets/root/Server/Common/Data/Request/Tool/Call/RequestCallTool.cs`](diffhunk://#diff-585ffc1adb2a8324b3fb370eebd1539b05974805aa8d5fb02f47df98cfcef18aL12-R17): Updated `Arguments` property and constructors to use `IReadOnlyDictionary<string, JsonElement>`. [[1]](diffhunk://#diff-585ffc1adb2a8324b3fb370eebd1539b05974805aa8d5fb02f47df98cfcef18aL12-R17) [[2]](diffhunk://#diff-585ffc1adb2a8324b3fb370eebd1539b05974805aa8d5fb02f47df98cfcef18aL26-R26)
* [`Assets/root/Server/Common/Runner/Tool/IRunTool.cs`](diffhunk://#diff-71d1f8910f6576dbf7c91b067f3f2e1332bd1737575e6464e7510d0e63de10e3L21-R21): Modified `Run` method parameter type from `IDictionary<string, JsonElement>?` to `IReadOnlyDictionary<string, JsonElement>?`.
* [`Assets/root/Server/Common/Runner/Tool/RunTool.cs`](diffhunk://#diff-17506e21c35b63da9ed953c429f7b5fa9756e79aed9f16acf2a03976bf3a5bbbL64-R64): Updated `Run` method parameter type to `IReadOnlyDictionary<string, JsonElement>?`.
* [`Assets/root/Server/Common/Utils/RequestCallToolExtensions.cs`](diffhunk://#diff-b95f7e9412ad6667484db7ee782dae29250c755abceacfb4fc7f75eb0f6dd770L17-R20): Adjusted `SetOrAddParameter` method to work with `IReadOnlyDictionary<string, JsonElement>`.

Package reference update:

* [`Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj`](diffhunk://#diff-8b3a1c77aed670a96768e64ea7c87d1fc4f48d898dfbcfb74754c613b532c0d4L16-R16): Updated `ModelContextProtocol` package reference from version `0.1.0-preview.6` to `0.1.0-preview.8`.