### PR TITLE
Tool: GameObject.FindByPath

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByName.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByName.cs
@@ -23,16 +23,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
             bool includeChildrenRecursively = false
         )
-        => MainThread.Run(() =>
         {
             if (string.IsNullOrEmpty(name))
                 return "[Error] GameObject name is empty.";
 
-            var go = GameObject.Find(name);
-            if (go == null)
-                return $"[Error] GameObject with name '{name}' not found.";
+            return MainThread.Run(() =>
+            {
+                var go = GameObject.Find(name);
+                if (go == null)
+                    return $"[Error] GameObject with name '{name}' not found.";
 
-            return go.ToMetadata(includeChildren, includeChildrenRecursively).ToString();
-        });
+                return go.ToMetadata(includeChildren, includeChildrenRecursively).ToString();
+            });
+        }
     }
 }

--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs
@@ -22,16 +22,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
             bool includeChildrenRecursively = false
         )
-        => MainThread.Run(() =>
         {
             if (string.IsNullOrEmpty(path))
                 return "[Error] GameObject path is empty.";
 
-            var go = GameObjectUtils.FindByPath(path);
-            if (go == null)
-                return $"[Error] GameObject '{path}' not found.";
+            return MainThread.Run(() =>
+            {
+                var go = GameObjectUtils.FindByPath(path);
+                if (go == null)
+                    return $"[Error] GameObject '{path}' not found.";
 
-            return go.ToMetadata(includeChildren, includeChildrenRecursively).ToString();
-        });
+                return go.ToMetadata(includeChildren, includeChildrenRecursively).ToString();
+            });
+        }
     }
 }

--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel;
 using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using UnityEngine;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
@@ -10,14 +9,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpPluginTool
         (
-            "GameObject_FindByName",
-            Title = "Find GameObject by name",
-            Description = "Find GameObject by name in the active scene. Returns metadata about each GameObject."
+            "GameObject_FindByPath",
+            Title = "Find GameObject by path",
+            Description = "Find GameObject tree by the path to the root GameObject. Returns metadata about each GameObject."
         )]
-        public string FindByName
+        public string FindByPath
         (
-            [Description("Name of the target GameObject.")]
-            string name,
+            [Description("Path to the GameObject.")]
+            string path,
             [Description("Include children GameObjects in the result.")]
             bool includeChildren = true,
             [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
@@ -25,12 +24,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )
         => MainThread.Run(() =>
         {
-            if (string.IsNullOrEmpty(name))
-                return "[Error] GameObject name is empty.";
+            if (string.IsNullOrEmpty(path))
+                return "[Error] GameObject path is empty.";
 
-            var go = GameObject.Find(name);
+            var go = GameObjectUtils.FindByPath(path);
             if (go == null)
-                return $"[Error] GameObject with name '{name}' not found.";
+                return $"[Error] GameObject '{path}' not found.";
 
             return go.ToMetadata(includeChildren, includeChildrenRecursively).ToString();
         });

--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs.meta
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39946234ef9d65b4ca3a34bf6315d337
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/root/Editor/Scripts/Unity.meta
+++ b/Assets/root/Editor/Scripts/Unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47a7807232061bf4cb07bbc4f679cace
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
+++ b/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System.Collections.Generic;
 using System.Text;
+using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using UnityEngine;
 
 namespace com.IvanMurzak.Unity.MCP.Editor
@@ -8,6 +9,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
     public class GameObjectMetadata
     {
         public string path;
+        public string name;
         public string tag;
         public bool activeSelf;
         public bool activeInHierarchy;
@@ -32,16 +34,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         private void AppendMetadata(StringBuilder sb, GameObjectMetadata metadata, int depth)
         {
             // Indent the path based on depth for better readability
-            string indentedPath = new string(' ', depth * 2) + metadata.path;
+            var indentedPath = new string(' ', depth * 2) + metadata.name;
 
             // Add the current GameObject's data
             sb.AppendLine($"{metadata.activeInHierarchy,-17} | {metadata.activeSelf,-10} | {metadata.tag,-9} | {indentedPath}");
 
             // Recursively add children
             foreach (var child in metadata.children)
-            {
                 AppendMetadata(sb, child, depth + 1);
-            }
         }
 
         public static GameObjectMetadata FromGameObject(GameObject go, bool includeChildren = true, bool includeChildrenRecursively = false)
@@ -55,7 +55,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             // Create metadata for the GameObject
             var metadata = new GameObjectMetadata
             {
-                path = go.name,
+                path = go.GetPath(),
+                name = go.name,
                 tag = go.tag,
                 activeSelf = go.activeSelf,
                 activeInHierarchy = go.activeInHierarchy

--- a/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
+++ b/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
@@ -1,0 +1,77 @@
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor
+{
+    public class GameObjectMetadata
+    {
+        public string path;
+        public string tag;
+        public bool activeSelf;
+        public bool activeInHierarchy;
+        public List<GameObjectMetadata> children = new();
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            // Add table header
+            sb.AppendLine("Path to root: " + path);
+            sb.AppendLine("------------------------------------------------------------");
+            sb.AppendLine("activeInHierarchy | activeSelf | tag       | name");
+            sb.AppendLine("------------------|------------|-----------|----------------");
+
+            // Add the current GameObject's metadata
+            AppendMetadata(sb, this, 0);
+
+            return sb.ToString();
+        }
+
+        private void AppendMetadata(StringBuilder sb, GameObjectMetadata metadata, int depth)
+        {
+            // Indent the path based on depth for better readability
+            string indentedPath = new string(' ', depth * 2) + metadata.path;
+
+            // Add the current GameObject's data
+            sb.AppendLine($"{metadata.activeInHierarchy,-17} | {metadata.activeSelf,-10} | {metadata.tag,-9} | {indentedPath}");
+
+            // Recursively add children
+            foreach (var child in metadata.children)
+            {
+                AppendMetadata(sb, child, depth + 1);
+            }
+        }
+
+        public static GameObjectMetadata FromGameObject(GameObject go, bool includeChildren = true, bool includeChildrenRecursively = false)
+        {
+            if (go == null)
+                return null;
+
+            if (includeChildrenRecursively && !includeChildren)
+                throw new System.ArgumentException("includeChildrenRecursively cannot be true if includeChildren is false.");
+
+            // Create metadata for the GameObject
+            var metadata = new GameObjectMetadata
+            {
+                path = go.name,
+                tag = go.tag,
+                activeSelf = go.activeSelf,
+                activeInHierarchy = go.activeInHierarchy
+            };
+
+            if (includeChildren)
+            {
+                metadata.children ??= new();
+                foreach (Transform child in go.transform)
+                {
+                    var childMetadata = FromGameObject(child.gameObject, includeChildrenRecursively, includeChildrenRecursively);
+                    metadata.children.Add(childMetadata);
+                }
+            }
+
+            return metadata;
+        }
+    }
+}

--- a/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs.meta
+++ b/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 562c66dfdd5a5194f9ceba11ba133f6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/root/Editor/Scripts/Utils/GameObjectUtils.cs
+++ b/Assets/root/Editor/Scripts/Utils/GameObjectUtils.cs
@@ -122,5 +122,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
 
             return path.ToString();
         }
+        public static GameObjectMetadata ToMetadata(this GameObject go, bool includeChildren = true, bool includeChildrenRecursively = false)
+            => GameObjectMetadata.FromGameObject(go, includeChildren, includeChildrenRecursively);
     }
 }

--- a/Assets/root/Runtime/Utils/MainThread.Editor.cs
+++ b/Assets/root/Runtime/Utils/MainThread.Editor.cs
@@ -8,7 +8,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 {
     public static class MainThread
     {
-        static readonly int MainThreadId = Thread.CurrentThread.ManagedThreadId;
+        static int MainThreadId = Thread.CurrentThread.ManagedThreadId;
+        static MainThread()
+        {
+            // Ensure initialization happens on the main thread
+            if (Thread.CurrentThread.ManagedThreadId != 1)
+            {
+                EditorApplication.update += InitializeMainThreadId;
+            }
+            else
+            {
+                MainThreadId = Thread.CurrentThread.ManagedThreadId;
+            }
+        }
+
+        private static void InitializeMainThreadId()
+        {
+            MainThreadId = Thread.CurrentThread.ManagedThreadId;
+            EditorApplication.update -= InitializeMainThreadId;
+        }
 
         public static void Run<T>(Task task) => RunAsync(task).Wait();
         public static Task RunAsync(Task task)

--- a/Assets/root/Runtime/Utils/MainThread.Editor.cs
+++ b/Assets/root/Runtime/Utils/MainThread.Editor.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using com.IvanMurzak.Unity.MCP.Common;
 using UnityEditor;
 
 namespace com.IvanMurzak.Unity.MCP.Editor

--- a/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
@@ -10,23 +10,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         [McpServerTool
         (
-            Name = "GameObject_FindByName",
-            Title = "Find GameObject by name"
+            Name = "GameObject_FindByPath",
+            Title = "Find GameObject by path"
         )]
-        [Description("Find GameObject by name in the active scene. Returns the path to the GameObject.")]
-        public Task<CallToolResponse> FindByName
+        [Description("Find GameObject tree by the path to the root GameObject. Returns metadata about each GameObject.")]
+        public Task<CallToolResponse> FindByPath
         (
-            [Description("Name of the target GameObject.")]
-            string name,
+            [Description("Path to the GameObject.")]
+            string path,
             [Description("Include children GameObjects in the result.")]
             bool includeChildren = true,
             [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
             bool includeChildrenRecursively = false
         )
         {
-            return ToolRouter.Call("GameObject_FindByName", arguments =>
+            return ToolRouter.Call("GameObject_Create", arguments =>
             {
-                arguments[nameof(name)] = name;
+                arguments[nameof(path)] = path;
                 arguments[nameof(includeChildren)] = includeChildren;
                 arguments[nameof(includeChildrenRecursively)] = includeChildrenRecursively;
             });

--- a/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
@@ -24,7 +24,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             bool includeChildrenRecursively = false
         )
         {
-            return ToolRouter.Call("GameObject_Create", arguments =>
+            return ToolRouter.Call("GameObject_FindByPath", arguments =>
             {
                 arguments[nameof(path)] = path;
                 arguments[nameof(includeChildren)] = includeChildren;

--- a/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs.meta
+++ b/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2237283f656e5ef40ba669f34538b39e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the GameObject finding functionality in the Unity Editor and Server API. The most notable changes include the addition of new methods for finding GameObjects by path, improvements to metadata handling, and updates to ensure proper initialization on the main thread.

Enhancements to GameObject finding functionality:

* [`Assets/root/Editor/Scripts/API/Tool/GameObject.FindByName.cs`](diffhunk://#diff-6dccf76ac3e7c8fe16efad6539d3cd417c6cc5323605382ae131579d2d33fcd7L16-R40): Updated the `FindByName` method to include parameters for including children GameObjects and recursively including children. The method now returns metadata about each GameObject instead of just the path.
* [`Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs`](diffhunk://#diff-c186212e02344c014a184b2a55a2fc7002193739965d63a53f6c2bf6e1e8a439R1-R39): Added a new method `FindByPath` to find GameObjects by their path, including options to include children and recursively include children. This method returns metadata about each GameObject.
* [`Assets/root/Server/Server/API/Tool/GameObject.FindByName.cs`](diffhunk://#diff-99a0e5839b0033549c1c021da8e854c0be0fa11c225fb0016e461b4513464d0fL20-R31): Updated the server-side `FindByName` method to include parameters for including children GameObjects and recursively including children.
* [`Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs`](diffhunk://#diff-05e0b040e6d27b4e206303ae185ebaf9de10bba91e3c75e5aa72e5db0c8c1e46R1-R35): Added a new server-side method `FindByPath` to find GameObjects by their path, with options to include children and recursively include children.

Metadata handling improvements:

* [`Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs`](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5R1-R78): Introduced a new class `GameObjectMetadata` to handle the metadata of GameObjects, including their path, name, tag, active state, and children. The class includes methods to convert GameObjects to metadata and to format metadata as a string.
* [`Assets/root/Editor/Scripts/Utils/GameObjectUtils.cs`](diffhunk://#diff-ea3475235faa9c97f1db910953528c515b770a976376a7d27f08857f2a2c0390R125-R126): Added an extension method `ToMetadata` to convert GameObjects to `GameObjectMetadata` objects.

Initialization updates:

* [`Assets/root/Runtime/Utils/MainThread.Editor.cs`](diffhunk://#diff-ae8336e1869a327a2025729cf3ea1a596efa58063a41ad951e34db3f917858f4L5-R29): Updated the `MainThread` class to ensure initialization happens on the main thread, using `EditorApplication.update` to set the main thread ID if the current thread is not the main thread.