### PR TITLE
Tool: GameObject.GetComponents

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.GetComponents.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.GetComponents.cs
@@ -1,0 +1,35 @@
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+using System.ComponentModel;
+using com.IvanMurzak.Unity.MCP.Common;
+using com.IvanMurzak.Unity.MCP.Editor.Utils;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_GameObject
+    {
+        [McpPluginTool
+        (
+            "GameObject_GetComponents",
+            Title = "Get GameObject components",
+            Description = "Get all components of a GameObject by path. Returns property values of each component."
+        )]
+        public string GetComponents
+        (
+            [Description("Path to the GameObject.")]
+            string path
+        )
+        {
+            if (string.IsNullOrEmpty(path))
+                return "[Error] GameObject path is empty.";
+
+            return MainThread.Run(() =>
+            {
+                var go = GameObjectUtils.FindByPath(path);
+                if (go == null)
+                    return $"[Error] GameObject '{path}' not found.";
+
+                return Runtime.Serializer.GameObject.Serialize(go);
+            });
+        }
+    }
+}

--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.GetComponents.cs.meta
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.GetComponents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 397d380e731609d4491203928625cdb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/root/Server/Server/API/Tool/Component.GetAll.cs
+++ b/Assets/root/Server/Server/API/Tool/Component.GetAll.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     public partial class Tool_Component
     {

--- a/Assets/root/Server/Server/API/Tool/Component.cs
+++ b/Assets/root/Server/Server/API/Tool/Component.cs
@@ -1,6 +1,6 @@
 using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     [McpServerToolType]
     public partial class Tool_Component

--- a/Assets/root/Server/Server/API/Tool/GameObject.AddComponent.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.AddComponent.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     public partial class Tool_GameObject
     {

--- a/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     public partial class Tool_GameObject
     {

--- a/Assets/root/Server/Server/API/Tool/GameObject.Destroy.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Destroy.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     public partial class Tool_GameObject
     {

--- a/Assets/root/Server/Server/API/Tool/GameObject.FindByName.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.FindByName.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     public partial class Tool_GameObject
     {

--- a/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     public partial class Tool_GameObject
     {

--- a/Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs
@@ -1,0 +1,29 @@
+using com.IvanMurzak.Unity.MCP.Server;
+using ModelContextProtocol.Protocol.Types;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_GameObject
+    {
+        [McpServerTool
+        (
+            Name = "GameObject_GetComponents",
+            Title = "Get GameObject components"
+        )]
+        [Description("Get all components of a GameObject by path. Returns property values of each component.")]
+        public Task<CallToolResponse> GetComponents
+        (
+            [Description("Path to the GameObject.")]
+            string path
+        )
+        {
+            return ToolRouter.Call("GameObject_GetComponents", arguments =>
+            {
+                arguments[nameof(path)] = path;
+            });
+        }
+    }
+}

--- a/Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs
@@ -4,7 +4,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     public partial class Tool_GameObject
     {

--- a/Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs.meta
+++ b/Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4eb5bf04be728644785cf21a082350d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/root/Server/Server/API/Tool/GameObject.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.cs
@@ -1,6 +1,6 @@
 using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Editor.API
+namespace com.IvanMurzak.Unity.MCP.Server.API
 {
     [McpServerToolType]
     public partial class Tool_GameObject


### PR DESCRIPTION
This pull request includes the addition of a new feature to retrieve all components of a `GameObject` by path, along with its metadata files. The most important changes include adding the `GetComponents` method to the `Tool_GameObject` class in both the Editor and Server contexts.

New feature additions:

* [`Assets/root/Editor/Scripts/API/Tool/GameObject.GetComponents.cs`](diffhunk://#diff-30dfe9cf9f4ff71265d65b0ebfad76f1835cd1d847d71f6a6c55564015b39e5eR1-R35): Added the `GetComponents` method to retrieve all components of a `GameObject` by path in the Editor context.
* [`Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs`](diffhunk://#diff-751735953346fdfa29f878ce8eb5a54f62e483c98055011d79fcf5cf6f14d4fcR1-R29): Added the `GetComponents` method to retrieve all components of a `GameObject` by path in the Server context.

Metadata files:

* [`Assets/root/Editor/Scripts/API/Tool/GameObject.GetComponents.cs.meta`](diffhunk://#diff-6a5363dc663dd31293cef4aaa3470ec335d12efdf4fccc0ddce1ed572d18e5dcR1-R11): Added metadata file for the new `GetComponents` method in the Editor context.
* [`Assets/root/Server/Server/API/Tool/GameObject.GetComponents.cs.meta`](diffhunk://#diff-21d854487c0e3c06ed457ea8179fee78f12b50ab84f9fdba8213a18068a1a3afR1-R11): Added metadata file for the new `GetComponents` method in the Server context.… path in both editor and server contexts