### PR TITLE
Updated Tool: Scene.Hierarchy

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByName.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByName.cs
@@ -18,10 +18,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         (
             [Description("Name of the target GameObject.")]
             string name,
-            [Description("Include children GameObjects in the result.")]
-            bool includeChildren = true,
-            [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
-            bool includeChildrenRecursively = false
+            [Description("Determines the depth of the hierarchy to include.")]
+            int includeChildrenDepth = 3
         )
         {
             return MainThread.Run(() =>
@@ -33,7 +31,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 if (go == null)
                     return Error.NotFoundGameObjectWithName(name);
 
-                return go.ToMetadata(includeChildren, includeChildrenRecursively).ToString();
+                return go.ToMetadata(includeChildrenDepth).Print();
             });
         }
     }

--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs
@@ -17,10 +17,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         (
             [Description("Path to the GameObject.")]
             string path,
-            [Description("Include children GameObjects in the result.")]
-            bool includeChildren = true,
-            [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
-            bool includeChildrenRecursively = false
+            [Description("Determines the depth of the hierarchy to include.")]
+            int includeChildrenDepth = 3
         )
         {
             path = StringUtils.TrimPath(path);
@@ -31,7 +29,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 if (go == null)
                     return Error.NotFoundGameObjectAtPath(path);
 
-                return go.ToMetadata(includeChildren, includeChildrenRecursively).ToString();
+                return go.ToMetadata(includeChildrenDepth).Print();
             });
         }
     }

--- a/Assets/root/Editor/Scripts/API/Tool/Scene.GetHierarchy.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/Scene.GetHierarchy.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System.ComponentModel;
+using System.Linq;
 using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 
@@ -15,6 +16,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         public string GetHierarchyRoot
         (
+            [Description("Determines the depth of the hierarchy to include.")]
+            int includeChildrenDepth = 3,
             [Description("Name of the loaded scene. If empty, the active scene will be used.")]
             string? loadedSceneName = null
         )
@@ -27,7 +30,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (!scene.IsValid())
                 return Error.NotFoundSceneWithName(loadedSceneName);
 
-            return GameObjectUtils.FindRootGameObjects(scene).Print();
+            return scene.ToMetadata(includeChildrenDepth).Print();
         });
     }
 }

--- a/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
+++ b/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
@@ -16,7 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         public bool activeInHierarchy;
         public List<GameObjectMetadata> children = new();
 
-        public override string ToString()
+        public string Print()
         {
             var sb = new StringBuilder();
 
@@ -32,7 +32,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             return sb.ToString();
         }
 
-        private void AppendMetadata(StringBuilder sb, GameObjectMetadata metadata, int depth)
+        public static void AppendMetadata(StringBuilder sb, GameObjectMetadata metadata, int depth)
         {
             // Indent the path based on depth for better readability
             var indentedPath = new string(' ', depth * 2) + metadata.name;
@@ -45,13 +45,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 AppendMetadata(sb, child, depth + 1);
         }
 
-        public static GameObjectMetadata FromGameObject(GameObject go, bool includeChildren = true, bool includeChildrenRecursively = false)
+        public static GameObjectMetadata FromGameObject(GameObject go, int includeChildrenDepth = 3)
         {
             if (go == null)
                 return null;
-
-            if (includeChildrenRecursively && !includeChildren)
-                throw new System.ArgumentException("includeChildrenRecursively cannot be true if includeChildren is false.");
 
             // Create metadata for the GameObject
             var metadata = new GameObjectMetadata
@@ -64,12 +61,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 activeInHierarchy = go.activeInHierarchy
             };
 
-            if (includeChildren)
+            if (includeChildrenDepth > 0)
             {
                 metadata.children ??= new();
                 foreach (Transform child in go.transform)
                 {
-                    var childMetadata = FromGameObject(child.gameObject, includeChildrenRecursively, includeChildrenRecursively);
+                    var childMetadata = FromGameObject(child.gameObject, includeChildrenDepth - 1);
                     metadata.children.Add(childMetadata);
                 }
             }

--- a/Assets/root/Editor/Scripts/Unity/SceneMetadata.cs
+++ b/Assets/root/Editor/Scripts/Unity/SceneMetadata.cs
@@ -1,0 +1,56 @@
+#pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using com.IvanMurzak.Unity.MCP.Editor.Utils;
+using UnityEngine.SceneManagement;
+
+namespace com.IvanMurzak.Unity.MCP.Editor
+{
+    public class SceneMetadata
+    {
+        public string path;
+        public string name;
+        public bool isDirty;
+        public bool isLoaded;
+        public List<GameObjectMetadata> rootGameObjects = new();
+
+        public string Print()
+        {
+            var sb = new StringBuilder();
+
+            // Add table header
+            sb.AppendLine("# Scene Information");
+            sb.AppendLine("name: " + name);
+            sb.AppendLine("path: " + path);
+            sb.AppendLine("isDirty: " + isDirty + ", isLoaded: " + isLoaded);
+            sb.AppendLine();
+            sb.AppendLine("# Scene Hierarchy of GameObjects");
+            sb.AppendLine("-------------------------------------------------------------------------");
+            sb.AppendLine("instanceId | activeInHierarchy | activeSelf | tag       | name");
+            sb.AppendLine("-----------|-------------------|------------|-----------|----------------");
+
+            // Add the current GameObject's metadata
+            foreach (var rootGameObject in rootGameObjects)
+                GameObjectMetadata.AppendMetadata(sb, rootGameObject, 0);
+
+            return sb.ToString();
+        }
+        public static SceneMetadata FromScene(Scene scene, int includeChildrenDepth = 3)
+        {
+            if (!scene.IsValid())
+                return null;
+
+            return new SceneMetadata
+            {
+                path = scene.path,
+                name = scene.name,
+                isDirty = scene.isDirty,
+                isLoaded = scene.isLoaded,
+                rootGameObjects = GameObjectUtils.FindRootGameObjects(scene)
+                    .Select(x => x.ToMetadata(includeChildrenDepth))
+                    .ToList()
+            };
+        }
+    }
+}

--- a/Assets/root/Editor/Scripts/Unity/SceneMetadata.cs.meta
+++ b/Assets/root/Editor/Scripts/Unity/SceneMetadata.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2082f8c3a3af91742b72972167480901
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/root/Editor/Scripts/Utils/GameObjectUtils.cs
+++ b/Assets/root/Editor/Scripts/Utils/GameObjectUtils.cs
@@ -142,7 +142,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
 
             return sb.ToString();
         }
-        public static GameObjectMetadata ToMetadata(this GameObject go, bool includeChildren = true, bool includeChildrenRecursively = false)
-            => GameObjectMetadata.FromGameObject(go, includeChildren, includeChildrenRecursively);
+        public static GameObjectMetadata ToMetadata(this GameObject go, int includeChildrenDepth = 3)
+            => GameObjectMetadata.FromGameObject(go, includeChildrenDepth);
     }
 }

--- a/Assets/root/Editor/Scripts/Utils/SceneUtils.cs
+++ b/Assets/root/Editor/Scripts/Utils/SceneUtils.cs
@@ -16,5 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
                     yield return scene;
             }
         }
+        public static SceneMetadata ToMetadata(this Scene scene, int includeChildrenDepth = 3)
+            => SceneMetadata.FromScene(scene, includeChildrenDepth);
     }
 }

--- a/Assets/root/Server/Program.cs
+++ b/Assets/root/Server/Program.cs
@@ -50,13 +50,13 @@ namespace com.IvanMurzak.Unity.MCP.Server
                         options.Capabilities.Tools.ListChanged = true;
                     })
                     .WithStdioServerTransport()
-                    // .WithPromptsFromAssembly()
+                    .WithPromptsFromAssembly()
                     .WithToolsFromAssembly()
                     .WithCallToolHandler(ToolRouter.Call)
-                    .WithListToolsHandler(ToolRouter.ListAll)
-                    .WithReadResourceHandler(ResourceRouter.ReadResource)
-                    .WithListResourcesHandler(ResourceRouter.ListResources)
-                    .WithListResourceTemplatesHandler(ResourceRouter.ListResourceTemplates);
+                    .WithListToolsHandler(ToolRouter.ListAll);
+                //.WithReadResourceHandler(ResourceRouter.ReadResource)
+                //.WithListResourcesHandler(ResourceRouter.ListResources)
+                //.WithListResourceTemplatesHandler(ResourceRouter.ListResourceTemplates);
 
                 // Setup McpApp ----------------------------------------------------------------
                 builder.Services.AddMcpPlugin(configure =>

--- a/Assets/root/Server/Server/API/Tool/GameObject.FindByName.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.FindByName.cs
@@ -17,17 +17,14 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         (
             [Description("Name of the target GameObject.")]
             string name,
-            [Description("Include children GameObjects in the result.")]
-            bool includeChildren = true,
-            [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
-            bool includeChildrenRecursively = false
+            [Description("Determines the depth of the hierarchy to include.")]
+            int includeChildrenDepth = 3
         )
         {
             return ToolRouter.Call("GameObject_FindByName", arguments =>
             {
                 arguments[nameof(name)] = name;
-                arguments[nameof(includeChildren)] = includeChildren;
-                arguments[nameof(includeChildrenRecursively)] = includeChildrenRecursively;
+                arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
             });
         }
     }

--- a/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs
@@ -17,17 +17,14 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         (
             [Description("Path to the GameObject.")]
             string path,
-            [Description("Include children GameObjects in the result.")]
-            bool includeChildren = true,
-            [Description("Include children GameObjects recursively in the result. Ignored if 'includeChildren' is false.")]
-            bool includeChildrenRecursively = false
+            [Description("Determines the depth of the hierarchy to include.")]
+            int includeChildrenDepth = 3
         )
         {
             return ToolRouter.Call("GameObject_FindByPath", arguments =>
             {
                 arguments[nameof(path)] = path;
-                arguments[nameof(includeChildren)] = includeChildren;
-                arguments[nameof(includeChildrenRecursively)] = includeChildrenRecursively;
+                arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
             });
         }
     }

--- a/Assets/root/Server/Server/API/Tool/Scene.GetHierarchy.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.GetHierarchy.cs
@@ -15,12 +15,15 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         [Description("This tool retrieves the list of root GameObjects in the specified scene.")]
         public Task<CallToolResponse> GetHierarchyRoot
         (
+            [Description("Determines the depth of the hierarchy to include.")]
+            int includeChildrenDepth = 3,
             [Description("Name of the loaded scene. If empty, the active scene will be used.")]
             string? loadedSceneName = null
         )
         {
             return ToolRouter.Call("Scene_GetHierarchyRoot", arguments =>
             {
+                arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
                 arguments[nameof(loadedSceneName)] = loadedSceneName ?? string.Empty;
             });
         }


### PR DESCRIPTION
This pull request introduces a significant change in how child GameObjects are included in metadata, moving from boolean flags to an integer depth parameter for better control. Additionally, it includes some refactoring and new functionality to support these changes.

### Key Changes:

#### Refactoring Child Inclusion Logic:
* [`Assets/root/Editor/Scripts/API/Tool/GameObject.FindByName.cs`](diffhunk://#diff-6dccf76ac3e7c8fe16efad6539d3cd417c6cc5323605382ae131579d2d33fcd7L21-R22): Replaced `includeChildren` and `includeChildrenRecursively` parameters with `includeChildrenDepth` to determine the depth of hierarchy inclusion. [[1]](diffhunk://#diff-6dccf76ac3e7c8fe16efad6539d3cd417c6cc5323605382ae131579d2d33fcd7L21-R22) [[2]](diffhunk://#diff-6dccf76ac3e7c8fe16efad6539d3cd417c6cc5323605382ae131579d2d33fcd7L36-R34)
* [`Assets/root/Editor/Scripts/API/Tool/GameObject.FindByPath.cs`](diffhunk://#diff-c186212e02344c014a184b2a55a2fc7002193739965d63a53f6c2bf6e1e8a439L20-R21): Updated to use `includeChildrenDepth` instead of the previous boolean parameters. [[1]](diffhunk://#diff-c186212e02344c014a184b2a55a2fc7002193739965d63a53f6c2bf6e1e8a439L20-R21) [[2]](diffhunk://#diff-c186212e02344c014a184b2a55a2fc7002193739965d63a53f6c2bf6e1e8a439L34-R32)
* [`Assets/root/Editor/Scripts/API/Tool/Scene.GetHierarchy.cs`](diffhunk://#diff-4a552a16fced64a314ea9189548e2277def0dd017f029abb53027534e907f605R19-R20): Added `includeChildrenDepth` parameter to control hierarchy depth inclusion. [[1]](diffhunk://#diff-4a552a16fced64a314ea9189548e2277def0dd017f029abb53027534e907f605R19-R20) [[2]](diffhunk://#diff-4a552a16fced64a314ea9189548e2277def0dd017f029abb53027534e907f605L30-R33)

#### Metadata Handling:
* [`Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs`](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L19-R19): Introduced `Print` method replacing `ToString` and modified `FromGameObject` method to use `includeChildrenDepth` parameter. [[1]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L19-R19) [[2]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L35-R35) [[3]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L48-L55) [[4]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L67-R69)
* [`Assets/root/Editor/Scripts/Unity/SceneMetadata.cs`](diffhunk://#diff-80e23446c322892d9eccd5b03d3e38b36b823d7190d382a5b979b5c959b0ef6fR1-R56): Added new `SceneMetadata` class to manage scene-related metadata with a `Print` method for formatted output.

#### Utility Functions:
* [`Assets/root/Editor/Scripts/Utils/GameObjectUtils.cs`](diffhunk://#diff-ea3475235faa9c97f1db910953528c515b770a976376a7d27f08857f2a2c0390L145-R146): Updated `ToMetadata` extension method to use `includeChildrenDepth` parameter.
* [`Assets/root/Editor/Scripts/Utils/SceneUtils.cs`](diffhunk://#diff-35cdd1e7027648a79b03c6a9d0d31e57a317109c225572bb2a78cca8515b77a1R19-R20): Added `ToMetadata` extension method for `Scene` class to handle metadata conversion with depth parameter.

#### Server API Updates:
* [`Assets/root/Server/Server/API/Tool/GameObject.FindByName.cs`](diffhunk://#diff-99a0e5839b0033549c1c021da8e854c0be0fa11c225fb0016e461b4513464d0fL20-R27): Updated server API to use `includeChildrenDepth` parameter.
* [`Assets/root/Server/Server/API/Tool/GameObject.FindByPath.cs`](diffhunk://#diff-05e0b040e6d27b4e206303ae185ebaf9de10bba91e3c75e5aa72e5db0c8c1e46L20-R27): Modified to include `includeChildrenDepth` parameter for hierarchy depth control.
* [`Assets/root/Server/Server/API/Tool/Scene.GetHierarchy.cs`](diffhunk://#diff-5568089962eb1cf322150011a6ef20c7af287cbf2ad94875ea9c03de3ab88647R18-R26): Added `includeChildrenDepth` parameter to API for better depth management.

These changes collectively enhance the flexibility and control over how child GameObjects are included in metadata, improving the overall functionality and maintainability of the code.