### PR TITLE
Fixed NLog Server integration

### DIFF
--- a/Assets/root/Server/Common/Utils/StringUtils.cs
+++ b/Assets/root/Server/Common/Utils/StringUtils.cs
@@ -6,9 +6,9 @@ namespace com.IvanMurzak.Unity.MCP.Common
 {
     public static class StringUtils
     {
-        public static string TrimPath(string path)
+        public static string? TrimPath(string? path)
             => path?.TrimEnd('/')?.TrimStart('/');
-        public static string Path_GetParentFolderPath(string path)
+        public static string? Path_GetParentFolderPath(string? path)
         {
             if (path == null)
                 return null;
@@ -16,7 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
             var lastSlashIndex = trimmedPath.LastIndexOf('/');
             return lastSlashIndex >= 0 ? trimmedPath.Substring(0, lastSlashIndex) : trimmedPath;
         }
-        public static string Path_GetLastName(string path)
+        public static string? Path_GetLastName(string? path)
             => path?.TrimEnd('/')?.Split('/')?.Last();
     }
 }

--- a/Assets/root/Server/NLog.config
+++ b/Assets/root/Server/NLog.config
@@ -7,12 +7,12 @@
     <target
       xsi:type="File"
       name="logFile"
-      fileName="{basedir}logs/server-log.txt"
+      fileName="logs/server-log.txt"
       layout="${longdate} | ${level:uppercase=true} | ${message} ${exception:format=toString}" />
     <target
       xsi:type="File"
       name="errorLogFile"
-      fileName="{basedir}logs/server-log-error.txt"
+      fileName="logs/server-log-error.txt"
       layout="${longdate} | ${level:uppercase=true} | ${message} ${exception:format=toString}" />
   </targets>
 
@@ -21,4 +21,8 @@
     <logger name="*" minlevel="Trace" writeTo="logFile" />
     <logger name="*" minlevel="Error" writeTo="errorLogFile" />
   </rules>
+
+  <extensions>
+    <add assembly="NLog.Web.AspNetCore"/>
+  </extensions>
 </nlog>

--- a/Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj
+++ b/Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj
@@ -14,8 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.8" />
-    <PackageReference Include="NLog.Config" Version="4.7.15" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.4.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request includes several changes to improve null safety, update logging configurations, and modify package references. The most important changes include adding nullable annotations to methods in `StringUtils`, updating file paths in the NLog configuration, and modifying the package reference for NLog.

### Null Safety Improvements:
* [`Assets/root/Server/Common/Utils/StringUtils.cs`](diffhunk://#diff-906c7284745b45c25c93793a7f4d696691a00947ac1e92c5185a7730118b8c1bL9-R19): Added nullable annotations to methods in `StringUtils` to handle potential null values more safely.

### Logging Configuration Updates:
* [`Assets/root/Server/NLog.config`](diffhunk://#diff-0249c28e18ef45c5163878263faff51c53abaa89475ae1c01e9aba0b6e34de4fL10-R15): Updated file paths to remove `{basedir}` and added an extension for `NLog.Web.AspNetCore`. [[1]](diffhunk://#diff-0249c28e18ef45c5163878263faff51c53abaa89475ae1c01e9aba0b6e34de4fL10-R15) [[2]](diffhunk://#diff-0249c28e18ef45c5163878263faff51c53abaa89475ae1c01e9aba0b6e34de4fR24-R27)

### Package Reference Modifications:
* [`Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj`](diffhunk://#diff-8b3a1c77aed670a96768e64ea7c87d1fc4f48d898dfbcfb74754c613b532c0d4L17-R17): Changed the package reference from `NLog.Config` and `NLog.Extensions.Logging` to `NLog.Web.AspNetCore`.