### PR TITLE
fix: NullReferenceException in Assets.Prefab.Instantiate

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Instantiate.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Instantiate.cs
@@ -47,7 +47,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             var go = PrefabUtility.InstantiatePrefab(prefab) as GameObject;
             go.name = name ?? prefab.name;
-            go.transform.SetParent(parentGo.transform, false);
+            if (parentGo != null)
+                go.transform.SetParent(parentGo.transform, false);
             go.SetTransform(position, rotation, scale, isLocalSpace);
 
             var bounds = go.CalculateBounds();


### PR DESCRIPTION
This pull request introduces a small enhancement to the `Instantiate` method in `Assets.Prefab.Instantiate.cs`. The change ensures that, if a `parentGo` (parent GameObject) is provided, the instantiated prefab is assigned to it as its parent.

* [`Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Instantiate.cs`](diffhunk://#diff-74a84ab8f00af375fc2c787e51c95af022d2a2d4d6e93d83f44dc2e52aecbba6R50): Added a null check for `parentGo` before setting it as the parent of the instantiated prefab.