### PR TITLE
Truncating long Scene.GetHierarchy response by 500 objects

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/Scene.GetHierarchy.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/Scene.GetHierarchy.cs
@@ -30,7 +30,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (!scene.IsValid())
                 return Error.NotFoundSceneWithName(loadedSceneName);
 
-            return scene.ToMetadata(includeChildrenDepth).Print();
+            return scene.ToMetadata(includeChildrenDepth: includeChildrenDepth).Print();
         });
     }
 }

--- a/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
+++ b/Assets/root/Editor/Scripts/Unity/GameObjectMetadata.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System.Collections.Generic;
 using System.Text;
+using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         public bool activeInHierarchy;
         public List<GameObjectMetadata> children = new();
 
-        public string Print()
+        public string Print(int limit = Consts.MCP.LinesLimit)
         {
             var sb = new StringBuilder();
 
@@ -27,13 +28,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             sb.AppendLine("-----------|-------------------|------------|-----------|----------------");
 
             // Add the current GameObject's metadata
-            AppendMetadata(sb, this, 0);
+            AppendMetadata(sb, this, depth: 0, ref limit);
 
             return sb.ToString();
         }
 
-        public static void AppendMetadata(StringBuilder sb, GameObjectMetadata metadata, int depth)
+        public static void AppendMetadata(StringBuilder sb, GameObjectMetadata metadata, int depth, ref int limit)
         {
+            if (limit <= 0)
+            {
+                sb.AppendLine(new string(' ', depth * 2) + "... [Limit reached] ...");
+                return;
+            }
+            limit--;
             // Indent the path based on depth for better readability
             var indentedPath = new string(' ', depth * 2) + metadata.name;
 
@@ -42,7 +49,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
             // Recursively add children
             foreach (var child in metadata.children)
-                AppendMetadata(sb, child, depth + 1);
+            {
+                if (limit <= 0)
+                {
+                    sb.AppendLine(new string(' ', (depth + 1) * 2) + "... [Limit reached] ...");
+                    return;
+                }
+                limit--;
+                AppendMetadata(sb, child, depth + 1, ref limit);
+            }
         }
 
         public static GameObjectMetadata FromGameObject(GameObject go, int includeChildrenDepth = 3)

--- a/Assets/root/Editor/Scripts/Unity/SceneMetadata.cs
+++ b/Assets/root/Editor/Scripts/Unity/SceneMetadata.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using UnityEngine.SceneManagement;
 
@@ -15,7 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         public bool isLoaded;
         public List<GameObjectMetadata> rootGameObjects = new();
 
-        public string Print()
+        public string Print(int limit = Consts.MCP.LinesLimit)
         {
             var sb = new StringBuilder();
 
@@ -32,7 +33,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
             // Add the current GameObject's metadata
             foreach (var rootGameObject in rootGameObjects)
-                GameObjectMetadata.AppendMetadata(sb, rootGameObject, 0);
+            {
+                if (limit <= 0)
+                {
+                    sb.AppendLine("... [Limit reached] ...");
+                    return sb.ToString();
+                }
+                limit--;
+                GameObjectMetadata.AppendMetadata(sb, rootGameObject, depth: 0, ref limit);
+            }
 
             return sb.ToString();
         }

--- a/Assets/root/Server/Common/Utils/Consts.RPC.cs
+++ b/Assets/root/Server/Common/Utils/Consts.RPC.cs
@@ -14,6 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
             public const string DefaultEndpoint = "http://localhost:60606";
             public const string LocalServer = "/mcp/local-server";
             public const string RemoteApp = "/mcp/remote-app";
+            public const float TimeoutSeconds = 10f;
         }
         public static partial class RPC
         {

--- a/Assets/root/Server/Common/Utils/Consts.cs
+++ b/Assets/root/Server/Common/Utils/Consts.cs
@@ -11,6 +11,10 @@ namespace com.IvanMurzak.Unity.MCP.Common
     {
       public const string Zero = "00000000-0000-0000-0000-000000000000";
     }
+    public static class MCP
+    {
+      public const int LinesLimit = 1000;
+    }
 
     public static partial class Command
     {

--- a/Assets/root/Server/Server/Hub/BaseHub.cs
+++ b/Assets/root/Server/Server/Hub/BaseHub.cs
@@ -52,6 +52,18 @@ namespace com.IvanMurzak.Unity.MCP.Server
             return base.OnDisconnectedAsync(exception);
         }
 
+        public void RemoveCurrentClient()
+        {
+            if (ConnectedClients.TryGetValue(GetType(), out var clients) && clients.TryRemove(Context.ConnectionId, out _))
+            {
+                _logger.LogInformation($"Client {Context.ConnectionId} removed from connected clients for {GetType().Name}.");
+            }
+            else
+            {
+                _logger.LogWarning($"Client {Context.ConnectionId} was not found in connected clients for {GetType().Name}.");
+            }
+        }
+
         protected ISingleClientProxy? GetActiveClient()
         {
             if (!ConnectedClients.TryGetValue(GetType(), out var clients) || clients.IsEmpty)

--- a/Assets/root/Server/Server/Hub/RemoteApp.cs
+++ b/Assets/root/Server/Server/Hub/RemoteApp.cs
@@ -38,7 +38,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
                 }
 
                 const int maxRetries = 5; // Maximum number of retries
-                int retryCount = 0;       // Retry counter
+                var retryCount = 0;       // Retry counter
 
                 while (retryCount < maxRetries)
                 {
@@ -66,6 +66,8 @@ namespace com.IvanMurzak.Unity.MCP.Server
                         // Restart the loop to try again with a new client
                     }
                 }
+                return ResponseData<ResponseCallTool>.Error(data.RequestID, $"Failed to run tool '{data.Name}' after {maxRetries} retries.")
+                    .Log(_logger);
             }
             catch (Exception ex)
             {

--- a/Assets/root/Server/Server/Hub/RemoteApp.cs
+++ b/Assets/root/Server/Server/Hub/RemoteApp.cs
@@ -61,7 +61,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
                     else
                     {
                         // Timeout occurred
-                        _logger.LogWarning($"Timeout: Client {Context.ConnectionId} did not respond in 10 seconds. Removing from ConnectedClients.");
+                        _logger.LogWarning($"Timeout: Client {Context.ConnectionId} did not respond in {Consts.Hub.TimeoutSeconds} seconds. Removing from ConnectedClients.");
                         RemoveCurrentClient();
                         // Restart the loop to try again with a new client
                     }

--- a/Assets/root/Server/Server/Hub/RemoteApp.cs
+++ b/Assets/root/Server/Server/Hub/RemoteApp.cs
@@ -61,6 +61,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
                         // Timeout occurred
                         _logger.LogWarning($"Timeout: Client {Context.ConnectionId} did not respond in 10 seconds. Removing from ConnectedClients.");
                         RemoveCurrentClient();
+                        // Restart the loop to try again with a new client
                     }
                 }
             }

--- a/Assets/root/Server/Server/Hub/RemoteApp.cs
+++ b/Assets/root/Server/Server/Hub/RemoteApp.cs
@@ -37,9 +37,11 @@ namespace com.IvanMurzak.Unity.MCP.Server
                     _logger.LogInformation(message);
                 }
 
-                while (true)
-                {
+                const int maxRetries = 5; // Maximum number of retries
+                int retryCount = 0;       // Retry counter
 
+                while (retryCount < maxRetries)
+                {
                     var client = GetActiveClient();
                     if (client == null)
                         return ResponseData<ResponseCallTool>.Error(data.RequestID, $"No connected clients for {GetType().Name}.")

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.Call.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.Call.cs
@@ -40,7 +40,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
 
             var requestData = new RequestCallTool(request.Params.Name, request.Params.Arguments);
             if (logger.IsTraceEnabled)
-                logger.Trace("Call tool:\n{0}", JsonUtils.Serialize(requestData));
+                logger.Trace("Call remote tool '{0}':\n{1}", request.Params.Name, JsonUtils.Serialize(requestData));
 
             var response = await toolRunner.RunCallTool(requestData, cancellationToken);
             if (response == null)


### PR DESCRIPTION
This pull request introduces several updates across different parts of the codebase, focusing on improving functionality, adding safeguards, and enhancing logging. Key changes include introducing a limit for metadata printing to prevent excessive output, implementing a timeout mechanism for client responses, and refining logging for better traceability.

### Metadata Printing Enhancements:
* Added a `LinesLimit` constant (`Consts.MCP.LinesLimit`) to restrict the number of lines printed in metadata outputs. This prevents excessive output when traversing large hierarchies. (`[Assets/root/Server/Common/Utils/Consts.csR14-R17](diffhunk://#diff-8e0f92794c00b6953f52f9deede8c93b3cd8710a62708141c06243a8fd2ea5d8R14-R17)`)
* Updated `GameObjectMetadata.Print()` and `SceneMetadata.Print()` to respect the line limit, appending a message when the limit is reached. (`[[1]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L19-R20)`, `[[2]](diffhunk://#diff-80e23446c322892d9eccd5b03d3e38b36b823d7190d382a5b979b5c959b0ef6fL18-R19)`)
* Modified `AppendMetadata` to handle the line limit recursively for child objects, ensuring the limit is enforced throughout the hierarchy. (`[[1]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L30-R43)`, `[[2]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5L45-R60)`)

### Client Timeout and Connection Management:
* Introduced a `TimeoutSeconds` constant (`Consts.Hub.TimeoutSeconds`) to define the timeout duration for client responses. (`[Assets/root/Server/Common/Utils/Consts.RPC.csR17](diffhunk://#diff-a207aae348be2eca919a738af34bf4560269fde1c839adcace8742fc0eb5c448R17)`)
* Added a timeout mechanism in `RunCallTool` to handle unresponsive clients. If a client fails to respond within the timeout, it is removed from the connected clients list. (`[Assets/root/Server/Server/Hub/RemoteApp.csR40-R66](diffhunk://#diff-44488f5bb82ad3d28c19e65498706cd1fbf1af52caa14e4c70aa459fe3f0a37cR40-R66)`)
* Implemented a helper method, `RemoveCurrentClient()`, to manage the removal of unresponsive clients and log the action. (`[Assets/root/Server/Server/Hub/BaseHub.csR55-R66](diffhunk://#diff-96b73a90e44ce243ab6420a1b9c8243ccc2c97da908440b971f8e1e34d75746fR55-R66)`)

### Logging Improvements:
* Improved trace logging in `ToolRouter.Call` to include the tool name, making logs more informative. (`[Assets/root/Server/Server/Routing/Tool/ToolRouter.Call.csL43-R43](diffhunk://#diff-44e983e79e6535579abe21111896726020d4cc9c58d30083dbf9199ec28b75f2L43-R43)`)

### Code Quality Improvements:
* Adjusted parameter naming in `GetHierarchyRoot` for clarity. (`[Assets/root/Editor/Scripts/API/Tool/Scene.GetHierarchy.csL33-R33](diffhunk://#diff-4a552a16fced64a314ea9189548e2277def0dd017f029abb53027534e907f605L33-R33)`)
* Added missing namespace imports in `GameObjectMetadata` and `SceneMetadata` for consistency. (`[[1]](diffhunk://#diff-79d44dfbb769702b3308f57fa0df37694b5725fa4a35c1dfc50bd9a176fbe1b5R4)`, `[[2]](diffhunk://#diff-80e23446c322892d9eccd5b03d3e38b36b823d7190d382a5b979b5c959b0ef6fR5)`)