### PR TITLE
fix: GameObject.ModifyComponent

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.cs
@@ -76,6 +76,7 @@ The target reference instance could be located in project assets, in the scene o
 
             var changedFieldResults = new string[data.fields?.Count ?? 0];
             var changedPropertyResults = new string[data.properties?.Count ?? 0];
+            var bindingFlags = System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
 
             if ((data.fields?.Count ?? 0) > 0)
             {
@@ -102,7 +103,7 @@ The target reference instance could be located in project assets, in the scene o
                             Debug.LogError($"[Error] Type '{field.type}' not found. Can't modify field '{field.name}'.", go);
                     }
 
-                    var fieldInfo = type.GetField(field.name);
+                    var fieldInfo = type.GetField(field.name, bindingFlags);
                     if (fieldInfo == null)
                     {
                         changedFieldResults[i] = $"[Error] Field '{field.name}' not found. Can't modify field '{field.name}'.";
@@ -198,7 +199,7 @@ The target reference instance could be located in project assets, in the scene o
                             Debug.LogWarning($"[Error] Type '{property.type}' not found. Can't modify property '{property.name}'.", go);
                     }
 
-                    var propInfo = type.GetProperty(property.name);
+                    var propInfo = type.GetProperty(property.name, bindingFlags);
                     if (propInfo == null)
                     {
                         changedPropertyResults[i] = $"[Error] Property '{property.name}' not found. Can't modify property '{property.name}'.";


### PR DESCRIPTION
This pull request updates the `GameObject.ModifyComponent` script to ensure that both public and non-public members of a component are correctly accessed and modified. The changes introduce the use of `BindingFlags` to improve the flexibility and accuracy of field and property lookups.

### Enhancements to member access:

* Added a `bindingFlags` variable to include `BindingFlags.Public`, `BindingFlags.NonPublic`, and `BindingFlags.Instance` for more comprehensive member access. (`Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.cs`, [Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.csR79](diffhunk://#diff-a41a8c4751719b201dfa779456970f448ac2d26676858fe1e67e0476fc856f45R79))
* Updated the `GetField` method to use the new `bindingFlags` parameter, allowing access to both public and non-public fields. (`Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.cs`, [Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.csL105-R106](diffhunk://#diff-a41a8c4751719b201dfa779456970f448ac2d26676858fe1e67e0476fc856f45L105-R106))
* Updated the `GetProperty` method to use the new `bindingFlags` parameter, enabling access to both public and non-public properties. (`Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.cs`, [Assets/root/Editor/Scripts/API/Tool/GameObject.ModifyComponent.csL201-R202](diffhunk://#diff-a41a8c4751719b201dfa779456970f448ac2d26676858fe1e67e0476fc856f45L201-R202))