### PR TITLE
feat: Add primitive type parameter to GameObject creation methods

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.Create.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.Create.cs
@@ -28,7 +28,9 @@ if needed - provide proper 'position', 'rotation' and 'scale' to reduce amount o
             [Description("Transform scale of the GameObject.")]
             Vector3? scale = default,
             [Description("World or Local space of transform.")]
-            bool isLocalSpace = false
+            bool isLocalSpace = false,
+            [Description("-1 - No primitive type; 0 - Cube; 1 - Sphere; 2 - Capsule; 3 - Cylinder; 4 - Plane; 5 - Quad.")]
+            int primitiveType = -1
         )
         => MainThread.Run(() =>
         {
@@ -43,7 +45,17 @@ if needed - provide proper 'position', 'rotation' and 'scale' to reduce amount o
             if (string.IsNullOrEmpty(name))
                 return Error.GameObjectNameIsEmpty();
 
-            var go = new GameObject(name);
+            var go = primitiveType switch
+            {
+                0 => GameObject.CreatePrimitive(PrimitiveType.Cube),
+                1 => GameObject.CreatePrimitive(PrimitiveType.Sphere),
+                2 => GameObject.CreatePrimitive(PrimitiveType.Capsule),
+                3 => GameObject.CreatePrimitive(PrimitiveType.Cylinder),
+                4 => GameObject.CreatePrimitive(PrimitiveType.Plane),
+                5 => GameObject.CreatePrimitive(PrimitiveType.Quad),
+                _ => new GameObject(name)
+            };
+            go.name = name;
             go.SetTransform(position, rotation, scale, isLocalSpace);
 
             if (parentGo != null)

--- a/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
@@ -25,7 +25,9 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             [Description("Transform scale of the GameObject.")]
             Vector3? scale = default,
             [Description("World or Local space of transform.")]
-            bool isLocalSpace = false
+            bool isLocalSpace = false,
+            [Description("-1 - No primitive type; 0 - Cube; 1 - Sphere; 2 - Capsule; 3 - Cylinder; 4 - Plane; 5 - Quad.")]
+            int primitiveType = -1
         )
         {
             return ToolRouter.Call("GameObject_Create", arguments =>
@@ -42,6 +44,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
                     arguments[nameof(scale)] = scale;
 
                 arguments[nameof(isLocalSpace)] = isLocalSpace;
+                arguments[nameof(primitiveType)] = primitiveType;
             });
         }
     }


### PR DESCRIPTION
This pull request introduces support for creating primitive GameObjects (e.g., Cube, Sphere) by adding a `primitiveType` parameter to the `Create` method in both the editor and server-side implementations. The changes enhance functionality and improve flexibility when creating GameObjects.

### Enhancements to GameObject creation:

* **Editor-side implementation (`Assets/root/Editor/Scripts/API/Tool/GameObject.Create.cs`)**:
  - Added a `primitiveType` parameter to the `Create` method, allowing users to specify the type of primitive GameObject to create (e.g., Cube, Sphere, Capsule). Defaults to `-1` for no primitive type.
  - Updated the `Create` method logic to use a `switch` statement for creating the specified primitive type. If `primitiveType` is not set, a standard GameObject is created.

* **Server-side implementation (`Assets/root/Server/Server/API/Tool/GameObject.Create.cs`)**:
  - Added a `primitiveType` parameter to the `Create` method to mirror the editor-side changes.
  - Passed the `primitiveType` parameter to the `ToolRouter.Call` method to ensure the server processes the primitive type correctly.