### PR TITLE
refactor: Optimized Json serialization

### DIFF
--- a/Assets/root/Runtime/Reflection/Serializers/Base/RS_Array.cs
+++ b/Assets/root/Runtime/Reflection/Serializers/Base/RS_Array.cs
@@ -53,12 +53,12 @@ namespace com.IvanMurzak.Unity.MCP.Utils
 
         protected override bool SetValue(ref object obj, Type type, JsonElement? value)
         {
-            var parsedList = JsonUtils.Deserialize<List<SerializedMember>>(value.Value.GetRawText());
+            var parsedList = JsonUtils.Deserialize<List<SerializedMember>>(value.Value);
             var enumerable = parsedList
                 .Select(element =>
                 {
                     var elementType = TypeUtils.GetType(element.type);
-                    var elementValue = JsonUtils.Deserialize(element.valueJsonElement.Value.GetRawText(), elementType);
+                    var elementValue = JsonUtils.Deserialize(element.valueJsonElement.Value, elementType);
                     return elementValue;
                 });
 
@@ -71,12 +71,12 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetAsField(ref object obj, Type type, FieldInfo fieldInfo, SerializedMember? value, StringBuilder? stringBuilder = null,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedList = JsonUtils.Deserialize<List<SerializedMember>>(value.valueJsonElement?.GetRawText());
+            var parsedList = JsonUtils.Deserialize<List<SerializedMember>>(value.valueJsonElement.Value);
             var enumerable = parsedList
                 .Select(element =>
                 {
                     var elementType = TypeUtils.GetType(element.type);
-                    var elementValue = JsonUtils.Deserialize(element.valueJsonElement.Value.GetRawText(), elementType);
+                    var elementValue = JsonUtils.Deserialize(element.valueJsonElement.Value, elementType);
                     return elementValue;
                 });
 
@@ -91,12 +91,12 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetAsProperty(ref object obj, Type type, PropertyInfo propertyInfo, SerializedMember? value, StringBuilder? stringBuilder = null,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedList = JsonUtils.Deserialize<List<SerializedMember>>(value.valueJsonElement?.GetRawText());
+            var parsedList = JsonUtils.Deserialize<List<SerializedMember>>(value.valueJsonElement.Value);
             var enumerable = parsedList
                 .Select(element =>
                 {
                     var elementType = TypeUtils.GetType(element.type);
-                    var elementValue = JsonUtils.Deserialize(element.valueJsonElement.Value.GetRawText(), elementType);
+                    var elementValue = JsonUtils.Deserialize(element.valueJsonElement.Value, elementType);
                     return elementValue;
                 });
 
@@ -111,7 +111,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetField(ref object obj, Type type, FieldInfo fieldInfo, SerializedMember? value,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             fieldInfo.SetValue(obj, parsedValue);
             return true;
         }
@@ -119,7 +119,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetProperty(ref object obj, Type type, PropertyInfo propertyInfo, SerializedMember? value,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             propertyInfo.SetValue(obj, parsedValue);
             return true;
         }

--- a/Assets/root/Runtime/Reflection/Serializers/Base/RS_Generic.cs
+++ b/Assets/root/Runtime/Reflection/Serializers/Base/RS_Generic.cs
@@ -42,7 +42,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
 
         protected override bool SetValue(ref object obj, Type type, JsonElement? value)
         {
-            var parsedValue = JsonUtils.Deserialize(value.Value.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.Value, type);
             obj = parsedValue;
             return true;
         }
@@ -50,7 +50,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetAsField(ref object obj, Type type, FieldInfo fieldInfo, SerializedMember? value, StringBuilder? stringBuilder = null,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             fieldInfo.SetValue(obj, parsedValue);
             stringBuilder?.AppendLine($"[Success] Field '{value.name}' modified to '{parsedValue}'.");
             return true;
@@ -59,7 +59,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetAsProperty(ref object obj, Type type, PropertyInfo propertyInfo, SerializedMember? value, StringBuilder? stringBuilder = null,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             propertyInfo.SetValue(obj, parsedValue);
             stringBuilder?.AppendLine($"[Success] Property '{value.name}' modified to '{parsedValue}'.");
             return true;
@@ -68,7 +68,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetField(ref object obj, Type type, FieldInfo fieldInfo, SerializedMember? value,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             fieldInfo.SetValue(obj, parsedValue);
             return true;
         }
@@ -76,7 +76,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetProperty(ref object obj, Type type, PropertyInfo propertyInfo, SerializedMember? value,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             propertyInfo.SetValue(obj, parsedValue);
             return true;
         }

--- a/Assets/root/Runtime/Reflection/Serializers/Base/RS_Primitive.cs
+++ b/Assets/root/Runtime/Reflection/Serializers/Base/RS_Primitive.cs
@@ -34,7 +34,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
 
         protected override bool SetValue(ref object obj, Type type, JsonElement? value)
         {
-            var parsedValue = JsonUtils.Deserialize(value.Value.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.Value, type);
             obj = parsedValue;
             return true;
         }
@@ -42,7 +42,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetAsField(ref object obj, Type type, FieldInfo fieldInfo, SerializedMember? value, StringBuilder? stringBuilder = null,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             fieldInfo.SetValue(obj, parsedValue);
             stringBuilder?.AppendLine($"[Success] Field '{value.name}' modified to '{parsedValue}'.");
             return true;
@@ -51,7 +51,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetAsProperty(ref object obj, Type type, PropertyInfo propertyInfo, SerializedMember? value, StringBuilder? stringBuilder = null,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             propertyInfo.SetValue(obj, parsedValue);
             stringBuilder?.AppendLine($"[Success] Property '{value.name}' modified to '{parsedValue}'.");
             return true;
@@ -60,7 +60,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetField(ref object obj, Type type, FieldInfo fieldInfo, SerializedMember? value,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             fieldInfo.SetValue(obj, parsedValue);
             return true;
         }
@@ -68,7 +68,7 @@ namespace com.IvanMurzak.Unity.MCP.Utils
         public override bool SetProperty(ref object obj, Type type, PropertyInfo propertyInfo, SerializedMember? value,
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
         {
-            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement?.GetRawText(), type);
+            var parsedValue = JsonUtils.Deserialize(value.valueJsonElement.Value, type);
             propertyInfo.SetValue(obj, parsedValue);
             return true;
         }

--- a/Assets/root/Server/Common/Runner/Utils/MethodWrapper.cs
+++ b/Assets/root/Server/Common/Runner/Utils/MethodWrapper.cs
@@ -148,7 +148,7 @@ namespace com.IvanMurzak.Unity.MCP.Common.MCP
                     // Handle JsonElement conversion
                     if (parameters[i] is JsonElement jsonElement)
                     {
-                        finalParameters[i] = JsonUtils.Deserialize(jsonElement.GetRawText(), methodParameters[i].ParameterType);
+                        finalParameters[i] = JsonUtils.Deserialize(jsonElement, methodParameters[i].ParameterType);
                     }
                     else
                     {
@@ -187,7 +187,7 @@ namespace com.IvanMurzak.Unity.MCP.Common.MCP
                 {
                     if (value is JsonElement jsonElement)
                     {
-                        finalParameters[i] = JsonUtils.Deserialize(jsonElement.GetRawText(), methodParameters[i].ParameterType);
+                        finalParameters[i] = JsonUtils.Deserialize(jsonElement, methodParameters[i].ParameterType);
                     }
                     else
                     {

--- a/Assets/root/Server/Common/Utils/Json/JsonUtils.cs
+++ b/Assets/root/Server/Common/Utils/Json/JsonUtils.cs
@@ -43,6 +43,9 @@ namespace com.IvanMurzak.Unity.MCP.Common
         public static T? Deserialize<T>(JsonElement jsonElement, JsonSerializerOptions? options = null)
             => JsonSerializer.Deserialize<T>(jsonElement, options ?? jsonSerializerOptions);
 
+        public static object? Deserialize(JsonElement jsonElement, Type type, JsonSerializerOptions? options = null)
+            => JsonSerializer.Deserialize(jsonElement, type, options ?? jsonSerializerOptions);
+
         public static object? Deserialize(string json, Type type, JsonSerializerOptions? options = null)
             => JsonSerializer.Deserialize(json, type, options ?? jsonSerializerOptions);
 


### PR DESCRIPTION
This pull request refactors the deserialization logic across multiple files to simplify the codebase and improve maintainability. The key change is the removal of unnecessary calls to `GetRawText()` on `JsonElement` objects, replacing them with direct usage of `JsonElement` in the `JsonUtils.Deserialize` method. Additionally, a new overload for `JsonUtils.Deserialize` is introduced to handle `JsonElement` inputs directly with a specified type.

### Refactoring deserialization logic:

* Updated all instances of `JsonUtils.Deserialize` across `RS_Array.cs`, `RS_Generic.cs`, and `RS_Primitive.cs` to use the `JsonElement` directly instead of calling `GetRawText()`. This simplifies the code and avoids unnecessary string conversions. [[1]](diffhunk://#diff-098376b7a4775251907e51713b6eea9d6ee7d1300de30734ba82595103709164L56-R61) [[2]](diffhunk://#diff-098376b7a4775251907e51713b6eea9d6ee7d1300de30734ba82595103709164L74-R79) [[3]](diffhunk://#diff-098376b7a4775251907e51713b6eea9d6ee7d1300de30734ba82595103709164L94-R99) [[4]](diffhunk://#diff-098376b7a4775251907e51713b6eea9d6ee7d1300de30734ba82595103709164L114-R122) [[5]](diffhunk://#diff-9d8e34323e353052b49f2246274f9bdbdce8f267243cd45aced22a31c04a1648L45-R53) [[6]](diffhunk://#diff-9d8e34323e353052b49f2246274f9bdbdce8f267243cd45aced22a31c04a1648L62-R62) [[7]](diffhunk://#diff-9d8e34323e353052b49f2246274f9bdbdce8f267243cd45aced22a31c04a1648L71-R79) [[8]](diffhunk://#diff-63e2815929d53b3d3b6df1739d5910f938f972bd47617698c589d99854e7dfc7L37-R45) [[9]](diffhunk://#diff-63e2815929d53b3d3b6df1739d5910f938f972bd47617698c589d99854e7dfc7L54-R54) [[10]](diffhunk://#diff-63e2815929d53b3d3b6df1739d5910f938f972bd47617698c589d99854e7dfc7L63-R71)

* Updated `MethodWrapper.cs` to use the new approach for deserialization, replacing `GetRawText()` with direct `JsonElement` usage. [[1]](diffhunk://#diff-b6c6b2813c22e7b1a7ad34577f86ed0ba8756155a74a1a0ed3cc058eb75ba8b2L151-R151) [[2]](diffhunk://#diff-b6c6b2813c22e7b1a7ad34577f86ed0ba8756155a74a1a0ed3cc058eb75ba8b2L190-R190)

### Enhancements to `JsonUtils`:

* Added a new overload for `JsonUtils.Deserialize` that accepts a `JsonElement` and a `Type`, allowing direct deserialization from `JsonElement` without intermediate string conversions.