### PR TITLE
Mcp server iterate over ghost connections

### DIFF
--- a/Assets/root/Editor/Scripts/API/Tool/GameObject.Find.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/GameObject.Find.cs
@@ -1,10 +1,8 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System.ComponentModel;
-using System.Linq;
 using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Common.Data.Unity;
 using com.IvanMurzak.Unity.MCP.Utils;
-using UnityEditor.PackageManager;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {

--- a/Assets/root/Editor/Scripts/API/Tool/Script.Delete.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/Script.Delete.cs
@@ -1,7 +1,6 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System.ComponentModel;
 using System.IO;
-using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Utils;
 using UnityEditor;

--- a/Assets/root/Editor/Scripts/API/Tool/Script.Delete.cs
+++ b/Assets/root/Editor/Scripts/API/Tool/Script.Delete.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System.ComponentModel;
 using System.IO;
+using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Utils;
 using UnityEditor;
@@ -31,6 +32,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 return Error.ScriptFileNotFound(filePath);
 
             File.Delete(filePath);
+            if (File.Exists(filePath + ".meta"))
+                File.Delete(filePath + ".meta");
 
             return MainThread.Run(() =>
             {

--- a/Assets/root/Server/.vscode/settings.json
+++ b/Assets/root/Server/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "cSpell.words": [
         "Murzak"
-    ]
+    ],
+    "files.exclude": {
+        "**/*.meta": true
+    }
 }

--- a/Assets/root/Server/Common/Connection/ConnectionManager.cs
+++ b/Assets/root/Server/Common/Connection/ConnectionManager.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
 
         readonly string _guid = Guid.NewGuid().ToString();
         readonly ILogger<ConnectionManager> _logger;
-        readonly ReactiveProperty<HubConnection> _hubConnection = new();
+        readonly ReactiveProperty<HubConnection?> _hubConnection = new();
         readonly Func<string, Task<HubConnection>> _hubConnectionBuilder;
         readonly ReactiveProperty<HubConnectionState> _connectionState = new(HubConnectionState.Disconnected);
         readonly ReactiveProperty<bool> _continueToReconnect = new(false);
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
         HubConnectionObservable? hubConnectionObservable;
         CancellationTokenSource? internalCts;
         public ReadOnlyReactiveProperty<HubConnectionState> ConnectionState => _connectionState.ToReadOnlyReactiveProperty();
-        public ReadOnlyReactiveProperty<HubConnection> HubConnection => _hubConnection.ToReadOnlyReactiveProperty();
+        public ReadOnlyReactiveProperty<HubConnection?> HubConnection => _hubConnection.ToReadOnlyReactiveProperty();
         public ReadOnlyReactiveProperty<bool> KeepConnected => _continueToReconnect.ToReadOnlyReactiveProperty();
         public string Endpoint { get; set; } = string.Empty;
 
@@ -57,17 +57,22 @@ namespace com.IvanMurzak.Unity.MCP.Common
 
         public async Task InvokeAsync<TInput>(string methodName, TInput input, CancellationToken cancellationToken = default)
         {
-            if (_hubConnection.Value?.State != HubConnectionState.Connected && _continueToReconnect.CurrentValue)
+            if (_hubConnection.CurrentValue?.State != HubConnectionState.Connected && _continueToReconnect.CurrentValue)
             {
                 await Connect(cancellationToken);
-                if (_hubConnection.Value?.State != HubConnectionState.Connected)
+                if (_hubConnection.CurrentValue?.State != HubConnectionState.Connected)
                 {
                     _logger.LogError("{0} Can't establish connection with Remote.", _guid);
                     return;
                 }
             }
+            if (_hubConnection.CurrentValue == null)
+            {
+                _logger.LogError("{0} HubConnection is null. Can't invoke method {1}.", _guid, methodName);
+                return;
+            }
 
-            await _hubConnection.Value.InvokeAsync(methodName, input, cancellationToken).ContinueWith(task =>
+            await _hubConnection.CurrentValue.InvokeAsync(methodName, input, cancellationToken).ContinueWith(task =>
             {
                 if (task.IsCompletedSuccessfully)
                     return;
@@ -78,20 +83,25 @@ namespace com.IvanMurzak.Unity.MCP.Common
 
         public async Task<TResult> InvokeAsync<TInput, TResult>(string methodName, TInput input, CancellationToken cancellationToken = default)
         {
-            if (_hubConnection.Value?.State != HubConnectionState.Connected && _continueToReconnect.CurrentValue)
+            if (_hubConnection.CurrentValue?.State != HubConnectionState.Connected && _continueToReconnect.CurrentValue)
             {
                 _logger.LogDebug("{0} Connection is not established. Attempting to connect...", _guid);
                 // Attempt to connect if the connection is not established
                 await Connect(cancellationToken);
 
-                if (_hubConnection.Value?.State != HubConnectionState.Connected)
+                if (_hubConnection.CurrentValue?.State != HubConnectionState.Connected)
                 {
                     _logger.LogError("{0} Can't establish connection with Remote.", _guid);
                     return default!;
                 }
             }
+            if (_hubConnection.CurrentValue == null)
+            {
+                _logger.LogError("{0} HubConnection is null. Can't invoke method {1}.", _guid, methodName);
+                return default!;
+            }
 
-            return await _hubConnection.Value.InvokeAsync<TResult>(methodName, input, cancellationToken).ContinueWith(task =>
+            return await _hubConnection.CurrentValue.InvokeAsync<TResult>(methodName, input, cancellationToken).ContinueWith(task =>
             {
                 if (task.IsCompletedSuccessfully)
                     return task.Result;
@@ -208,8 +218,16 @@ namespace com.IvanMurzak.Unity.MCP.Common
             _logger.LogDebug("{0} Connecting to {1}...", _guid, Endpoint);
             while (_continueToReconnect.CurrentValue && !cancellationToken.IsCancellationRequested)
             {
+                var connection = _hubConnection.CurrentValue;
+                if (connection == null)
+                {
+                    _logger.LogTrace("{0} Waiting before retry... {1}", _guid, Endpoint);
+                    await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken); // Wait before retrying
+                    continue;
+                }
+
                 var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                var task = _hubConnection.CurrentValue.StartAsync(cts.Token);
+                var task = connection.StartAsync(cts.Token);
                 try
                 {
                     await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(3), cancellationToken));
@@ -302,17 +320,22 @@ namespace com.IvanMurzak.Unity.MCP.Common
                 try
                 {
                     var tempHubConnection = _hubConnection.Value;
+                    
                     _hubConnection.Value = null;
                     _hubConnection.Dispose();
-                    await tempHubConnection.StopAsync()
-                        .ContinueWith(task =>
-                        {
-                            try
+
+                    if (tempHubConnection != null)
+                    {
+                        await tempHubConnection.StopAsync()
+                            .ContinueWith(task =>
                             {
-                                tempHubConnection.DisposeAsync();
-                            }
-                            catch { }
-                        });
+                                try
+                                {
+                                    tempHubConnection.DisposeAsync();
+                                }
+                                catch { }
+                            });
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/Assets/root/Server/Common/Connection/IConnectionManager.cs
+++ b/Assets/root/Server/Common/Connection/IConnectionManager.cs
@@ -10,7 +10,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
     public interface IConnectionManager : IConnection, IDisposable
     {
         string Endpoint { get; set; }
-        ReadOnlyReactiveProperty<HubConnection> HubConnection { get; }
+        ReadOnlyReactiveProperty<HubConnection?> HubConnection { get; }
         Task InvokeAsync<TInput>(string methodName, TInput input, CancellationToken cancellationToken = default);
         Task<TResult> InvokeAsync<TInput, TResult>(string methodName, TInput input, CancellationToken cancellationToken = default);
     }

--- a/Assets/root/Server/Common/McpPlugin/Interfaces.cs
+++ b/Assets/root/Server/Common/McpPlugin/Interfaces.cs
@@ -29,15 +29,15 @@ namespace com.IvanMurzak.Unity.MCP.Common
 
     public interface IToolRunner
     {
-        Task<IResponseData<ResponseCallTool>> RunCallTool(IRequestCallTool requestData, string? connectionId = null, CancellationToken cancellationToken = default);
-        Task<IResponseData<ResponseListTool[]>> RunListTool(IRequestListTool requestData, string? connectionId = null, CancellationToken cancellationToken = default);
+        Task<IResponseData<ResponseCallTool>> RunCallTool(IRequestCallTool requestData, CancellationToken cancellationToken = default);
+        Task<IResponseData<ResponseListTool[]>> RunListTool(IRequestListTool requestData, CancellationToken cancellationToken = default);
     }
 
     public interface IResourceRunner
     {
-        Task<IResponseData<ResponseResourceContent[]>> RunResourceContent(IRequestResourceContent requestData, string? connectionId = null, CancellationToken cancellationToken = default);
-        Task<IResponseData<ResponseListResource[]>> RunListResources(IRequestListResources requestData, string? connectionId = null, CancellationToken cancellationToken = default);
-        Task<IResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(IRequestListResourceTemplates requestData, string? connectionId = null, CancellationToken cancellationToken = default);
+        Task<IResponseData<ResponseResourceContent[]>> RunResourceContent(IRequestResourceContent requestData, CancellationToken cancellationToken = default);
+        Task<IResponseData<ResponseListResource[]>> RunListResources(IRequestListResources requestData, CancellationToken cancellationToken = default);
+        Task<IResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(IRequestListResourceTemplates requestData, CancellationToken cancellationToken = default);
     }
 
     // -----------------------------------------------------------------

--- a/Assets/root/Server/Common/McpPlugin/RpcRouter.cs
+++ b/Assets/root/Server/Common/McpPlugin/RpcRouter.cs
@@ -54,6 +54,12 @@ namespace com.IvanMurzak.Unity.MCP.Common
 
             _logger.LogTrace("{0} Subscribing to server events.", nameof(RpcRouter));
 
+            hubConnection.On(Consts.RPC.Client.ForceDisconnect, async () =>
+            {
+                _logger.LogDebug("{0}.{1}", nameof(RpcRouter), Consts.RPC.Client.ForceDisconnect);
+                await _connectionManager.Disconnect();
+            });
+
             hubConnection.On<RequestCallTool, IResponseData<ResponseCallTool>>(Consts.RPC.Client.RunCallTool, async data =>
                 {
                     _logger.LogDebug("{0}.{1}", nameof(RpcRouter), Consts.RPC.Client.RunCallTool);

--- a/Assets/root/Server/Common/Runner/McpRunner.cs
+++ b/Assets/root/Server/Common/Runner/McpRunner.cs
@@ -44,7 +44,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
         public bool HasTool(string name) => _tools.ContainsKey(name);
         public bool HasResource(string name) => _resources.ContainsKey(name);
 
-        public async Task<IResponseData<ResponseCallTool>> RunCallTool(IRequestCallTool data, string? connectionId = null, CancellationToken cancellationToken = default)
+        public async Task<IResponseData<ResponseCallTool>> RunCallTool(IRequestCallTool data, CancellationToken cancellationToken = default)
         {
             if (data == null)
                 return ResponseData<ResponseCallTool>.Error(Consts.Guid.Zero, "Tool data is null.")
@@ -63,7 +63,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
                 {
                     var message = data.Arguments == null
                         ? $"Run tool '{data.Name}' with no parameters."
-                        : $"Run tool '{data.Name}' with parameters[{data.Arguments.Count}]:\n{string.Join(",\n", data.Arguments)}";
+                        : $"Run tool '{data.Name}' with parameters[{data.Arguments.Count}]:\n{string.Join(",\n", data.Arguments)}\n";
                     _logger.LogInformation(message);
                 }
 
@@ -82,7 +82,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
             }
         }
 
-        public Task<IResponseData<ResponseListTool[]>> RunListTool(IRequestListTool data, string? connectionId = null, CancellationToken cancellationToken = default)
+        public Task<IResponseData<ResponseListTool[]>> RunListTool(IRequestListTool data, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -111,7 +111,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
             }
         }
 
-        public async Task<IResponseData<ResponseResourceContent[]>> RunResourceContent(IRequestResourceContent data, string? connectionId = null, CancellationToken cancellationToken = default)
+        public async Task<IResponseData<ResponseResourceContent[]>> RunResourceContent(IRequestResourceContent data, CancellationToken cancellationToken = default)
         {
             if (data == null)
                 throw new ArgumentException("Resource data is null.");
@@ -133,7 +133,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
             return result.Pack(data.RequestID);
         }
 
-        public async Task<IResponseData<ResponseListResource[]>> RunListResources(IRequestListResources data, string? connectionId = null, CancellationToken cancellationToken = default)
+        public async Task<IResponseData<ResponseListResource[]>> RunListResources(IRequestListResources data, CancellationToken cancellationToken = default)
         {
             var tasks = _resources.Values
                 .Select(resource => resource.RunListContext.Run());
@@ -146,7 +146,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
                 .Pack(data.RequestID);
         }
 
-        public Task<IResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(IRequestListResourceTemplates data, string? connectionId = null, CancellationToken cancellationToken = default)
+        public Task<IResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(IRequestListResourceTemplates data, CancellationToken cancellationToken = default)
             => _resources.Values
                 .Select(resource => new ResponseResourceTemplate(resource.Route, resource.Name, resource.Description, resource.MimeType))
                 .ToArray()

--- a/Assets/root/Server/Common/Utils/Consts.RPC.cs
+++ b/Assets/root/Server/Common/Utils/Consts.RPC.cs
@@ -13,7 +13,7 @@ namespace com.IvanMurzak.Unity.MCP.Common
             public const int MaxPort = 65535;
             public const string DefaultEndpoint = "http://localhost:60606";
             public const string RemoteApp = "/mcp/remote-app";
-            public const float TimeoutSeconds = 10f;
+            public const float TimeoutSeconds = 3f;
         }
 
         public static partial class RPC

--- a/Assets/root/Server/Common/Utils/Consts.RPC.cs
+++ b/Assets/root/Server/Common/Utils/Consts.RPC.cs
@@ -25,6 +25,8 @@ namespace com.IvanMurzak.Unity.MCP.Common
                 public const string RunResourceContent = "/mcp/run-resource-content";
                 public const string RunListResources = "/mcp/run-list-resources";
                 public const string RunListResourceTemplates = "/mcp/run-list-resource-templates";
+
+                public const string ForceDisconnect = "force-disconnect";
             }
 
             public static class Server

--- a/Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.cs
+++ b/Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System;
+using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -16,30 +17,40 @@ namespace com.IvanMurzak.Unity.MCP.Common
 
             var parameters = method.GetParameters();
             if (parameters.Length == 0)
-                return null; // No parameters to generate schema for
+                return new JsonObject { ["type"] = "object" };
 
+            var properties = new JsonObject();
+            var required = new JsonArray();
             // Create a schema object manually
             var schema = new JsonObject
             {
                 ["type"] = "object",
-                ["properties"] = new JsonObject(),
-                ["required"] = new JsonArray()
+                ["properties"] = properties,
+                ["required"] = required
             };
-
-            var properties = (JsonObject)schema["properties"]!;
-            var required = (JsonArray)schema["required"]!;
 
             foreach (var parameter in parameters)
             {
                 // Use JsonSchemaExporter to get the schema for each parameter type
-                var parameterSchema = JsonSchemaExporter.GetJsonSchemaAsNode(jsonSerializerOptions, type: parameter.ParameterType);
+                var parameterSchema = JsonSchemaExporter.GetJsonSchemaAsNode(
+                    jsonSerializerOptions,
+                    type: parameter.ParameterType);
+
                 if (parameterSchema == null)
                     continue;
 
                 properties[parameter.Name!] = parameterSchema;
 
-                // Add to "required" if the parameter is not nullable
-                if (!IsNullable(parameter.ParameterType))
+                if (parameterSchema is JsonObject parameterSchemaObject)
+                {
+                    var propertyDescription = parameter.GetCustomAttribute<DescriptionAttribute>()?.Description
+                        ?? parameter.ParameterType.GetCustomAttribute<DescriptionAttribute>()?.Description;
+                    if (!string.IsNullOrEmpty(propertyDescription))
+                        parameterSchemaObject["description"] = JsonValue.Create(propertyDescription);
+                }
+
+                // Check if the parameter has a default value
+                if (!parameter.HasDefaultValue)
                     required.Add(parameter.Name!);
             }
             return schema;

--- a/Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.cs
+++ b/Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.cs
@@ -34,7 +34,11 @@ namespace com.IvanMurzak.Unity.MCP.Common
                 // Use JsonSchemaExporter to get the schema for each parameter type
                 var parameterSchema = JsonSchemaExporter.GetJsonSchemaAsNode(
                     jsonSerializerOptions,
-                    type: parameter.ParameterType);
+                    type: parameter.ParameterType,
+                    exporterOptions: new JsonSchemaExporterOptions
+                    {
+                        TreatNullObliviousAsNonNullable = true
+                    });
 
                 if (parameterSchema == null)
                     continue;

--- a/Assets/root/Server/Server/Client/RemoteResourceRunner.cs
+++ b/Assets/root/Server/Server/Client/RemoteResourceRunner.cs
@@ -23,53 +23,50 @@ namespace com.IvanMurzak.Unity.MCP.Server
             _remoteAppContext = remoteAppContext ?? throw new ArgumentNullException(nameof(remoteAppContext));
         }
 
-        public Task<IResponseData<ResponseResourceContent[]>> RunResourceContent(IRequestResourceContent requestData, string? connectionId, CancellationToken cancellationToken = default)
+        public Task<IResponseData<ResponseResourceContent[]>> RunResourceContent(IRequestResourceContent requestData, CancellationToken cancellationToken = default)
             => ClientUtils.InvokeAsync<IRequestResourceContent, ResponseResourceContent[], RemoteApp>(
                 logger: _logger,
                 hubContext: _remoteAppContext,
                 methodName: Consts.RPC.Client.RunResourceContent,
-                connectionId: connectionId,
                 requestData: requestData,
                 cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token)
                 .ContinueWith(task =>
             {
                 var response = task.Result;
                 if (response.IsError)
-                    return ResponseData<ResponseResourceContent[]>.Error(requestData.RequestID, response.Message ?? "[Error] Got an error during invoking tool");
+                    return ResponseData<ResponseResourceContent[]>.Error(requestData.RequestID, response.Message ?? "Got an error during invoking tool");
 
                 return response;
             }, cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token);
 
-        public Task<IResponseData<ResponseListResource[]>> RunListResources(IRequestListResources requestData, string? connectionId, CancellationToken cancellationToken = default)
+        public Task<IResponseData<ResponseListResource[]>> RunListResources(IRequestListResources requestData, CancellationToken cancellationToken = default)
             => ClientUtils.InvokeAsync<IRequestListResources, ResponseListResource[], RemoteApp>(
                 logger: _logger,
                 hubContext: _remoteAppContext,
                 methodName: Consts.RPC.Client.RunListResources,
-                connectionId: connectionId,
                 requestData: requestData,
                 cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token)
                 .ContinueWith(task =>
             {
                 var response = task.Result;
                 if (response.IsError)
-                    return ResponseData<ResponseListResource[]>.Error(requestData.RequestID, response.Message ?? "[Error] Got an error during invoking tool");
+                    return ResponseData<ResponseListResource[]>.Error(requestData.RequestID, response.Message ?? "Got an error during invoking tool");
 
                 return response;
             }, cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token);
 
-        public Task<IResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(IRequestListResourceTemplates requestData, string? connectionId = null, CancellationToken cancellationToken = default)
+        public Task<IResponseData<ResponseResourceTemplate[]>> RunResourceTemplates(IRequestListResourceTemplates requestData, CancellationToken cancellationToken = default)
             => ClientUtils.InvokeAsync<IRequestListResourceTemplates, ResponseResourceTemplate[], RemoteApp>(
                 logger: _logger,
                 hubContext: _remoteAppContext,
                 methodName: Consts.RPC.Client.RunListResourceTemplates,
-                connectionId: connectionId!,
                 requestData: requestData,
                 cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token)
                 .ContinueWith(task =>
             {
                 var response = task.Result;
                 if (response.IsError)
-                    return ResponseData<ResponseResourceTemplate[]>.Error(requestData.RequestID, response.Message ?? "[Error] Got an error during invoking tool");
+                    return ResponseData<ResponseResourceTemplate[]>.Error(requestData.RequestID, response.Message ?? "Got an error during invoking tool");
 
                 return response;
             }, cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token);

--- a/Assets/root/Server/Server/Client/RemoteToolRunner.cs
+++ b/Assets/root/Server/Server/Client/RemoteToolRunner.cs
@@ -23,36 +23,34 @@ namespace com.IvanMurzak.Unity.MCP.Server
             _remoteAppContext = remoteAppContext ?? throw new ArgumentNullException(nameof(remoteAppContext));
         }
 
-        public Task<IResponseData<ResponseCallTool>> RunCallTool(IRequestCallTool requestData, string? connectionId, CancellationToken cancellationToken = default)
+        public Task<IResponseData<ResponseCallTool>> RunCallTool(IRequestCallTool requestData, CancellationToken cancellationToken = default)
             => ClientUtils.InvokeAsync<IRequestCallTool, ResponseCallTool, RemoteApp>(
                 logger: _logger,
                 hubContext: _remoteAppContext,
                 methodName: Consts.RPC.Client.RunCallTool,
-                connectionId: connectionId,
                 requestData: requestData,
                 cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token)
                 .ContinueWith(task =>
             {
                 var response = task.Result;
                 if (response.IsError)
-                    return ResponseData<ResponseCallTool>.Error(requestData.RequestID, response.Message ?? "[Error] Got an error during invoking tool");
+                    return ResponseData<ResponseCallTool>.Error(requestData.RequestID, response.Message ?? "Got an error during invoking tool");
 
                 return response;
             }, cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token);
 
-        public Task<IResponseData<ResponseListTool[]>> RunListTool(IRequestListTool requestData, string? connectionId, CancellationToken cancellationToken = default)
+        public Task<IResponseData<ResponseListTool[]>> RunListTool(IRequestListTool requestData, CancellationToken cancellationToken = default)
             => ClientUtils.InvokeAsync<IRequestListTool, ResponseListTool[], RemoteApp>(
                 logger: _logger,
                 hubContext: _remoteAppContext,
                 methodName: Consts.RPC.Client.RunListTool,
-                connectionId: connectionId,
                 requestData: requestData,
                 cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token)
                 .ContinueWith(task =>
             {
                 var response = task.Result;
                 if (response.IsError)
-                    return ResponseData<ResponseListTool[]>.Error(requestData.RequestID, response.Message ?? "[Error] Got an error during listing tools");
+                    return ResponseData<ResponseListTool[]>.Error(requestData.RequestID, response.Message ?? "Got an error during listing tools");
 
                 return response;
             }, cancellationToken: CancellationTokenSource.CreateLinkedTokenSource(cts.Token, cancellationToken).Token);

--- a/Assets/root/Server/Server/Hub/BaseHub.cs
+++ b/Assets/root/Server/Server/Hub/BaseHub.cs
@@ -35,7 +35,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
 
             _logger.LogInformation("{0} Client connected: '{1}', Total connected clients for {2}: {3}", _guid, Context.ConnectionId, GetType().Name, clients.Count);
 
-            DisconnectOtherClients(clients, currentConnectionId: Context.ConnectionId);
+            // DisconnectOtherClients(clients, currentConnectionId: Context.ConnectionId);
             return base.OnConnectedAsync();
         }
 

--- a/Assets/root/Server/Server/Hub/BaseHub.cs
+++ b/Assets/root/Server/Server/Hub/BaseHub.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
+using com.IvanMurzak.Unity.MCP.Common;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using R3;
@@ -33,6 +34,8 @@ namespace com.IvanMurzak.Unity.MCP.Server
                 _logger.LogWarning("{0} Client '{1}' is already connected to {2}.", _guid, Context.ConnectionId, GetType().Name);
 
             _logger.LogInformation("{0} Client connected: '{1}', Total connected clients for {2}: {3}", _guid, Context.ConnectionId, GetType().Name, clients.Count);
+
+            DisconnectOtherClients(clients, currentConnectionId: Context.ConnectionId);
             return base.OnConnectedAsync();
         }
 
@@ -55,60 +58,31 @@ namespace com.IvanMurzak.Unity.MCP.Server
             return base.OnDisconnectedAsync(exception);
         }
 
-        // public void RemoveCurrentClient(ISingleClientProxy client)
-        // {
-        //     if (!ConnectedClients.TryGetValue(GetType(), out var clients) || clients.IsEmpty)
-        //     {
-        //         _logger.LogWarning($"No connected clients found for {GetType().Name}.");
-        //         return;
-        //     }
+        protected virtual void DisconnectOtherClients(ConcurrentDictionary<string, bool> clients, string currentConnectionId)
+        {
+            if (clients.IsEmpty)
+                return;
 
-        //     var connectionId = Context?.ConnectionId;
-        //     if (connectionId == null)
-        //         connectionId = clients.Last().Key;
+            foreach (var connectionId in clients.Keys.Where(c => c != currentConnectionId).ToList())
+            {
+                if (clients.TryRemove(connectionId, out _))
+                {
+                    _logger.LogInformation("{0} Client '{1}' removed from connected clients for {2}.", _guid, connectionId, GetType().Name);
+                    var client = Clients.Client(connectionId);
+                    client.SendAsync(Consts.RPC.Client.ForceDisconnect);
+                }
+                else
+                {
+                    _logger.LogWarning("{0} Client '{1}' was not found in connected clients for {2}.", _guid, connectionId, GetType().Name);
+                }
+            }
+        }
 
-        //     if (clients.TryRemove(connectionId, out _))
-        //     {
-        //         _logger.LogInformation($"Client '{connectionId}' removed from connected clients for {GetType().Name}.");
-        //         Context?.Abort();
-        //     }
-        //     else
-        //     {
-        //         _logger.LogWarning($"Client '{connectionId}' was not found in connected clients for {GetType().Name}.");
-        //     }
-        // }
-
-        // protected ISingleClientProxy? GetActiveClient()
-        // {
-        //     if (!ConnectedClients.TryGetValue(GetType(), out var clients) || clients.IsEmpty)
-        //     {
-        //         _logger.LogWarning($"No connected clients of type {GetType().Name}.");
-        //         return null;
-        //     }
-
-        //     var connectionId = clients.Keys.LastOrDefault();
-        //     if (connectionId == null)
-        //         return null;
-
-        //     var client = _hubContext.Clients.Client(connectionId);
-        //     if (client == null)
-        //     {
-        //         _logger.LogDebug($"Client {connectionId} is not available. Removing from connected clients.");
-        //         clients.TryRemove(connectionId, out _);
-        //         return GetActiveClient();
-        //     }
-
-        //     _logger.LogTrace($"Client {connectionId} is available.");
-        //     return client;
-        // }
         public virtual new void Dispose()
         {
             _logger.LogTrace("Dispose. {0}", _guid);
             base.Dispose();
             _disposables.Dispose();
-
-            // if (ConnectedClients.TryRemove(GetType(), out var clients))
-            //     clients.Clear();
         }
     }
 }

--- a/Assets/root/Server/Server/Hub/RemoteApp.cs
+++ b/Assets/root/Server/Server/Hub/RemoteApp.cs
@@ -1,8 +1,5 @@
 #pragma warning disable CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.Unity.MCP.Common.Data;
@@ -12,15 +9,7 @@ using Microsoft.Extensions.Logging;
 namespace com.IvanMurzak.Unity.MCP.Server
 {
     public class RemoteApp : BaseHub<RemoteApp>, IRemoteApp
-    {
-        public static IEnumerable<string> AllConnections => ConnectedClients.TryGetValue(typeof(RemoteApp), out var clients)
-            ? clients?.Keys ?? new string[0]
-            : Enumerable.Empty<string>();
-
-        public static string? FirstConnectionId => ConnectedClients.TryGetValue(typeof(RemoteApp), out var clients)
-            ? clients?.FirstOrDefault().Key
-            : null;
-        
+    {        
         readonly EventAppToolsChange _eventAppToolsChange;
 
         public RemoteApp(ILogger<RemoteApp> logger, IHubContext<RemoteApp> hubContext, EventAppToolsChange eventAppToolsChange)

--- a/Assets/root/Server/Server/McpServerService.cs
+++ b/Assets/root/Server/Server/McpServerService.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Common;
-using com.IvanMurzak.Unity.MCP.Common.Data;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.Call.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.Call.cs
@@ -16,7 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
         public static async Task<CallToolResponse> Call(RequestContext<CallToolRequestParams> request, CancellationToken cancellationToken)
         {
             var logger = LogManager.GetCurrentClassLogger();
-            logger.Trace("{0}.Call", typeof(ToolRouter).Name);
+            logger.Trace("{0}.Call", nameof(ToolRouter));
 
             if (request == null)
                 return new CallToolResponse().SetError("[Error] Request is null");
@@ -35,27 +35,19 @@ namespace com.IvanMurzak.Unity.MCP.Server
                 ? mcpServerService.McpRunner
                 : mcpServerService.ToolRunner;
 
+            logger.Trace("Using ToolRunner: {0}", toolRunner?.GetType().Name);
+
             if (toolRunner == null)
                 return new CallToolResponse().SetError($"[Error] '{nameof(toolRunner)}' is null");
 
             // while (RemoteApp.FirstConnectionId == null)
             //     await Task.Delay(100, cancellationToken);
 
-            var clientConnectionId = RemoteApp.FirstConnectionId;
-            if (mcpServerService.McpRunner.HasTool(request.Params.Name))
-            {
-                if (string.IsNullOrEmpty(clientConnectionId))
-                {
-                    logger.Warn("{0}.Call, no connected client. Returning empty success result.", typeof(ToolRouter).Name);
-                    return new CallToolResponse().SetError($"[Error] '{nameof(clientConnectionId)}' is null");
-                }
-            }
-
             var requestData = new RequestCallTool(request.Params.Name, request.Params.Arguments);
             if (logger.IsTraceEnabled)
                 logger.Trace("Call remote tool '{0}':\n{1}", request.Params.Name, JsonUtils.Serialize(requestData));
 
-            var response = await toolRunner.RunCallTool(requestData, connectionId: clientConnectionId, cancellationToken: cancellationToken);
+            var response = await toolRunner.RunCallTool(requestData, cancellationToken: cancellationToken);
             if (response == null)
                 return new CallToolResponse().SetError($"[Error] '{nameof(response)}' is null");
 

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
         public static async Task<ListToolsResult> ListAll(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
         {
             var logger = LogManager.GetCurrentClassLogger();
-            logger.Trace("{0}.ListAll", typeof(ToolRouter).Name);
+            logger.Trace("{0}.ListAll", nameof(ToolRouter));
 
             var mcpServerService = McpServerService.Instance;
             if (mcpServerService == null)
@@ -24,18 +24,10 @@ namespace com.IvanMurzak.Unity.MCP.Server
             if (toolRunner == null)
                 return new ListToolsResult().SetError($"[Error] '{nameof(toolRunner)}' is null");
 
-            // while (RemoteApp.FirstConnectionId == null)
-            //     await Task.Delay(100, cancellationToken);
-
-            var clientConnectionId = RemoteApp.FirstConnectionId;
-            if (string.IsNullOrEmpty(clientConnectionId))
-            {
-                logger.Warn("{0}.ListAll, no connected client. Returning empty success result.", typeof(ToolRouter).Name);
-                return new ListToolsResult();
-            }
+            logger.Trace("Using ToolRunner: {0}", toolRunner.GetType().Name);
 
             var requestData = new RequestListTool();
-            var response = await toolRunner.RunListTool(requestData, clientConnectionId, cancellationToken: cancellationToken);
+            var response = await toolRunner.RunListTool(requestData, cancellationToken: cancellationToken);
             if (response == null)
                 return new ListToolsResult().SetError($"[Error] '{nameof(response)}' is null");
 
@@ -54,6 +46,10 @@ namespace com.IvanMurzak.Unity.MCP.Server
             };
 
             logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
+
+            // Clear current Tools
+            mcpServerService.McpServer.ServerOptions.Capabilities?.Tools?.ToolCollection?.Clear();
+
             return result;
         }
     }

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
@@ -13,6 +13,10 @@ namespace com.IvanMurzak.Unity.MCP.Server
     {
         public static async Task<ListToolsResult> ListAll(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
         {
+            // TODO: Dynamic tool list update has too much issues in the current implementation of MCP Client (Cursor, Claude)
+            // That is why it is disabled for now
+            return new ListToolsResult().SetError($"[Error] Dynamic tool list update is disabled for now.");
+
             var logger = LogManager.GetCurrentClassLogger();
             logger.Trace("{0}.ListAll", nameof(ToolRouter));
 

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
@@ -13,10 +13,6 @@ namespace com.IvanMurzak.Unity.MCP.Server
     {
         public static async Task<ListToolsResult> ListAll(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
         {
-            // TODO: Dynamic tool list update has too much issues in the current implementation of MCP Client (Cursor, Claude)
-            // That is why it is disabled for now
-            return new ListToolsResult().SetError($"[Error] Dynamic tool list update is disabled for now.");
-
             var logger = LogManager.GetCurrentClassLogger();
             logger.Trace("{0}.ListAll", nameof(ToolRouter));
 


### PR DESCRIPTION
This pull request introduces several changes across different areas of the codebase, including nullable reference types, connection management, file handling, and JSON schema generation. The changes aim to improve code clarity, robustness, and functionality. Below is a summary of the most important changes grouped by theme:

### Nullable Reference Type Enhancements:
* Updated `HubConnection` and related properties in `ConnectionManager` to use nullable types (`HubConnection?`) for better null safety and to handle uninitialized states more effectively (`Assets/root/Server/Common/Connection/ConnectionManager.cs`, [[1]](diffhunk://#diff-22593c754df2cfc57caaad034df1c951d3eefb80eea3967dd7bb90fbf5d819f7L17-R17) [[2]](diffhunk://#diff-22593c754df2cfc57caaad034df1c951d3eefb80eea3967dd7bb90fbf5d819f7L28-R28).
* Adjusted the `HubConnection` property in the `IConnectionManager` interface to align with the nullable type changes (`Assets/root/Server/Common/Connection/IConnectionManager.cs`, [Assets/root/Server/Common/Connection/IConnectionManager.csL13-R13](diffhunk://#diff-4d5bca29dd303bf3d012107ce5989a7016644dd660dcee7e0709b2e28b78e88fL13-R13)).

### Connection Management Improvements:
* Added checks and logging for null `HubConnection` instances to prevent runtime errors during connection attempts and method invocations (`Assets/root/Server/Common/Connection/ConnectionManager.cs`, [[1]](diffhunk://#diff-22593c754df2cfc57caaad034df1c951d3eefb80eea3967dd7bb90fbf5d819f7L53-R75) [[2]](diffhunk://#diff-22593c754df2cfc57caaad034df1c951d3eefb80eea3967dd7bb90fbf5d819f7L81-R104) [[3]](diffhunk://#diff-22593c754df2cfc57caaad034df1c951d3eefb80eea3967dd7bb90fbf5d819f7R221-R230).
* Introduced a new `ForceDisconnect` event for the `RpcRouter` to handle client-side disconnection requests (`Assets/root/Server/Common/McpPlugin/RpcRouter.cs`, [[1]](diffhunk://#diff-05c52af70188024b57e145fcd1d5b85fce575e6703012bf6d6fef261552a1ac6R57-R62); `Assets/root/Server/Common/Utils/Consts.RPC.cs`, [[2]](diffhunk://#diff-a207aae348be2eca919a738af34bf4560269fde1c839adcace8742fc0eb5c448R28-R29).

### File Handling Enhancements:
* Added logic to delete associated `.meta` files when deleting script files, ensuring cleaner file management (`Assets/root/Editor/Scripts/API/Tool/Script.Delete.cs`, [Assets/root/Editor/Scripts/API/Tool/Script.Delete.csR34-R35](diffhunk://#diff-b7740d49d8b0a000c10f59da0a34b27052246861dc8a462a8b6d099a22217c4dR34-R35)).
* Updated `.vscode/settings.json` to exclude `.meta` files from the file explorer (`Assets/root/Server/.vscode/settings.json`, [Assets/root/Server/.vscode/settings.jsonL4-R7](diffhunk://#diff-b5aa4c81aa9ed9228c006c9d8665112e6d16f45e2af2918cdeb3965157ee6d25L4-R7)).

### JSON Schema Generation:
* Improved JSON schema generation by adding support for descriptions from `DescriptionAttribute` and ensuring non-nullable parameters are marked as required (`Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.cs`, [Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.csL19-R57](diffhunk://#diff-f0355f30d04f737301c9f0fe61fca5f257987e8b5d27f18ea249dc6bad32efdaL19-R57)).
* Fixed an issue where methods with no parameters returned `null` instead of an empty schema object (`Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.cs`, [Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.csL19-R57](diffhunk://#diff-f0355f30d04f737301c9f0fe61fca5f257987e8b5d27f18ea249dc6bad32efdaL19-R57)).

### Miscellaneous Changes:
* Reduced the default timeout for RPC operations from 10 seconds to 3 seconds for faster failure detection (`Assets/root/Server/Common/Utils/Consts.RPC.cs`, [Assets/root/Server/Common/Utils/Consts.RPC.csL16-R16](diffhunk://#diff-a207aae348be2eca919a738af34bf4560269fde1c839adcace8742fc0eb5c448L16-R16)).
* Removed unused imports (`Assets/root/Editor/Scripts/API/Tool/GameObject.Find.cs`, [[1]](diffhunk://#diff-b4b1b366a5ca50c565a9cd7b6d3a91659c5ac91cc4ecc8a041b767d9352d408bL3-L7); `Assets/root/Server/Common/Utils/Json/JsonUtils.Schema.cs`, [[2]](diffhunk://#diff-f0355f30d04f737301c9f0fe61fca5f257987e8b5d27f18ea249dc6bad32efdaR3).