### PR TITLE
Fix casing in directory name checks and update package version

### DIFF
--- a/Assets/root/Editor/Scripts/Startup.Server.cs
+++ b/Assets/root/Editor/Scripts/Startup.Server.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             {
                 var sourceDir = new DirectoryInfo(PackageCache)
                     .GetDirectories()
-                    .FirstOrDefault(d => d.Name.ToLower().Contains(PackageName.ToLower()))
+                    .FirstOrDefault(d => d.Name.ToLowerInvariant().Contains(PackageName.ToLowerInvariant()))
                     ?.FullName;
 
                 if (string.IsNullOrEmpty(sourceDir))
@@ -36,7 +36,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         }
 
         // Server executable path
-        public static string ServerExecutableRootPath => Path.GetFullPath(Path.Combine(Application.dataPath, "../Library", ServerProjectName.ToLower()));
+        public static string ServerExecutableRootPath => Path.GetFullPath(Path.Combine(Application.dataPath, "../Library", ServerProjectName.ToLowerInvariant()));
         public static string ServerExecutableFolder => Path.Combine(ServerExecutableRootPath, "bin~", "Release", "net9.0");
         public static string ServerExecutableFile => Path.Combine(ServerExecutableFolder, $"{ServerProjectName}");
 

--- a/Assets/root/package.json
+++ b/Assets/root/package.json
@@ -11,7 +11,7 @@
         "MCP",
         "Unity MCP"
     ],
-    "version": "0.7.4",
+    "version": "0.7.5",
     "unity": "2022.3",
     "description": "Bridge between LLM and Unity. It expose Unity API to LLM and allows LLM to control Unity. It is based on Model Context Protocol (MCP) and uses SignalR for communication.",
     "dependencies": {


### PR DESCRIPTION
Ensure consistent casing in directory name checks by using `ToLowerInvariant` and update the package version to 0.7.5.