### PR TITLE
fix: Client <-> Server update loop

### DIFF
--- a/Assets/root/Server/Server/API/Tool/Assets.Copy.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Copy.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Assets Copy"
         )]
         [Description(@"Copy the asset at path and stores it at newPath. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResponse> Copy
+        public ValueTask<CallToolResult> Copy
         (
             [Description("The paths of the asset to copy.")]
             string[] sourcePaths,

--- a/Assets/root/Server/Server/API/Tool/Assets.Copy.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Copy.cs
@@ -1,33 +1,33 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Copy",
-            Title = "Assets Copy"
-        )]
-        [Description(@"Copy the asset at path and stores it at newPath. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResult> Copy
-        (
-            [Description("The paths of the asset to copy.")]
-            string[] sourcePaths,
-            [Description("The paths to store the copied asset.")]
-            string[] destinationPaths
-        )
-        {
-            return ToolRouter.Call("Assets_Copy", arguments =>
-            {
-                arguments[nameof(sourcePaths)] = sourcePaths ?? new string[0];
-                arguments[nameof(destinationPaths)] = destinationPaths ?? new string[0];
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Copy",
+//             Title = "Assets Copy"
+//         )]
+//         [Description(@"Copy the asset at path and stores it at newPath. Does AssetDatabase.Refresh() at the end.")]
+//         public ValueTask<CallToolResult> Copy
+//         (
+//             [Description("The paths of the asset to copy.")]
+//             string[] sourcePaths,
+//             [Description("The paths to store the copied asset.")]
+//             string[] destinationPaths
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Copy", arguments =>
+//             {
+//                 arguments[nameof(sourcePaths)] = sourcePaths ?? new string[0];
+//                 arguments[nameof(destinationPaths)] = destinationPaths ?? new string[0];
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.CreateFolders.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.CreateFolders.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         )]
         [Description(@"Create folders at specific locations in the project.
 Use it to organize scripts and assets in the project. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResponse> CreateFolders
+        public ValueTask<CallToolResult> CreateFolders
         (
             [Description("The paths for the folders to create.")]
             string[] paths

--- a/Assets/root/Server/Server/API/Tool/Assets.CreateFolders.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.CreateFolders.cs
@@ -1,31 +1,31 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_CreateFolders",
-            Title = "Assets Create Folders"
-        )]
-        [Description(@"Create folders at specific locations in the project.
-Use it to organize scripts and assets in the project. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResult> CreateFolders
-        (
-            [Description("The paths for the folders to create.")]
-            string[] paths
-        )
-        {
-            return ToolRouter.Call("Assets_CreateFolders", arguments =>
-            {
-                arguments[nameof(paths)] = paths ?? new string[0];
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_CreateFolders",
+//             Title = "Assets Create Folders"
+//         )]
+//         [Description(@"Create folders at specific locations in the project.
+// Use it to organize scripts and assets in the project. Does AssetDatabase.Refresh() at the end.")]
+//         public ValueTask<CallToolResult> CreateFolders
+//         (
+//             [Description("The paths for the folders to create.")]
+//             string[] paths
+//         )
+//         {
+//             return ToolRouter.Call("Assets_CreateFolders", arguments =>
+//             {
+//                 arguments[nameof(paths)] = paths ?? new string[0];
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Delete.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Delete.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Delete",
-            Title = "Assets Delete"
-        )]
-        [Description(@"Delete the assets at paths from the project. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResult> Delete
-        (
-            [Description("The paths of the assets")]
-            string[] paths
-        )
-        {
-            return ToolRouter.Call("Assets_Delete", arguments =>
-            {
-                arguments[nameof(paths)] = paths ?? new string[0];
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Delete",
+//             Title = "Assets Delete"
+//         )]
+//         [Description(@"Delete the assets at paths from the project. Does AssetDatabase.Refresh() at the end.")]
+//         public ValueTask<CallToolResult> Delete
+//         (
+//             [Description("The paths of the assets")]
+//             string[] paths
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Delete", arguments =>
+//             {
+//                 arguments[nameof(paths)] = paths ?? new string[0];
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Delete.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Delete.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Assets Delete"
         )]
         [Description(@"Delete the assets at paths from the project. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResponse> Delete
+        public ValueTask<CallToolResult> Delete
         (
             [Description("The paths of the assets")]
             string[] paths

--- a/Assets/root/Server/Server/API/Tool/Assets.Find.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Find.cs
@@ -1,66 +1,66 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Find",
-            Title = "Find assets in the project"
-        )]
-        [Description(@"Search the asset database using the search filter string.
-Available types:
-t:AnimationClip
-t:AudioClip
-t:AudioMixer
-t:ComputeShader
-t:Font
-t:GUISkin
-t:Material
-t:Mesh
-t:Model
-t:PhysicMaterial
-t:Prefab
-t:Scene
-t:Script
-t:Shader
-t:Sprite
-t:Texture
-t:VideoClip
-t:VisualEffectAsset
-t:VisualEffectSubgraph")]
-        public ValueTask<CallToolResult> Search
-        (
-            [Description("The folders where the search will start. If null, the search will be performed in all folders.")]
-            string[]? searchInFolders = null,
-// <ref>https://docs.unity3d.com/ScriptReference/AssetDatabase.FindAssets.html</ref>
-[Description(@"Searching filter. Could be empty.
-Name: Filter assets by their filename (without extension). Words separated by whitespace are treated as separate name searches. For example, 'test asset' is a name of an Asset which will be searched for. Note that the name can be used to identify an asset. Further, the name used in the filter string can be specified as a subsection. For example, the 'test asset' example above can be matched using 'test'.
-Labels (l:): Assets can have labels attached to them. Assets with particular labels can be found using the keyword 'l:' before each label. This indicates that the string is searching for labels.
-Types (t:): Find assets based on explicitly identified types. The keyword 't:' is used as a way to specify that typed assets are being looked for. If more than one type is included in the filter string, then assets that match one class will be returned. Types can either be built-in types such as Texture2D or user-created script classes. User-created classes are assets created from a ScriptableObject class in the project. If all assets are wanted, use Object as all assets derive from Object. Specifying one or more folders using the searchInFolders argument will limit the searching to these folders and their child folders. This is faster than searching all assets in all folders.
-AssetBundles (b:): Find assets which are part of an Asset bundle. The keyword 'b:' is used to determine that Asset bundle names should be part of the query.
-Area (a:): Find assets in a specific area of a project. Valid values are 'all', 'assets', and 'packages'. Use this to make your query more specific using the 'a:' keyword followed by the area name to speed up searching.
-Globbing (glob:): Use globbing to match specific rules. The keyword 'glob:' is followed by the query. For example, 'glob:Editor' will find all Editor folders in a project, 'glob:(Editor|Resources)' will find all Editor and Resources folders in a project, 'glob:Editor/*' will return all Assets inside Editor folders in a project, while 'glob:Editor/**' will return all Assets within Editor folders recursively.
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Find",
+//             Title = "Find assets in the project"
+//         )]
+//         [Description(@"Search the asset database using the search filter string.
+// Available types:
+// t:AnimationClip
+// t:AudioClip
+// t:AudioMixer
+// t:ComputeShader
+// t:Font
+// t:GUISkin
+// t:Material
+// t:Mesh
+// t:Model
+// t:PhysicMaterial
+// t:Prefab
+// t:Scene
+// t:Script
+// t:Shader
+// t:Sprite
+// t:Texture
+// t:VideoClip
+// t:VisualEffectAsset
+// t:VisualEffectSubgraph")]
+//         public ValueTask<CallToolResult> Search
+//         (
+//             [Description("The folders where the search will start. If null, the search will be performed in all folders.")]
+//             string[]? searchInFolders = null,
+// // <ref>https://docs.unity3d.com/ScriptReference/AssetDatabase.FindAssets.html</ref>
+// [Description(@"Searching filter. Could be empty.
+// Name: Filter assets by their filename (without extension). Words separated by whitespace are treated as separate name searches. For example, 'test asset' is a name of an Asset which will be searched for. Note that the name can be used to identify an asset. Further, the name used in the filter string can be specified as a subsection. For example, the 'test asset' example above can be matched using 'test'.
+// Labels (l:): Assets can have labels attached to them. Assets with particular labels can be found using the keyword 'l:' before each label. This indicates that the string is searching for labels.
+// Types (t:): Find assets based on explicitly identified types. The keyword 't:' is used as a way to specify that typed assets are being looked for. If more than one type is included in the filter string, then assets that match one class will be returned. Types can either be built-in types such as Texture2D or user-created script classes. User-created classes are assets created from a ScriptableObject class in the project. If all assets are wanted, use Object as all assets derive from Object. Specifying one or more folders using the searchInFolders argument will limit the searching to these folders and their child folders. This is faster than searching all assets in all folders.
+// AssetBundles (b:): Find assets which are part of an Asset bundle. The keyword 'b:' is used to determine that Asset bundle names should be part of the query.
+// Area (a:): Find assets in a specific area of a project. Valid values are 'all', 'assets', and 'packages'. Use this to make your query more specific using the 'a:' keyword followed by the area name to speed up searching.
+// Globbing (glob:): Use globbing to match specific rules. The keyword 'glob:' is followed by the query. For example, 'glob:Editor' will find all Editor folders in a project, 'glob:(Editor|Resources)' will find all Editor and Resources folders in a project, 'glob:Editor/*' will return all Assets inside Editor folders in a project, while 'glob:Editor/**' will return all Assets within Editor folders recursively.
 
-Note:
-Searching is case insensitive.")]
-            string? filter = null
-        )
-        {
-            return ToolRouter.Call("Assets_Find", arguments =>
-            {
-                if (filter != null && filter.Length > 0)
-                    arguments[nameof(filter)] = filter;
+// Note:
+// Searching is case insensitive.")]
+//             string? filter = null
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Find", arguments =>
+//             {
+//                 if (filter != null && filter.Length > 0)
+//                     arguments[nameof(filter)] = filter;
 
-                if (searchInFolders != null && searchInFolders.Length > 0)
-                    arguments[nameof(searchInFolders)] = searchInFolders;
-            });
-        }
-    }
-}
-#endif
+//                 if (searchInFolders != null && searchInFolders.Length > 0)
+//                     arguments[nameof(searchInFolders)] = searchInFolders;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Find.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Find.cs
@@ -34,7 +34,7 @@ t:Texture
 t:VideoClip
 t:VisualEffectAsset
 t:VisualEffectSubgraph")]
-        public ValueTask<CallToolResponse> Search
+        public ValueTask<CallToolResult> Search
         (
             [Description("The folders where the search will start. If null, the search will be performed in all folders.")]
             string[]? searchInFolders = null,

--- a/Assets/root/Server/Server/API/Tool/Assets.Material.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Material.Create.cs
@@ -1,33 +1,33 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Material
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Material_Create",
-            Title = "Create Material asset"
-        )]
-        [Description(@"Create new material asset with default parameters. Right 'shaderName' should be set. To find the shader, use 'Shader.Find' method.")]
-        public ValueTask<CallToolResult> Create
-        (
-            [Description("Asset path. Starts with 'Assets/'. Ends with '.mat'.")]
-            string assetPath,
-            [Description("Name of the shader that need to be used to create the material.")]
-            string shaderName
-        )
-        {
-            return ToolRouter.Call("Assets_Material_Create", arguments =>
-            {
-                arguments[nameof(assetPath)] = assetPath ?? string.Empty;
-                arguments[nameof(shaderName)] = shaderName ?? string.Empty;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Material
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Material_Create",
+//             Title = "Create Material asset"
+//         )]
+//         [Description(@"Create new material asset with default parameters. Right 'shaderName' should be set. To find the shader, use 'Shader.Find' method.")]
+//         public ValueTask<CallToolResult> Create
+//         (
+//             [Description("Asset path. Starts with 'Assets/'. Ends with '.mat'.")]
+//             string assetPath,
+//             [Description("Name of the shader that need to be used to create the material.")]
+//             string shaderName
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Material_Create", arguments =>
+//             {
+//                 arguments[nameof(assetPath)] = assetPath ?? string.Empty;
+//                 arguments[nameof(shaderName)] = shaderName ?? string.Empty;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Material.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Material.Create.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Create Material asset"
         )]
         [Description(@"Create new material asset with default parameters. Right 'shaderName' should be set. To find the shader, use 'Shader.Find' method.")]
-        public ValueTask<CallToolResponse> Create
+        public ValueTask<CallToolResult> Create
         (
             [Description("Asset path. Starts with 'Assets/'. Ends with '.mat'.")]
             string assetPath,

--- a/Assets/root/Server/Server/API/Tool/Assets.Material.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Material.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Assets_Material
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Assets_Material
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Modify.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Modify.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Modify asset file"
         )]
         [Description(@"Modify asset in the project. Not allowed to modify asset in 'Packages/' folder. Please modify it in 'Assets/' folder.")]
-        public ValueTask<CallToolResponse> Modify
+        public ValueTask<CallToolResult> Modify
         (
             [Description("The asset content. It overrides the existing asset content.")]
             SerializedMember content,

--- a/Assets/root/Server/Server/API/Tool/Assets.Modify.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Modify.cs
@@ -1,39 +1,39 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Modify",
-            Title = "Modify asset file"
-        )]
-        [Description(@"Modify asset in the project. Not allowed to modify asset in 'Packages/' folder. Please modify it in 'Assets/' folder.")]
-        public ValueTask<CallToolResult> Modify
-        (
-            [Description("The asset content. It overrides the existing asset content.")]
-            SerializedMember content,
-            [Description("Path to the asset. See 'Assets_Search' for more details. Starts with 'Assets/'. Priority: 1. (Recommended)")]
-            string? assetPath = null,
-            [Description("GUID of the asset. Priority: 2.")]
-            string? assetGuid = null
-        )
-        {
-            return ToolRouter.Call("Assets_Modify", arguments =>
-            {
-                if (content != null)
-                    arguments[nameof(content)] = content;
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Modify",
+//             Title = "Modify asset file"
+//         )]
+//         [Description(@"Modify asset in the project. Not allowed to modify asset in 'Packages/' folder. Please modify it in 'Assets/' folder.")]
+//         public ValueTask<CallToolResult> Modify
+//         (
+//             [Description("The asset content. It overrides the existing asset content.")]
+//             SerializedMember content,
+//             [Description("Path to the asset. See 'Assets_Search' for more details. Starts with 'Assets/'. Priority: 1. (Recommended)")]
+//             string? assetPath = null,
+//             [Description("GUID of the asset. Priority: 2.")]
+//             string? assetGuid = null
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Modify", arguments =>
+//             {
+//                 if (content != null)
+//                     arguments[nameof(content)] = content;
 
-                arguments[nameof(assetPath)] = assetPath ?? string.Empty;
-                arguments[nameof(assetGuid)] = assetGuid ?? string.Empty;
-            });
-        }
-    }
-}
-#endif
+//                 arguments[nameof(assetPath)] = assetPath ?? string.Empty;
+//                 arguments[nameof(assetGuid)] = assetGuid ?? string.Empty;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Move.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Move.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Assets Move"
         )]
         [Description(@"Move the assets at paths in the project. Should be used for asset rename. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResponse> Move
+        public ValueTask<CallToolResult> Move
         (
             [Description("The paths of the assets to move.")]
             string[] sourcePaths,

--- a/Assets/root/Server/Server/API/Tool/Assets.Move.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Move.cs
@@ -1,33 +1,33 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Move",
-            Title = "Assets Move"
-        )]
-        [Description(@"Move the assets at paths in the project. Should be used for asset rename. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResult> Move
-        (
-            [Description("The paths of the assets to move.")]
-            string[] sourcePaths,
-            [Description("The paths of moved assets.")]
-            string[] destinationPaths
-        )
-        {
-            return ToolRouter.Call("Assets_Move", arguments =>
-            {
-                arguments[nameof(sourcePaths)] = sourcePaths ?? new string[0];
-                arguments[nameof(destinationPaths)] = destinationPaths ?? new string[0];
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Move",
+//             Title = "Assets Move"
+//         )]
+//         [Description(@"Move the assets at paths in the project. Should be used for asset rename. Does AssetDatabase.Refresh() at the end.")]
+//         public ValueTask<CallToolResult> Move
+//         (
+//             [Description("The paths of the assets to move.")]
+//             string[] sourcePaths,
+//             [Description("The paths of moved assets.")]
+//             string[] destinationPaths
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Move", arguments =>
+//             {
+//                 arguments[nameof(sourcePaths)] = sourcePaths ?? new string[0];
+//                 arguments[nameof(destinationPaths)] = destinationPaths ?? new string[0];
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Close.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Close.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Close prefab"
         )]
         [Description("Close a prefab. Use it when you are in prefab editing mode in Unity Editor.")]
-        public ValueTask<CallToolResponse> Close
+        public ValueTask<CallToolResult> Close
         (
             [Description("True to save prefab. False to discard changes.")]
             bool save = true

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Close.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Close.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Prefab
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Prefab_Close",
-            Title = "Close prefab"
-        )]
-        [Description("Close a prefab. Use it when you are in prefab editing mode in Unity Editor.")]
-        public ValueTask<CallToolResult> Close
-        (
-            [Description("True to save prefab. False to discard changes.")]
-            bool save = true
-        )
-        {
-            return ToolRouter.Call("Assets_Prefab_Close", arguments =>
-            {
-                arguments[nameof(save)] = save;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Prefab
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Prefab_Close",
+//             Title = "Close prefab"
+//         )]
+//         [Description("Close a prefab. Use it when you are in prefab editing mode in Unity Editor.")]
+//         public ValueTask<CallToolResult> Close
+//         (
+//             [Description("True to save prefab. False to discard changes.")]
+//             bool save = true
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Prefab_Close", arguments =>
+//             {
+//                 arguments[nameof(save)] = save;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Create.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Create prefab from a GameObject in a scene"
         )]
         [Description("Create a prefab from a GameObject in a scene. The prefab will be saved in the project assets at the specified path.")]
-        public ValueTask<CallToolResponse> Create
+        public ValueTask<CallToolResult> Create
         (
             [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
             string prefabAssetPath,

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Create.cs
@@ -1,36 +1,36 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Prefab
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Prefab_Create",
-            Title = "Create prefab from a GameObject in a scene"
-        )]
-        [Description("Create a prefab from a GameObject in a scene. The prefab will be saved in the project assets at the specified path.")]
-        public ValueTask<CallToolResult> Create
-        (
-            [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
-            string prefabAssetPath,
-            [Description("'instanceID' of GameObject in a scene.")]
-            int instanceID,
-            [Description("If true, the prefab will replace the GameObject in the scene.")]
-            bool replaceGameObjectWithPrefab = true
-        )
-        {
-            return ToolRouter.Call("Assets_Prefab_Create", arguments =>
-            {
-                arguments[nameof(prefabAssetPath)] = prefabAssetPath ?? string.Empty;
-                arguments[nameof(instanceID)] = instanceID;
-                arguments[nameof(replaceGameObjectWithPrefab)] = replaceGameObjectWithPrefab;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Prefab
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Prefab_Create",
+//             Title = "Create prefab from a GameObject in a scene"
+//         )]
+//         [Description("Create a prefab from a GameObject in a scene. The prefab will be saved in the project assets at the specified path.")]
+//         public ValueTask<CallToolResult> Create
+//         (
+//             [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
+//             string prefabAssetPath,
+//             [Description("'instanceID' of GameObject in a scene.")]
+//             int instanceID,
+//             [Description("If true, the prefab will replace the GameObject in the scene.")]
+//             bool replaceGameObjectWithPrefab = true
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Prefab_Create", arguments =>
+//             {
+//                 arguments[nameof(prefabAssetPath)] = prefabAssetPath ?? string.Empty;
+//                 arguments[nameof(instanceID)] = instanceID;
+//                 arguments[nameof(replaceGameObjectWithPrefab)] = replaceGameObjectWithPrefab;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Instantiate.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Instantiate.cs
@@ -1,53 +1,53 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.Unity.MCP.Server.API.Data;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.Unity.MCP.Server.API.Data;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Prefab
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Prefab_Instantiate",
-            Title = "Instantiate prefab in the current active scene"
-        )]
-        [Description("Instantiates prefab in a scene.")]
-        public ValueTask<CallToolResult> Instantiate
-        (
-            [Description("Prefab asset path.")]
-            string prefabAssetPath,
-            [Description("GameObject path in the current active scene.")]
-            string gameObjectPath,
-            [Description("Transform position of the GameObject.")]
-            Vector3? position = default,
-            [Description("Transform rotation of the GameObject. Euler angles in degrees.")]
-            Vector3? rotation = default,
-            [Description("Transform scale of the GameObject.")]
-            Vector3? scale = default,
-            [Description("World or Local space of transform.")]
-            bool isLocalSpace = false
-        )
-        {
-            return ToolRouter.Call("Assets_Prefab_Instantiate", arguments =>
-            {
-                arguments[nameof(prefabAssetPath)] = prefabAssetPath;
-                arguments[nameof(gameObjectPath)] = gameObjectPath;
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Prefab
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Prefab_Instantiate",
+//             Title = "Instantiate prefab in the current active scene"
+//         )]
+//         [Description("Instantiates prefab in a scene.")]
+//         public ValueTask<CallToolResult> Instantiate
+//         (
+//             [Description("Prefab asset path.")]
+//             string prefabAssetPath,
+//             [Description("GameObject path in the current active scene.")]
+//             string gameObjectPath,
+//             [Description("Transform position of the GameObject.")]
+//             Vector3? position = default,
+//             [Description("Transform rotation of the GameObject. Euler angles in degrees.")]
+//             Vector3? rotation = default,
+//             [Description("Transform scale of the GameObject.")]
+//             Vector3? scale = default,
+//             [Description("World or Local space of transform.")]
+//             bool isLocalSpace = false
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Prefab_Instantiate", arguments =>
+//             {
+//                 arguments[nameof(prefabAssetPath)] = prefabAssetPath;
+//                 arguments[nameof(gameObjectPath)] = gameObjectPath;
 
-                if (position != null)
-                    arguments[nameof(position)] = position;
+//                 if (position != null)
+//                     arguments[nameof(position)] = position;
 
-                if (rotation != null)
-                    arguments[nameof(rotation)] = rotation;
+//                 if (rotation != null)
+//                     arguments[nameof(rotation)] = rotation;
 
-                if (scale != null)
-                    arguments[nameof(scale)] = scale;
+//                 if (scale != null)
+//                     arguments[nameof(scale)] = scale;
 
-                arguments[nameof(isLocalSpace)] = isLocalSpace;
-            });
-        }
-    }
-}
-#endif
+//                 arguments[nameof(isLocalSpace)] = isLocalSpace;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Instantiate.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Instantiate.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Instantiate prefab in the current active scene"
         )]
         [Description("Instantiates prefab in a scene.")]
-        public ValueTask<CallToolResponse> Instantiate
+        public ValueTask<CallToolResult> Instantiate
         (
             [Description("Prefab asset path.")]
             string prefabAssetPath,

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Open.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Open.cs
@@ -18,7 +18,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
                     "2. Open prefab from GameObject in loaded scene using 'instanceID' of the GameObject.\n" +
                     "   The GameObject should be connected to a prefab.\n\n" +
                     "Note: Please 'Close' the prefab after editing.")]
-        public ValueTask<CallToolResponse> Open
+        public ValueTask<CallToolResult> Open
         (
             [Description("'instanceID' of GameObject in a scene.")]
             int instanceID = 0,

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Open.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Open.cs
@@ -1,37 +1,37 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Prefab
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Prefab_Open",
-            Title = "Open prefab"
-        )]
-        [Description("Open a prefab. Use it for get started with prefab editing. There are two options to open prefab:\n" +
-                    "1. Open prefab from asset using 'prefabAssetPath'.\n" +
-                    "2. Open prefab from GameObject in loaded scene using 'instanceID' of the GameObject.\n" +
-                    "   The GameObject should be connected to a prefab.\n\n" +
-                    "Note: Please 'Close' the prefab after editing.")]
-        public ValueTask<CallToolResult> Open
-        (
-            [Description("'instanceID' of GameObject in a scene.")]
-            int instanceID = 0,
-            [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
-            string? prefabAssetPath = null
-        )
-        {
-            return ToolRouter.Call("Assets_Prefab_Open", arguments =>
-            {
-                arguments[nameof(instanceID)] = instanceID;
-                arguments[nameof(prefabAssetPath)] = prefabAssetPath ?? string.Empty;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Prefab
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Prefab_Open",
+//             Title = "Open prefab"
+//         )]
+//         [Description("Open a prefab. Use it for get started with prefab editing. There are two options to open prefab:\n" +
+//                     "1. Open prefab from asset using 'prefabAssetPath'.\n" +
+//                     "2. Open prefab from GameObject in loaded scene using 'instanceID' of the GameObject.\n" +
+//                     "   The GameObject should be connected to a prefab.\n\n" +
+//                     "Note: Please 'Close' the prefab after editing.")]
+//         public ValueTask<CallToolResult> Open
+//         (
+//             [Description("'instanceID' of GameObject in a scene.")]
+//             int instanceID = 0,
+//             [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
+//             string? prefabAssetPath = null
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Prefab_Open", arguments =>
+//             {
+//                 arguments[nameof(instanceID)] = instanceID;
+//                 arguments[nameof(prefabAssetPath)] = prefabAssetPath ?? string.Empty;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Read.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Read.cs
@@ -17,7 +17,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
                     "1. Read prefab from asset using 'prefabAssetPath'.\n" +
                     "2. Read prefab from GameObject in loaded scene using 'instanceID' of the GameObject.\n" +
                     "   The GameObject should be connected to a prefab.")]
-        public ValueTask<CallToolResponse> Read
+        public ValueTask<CallToolResult> Read
         (
             [Description("'instanceID' of GameObject in a scene.")]
             int instanceID = 0,

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Read.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Read.cs
@@ -1,39 +1,39 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Prefab
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Prefab_Read",
-            Title = "Read prefab content"
-        )]
-        [Description("Read a prefab content. Use it for get started with prefab editing. There are two options to open prefab:\n" +
-                    "1. Read prefab from asset using 'prefabAssetPath'.\n" +
-                    "2. Read prefab from GameObject in loaded scene using 'instanceID' of the GameObject.\n" +
-                    "   The GameObject should be connected to a prefab.")]
-        public ValueTask<CallToolResult> Read
-        (
-            [Description("'instanceID' of GameObject in a scene.")]
-            int instanceID = 0,
-            [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
-            string? prefabAssetPath = null,
-            [Description("Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below.")]
-            int includeChildrenDepth = 3
-        )
-        {
-            return ToolRouter.Call("Assets_Prefab_Read", arguments =>
-            {
-                arguments[nameof(instanceID)] = instanceID;
-                arguments[nameof(prefabAssetPath)] = prefabAssetPath ?? string.Empty;
-                arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Prefab
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Prefab_Read",
+//             Title = "Read prefab content"
+//         )]
+//         [Description("Read a prefab content. Use it for get started with prefab editing. There are two options to open prefab:\n" +
+//                     "1. Read prefab from asset using 'prefabAssetPath'.\n" +
+//                     "2. Read prefab from GameObject in loaded scene using 'instanceID' of the GameObject.\n" +
+//                     "   The GameObject should be connected to a prefab.")]
+//         public ValueTask<CallToolResult> Read
+//         (
+//             [Description("'instanceID' of GameObject in a scene.")]
+//             int instanceID = 0,
+//             [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
+//             string? prefabAssetPath = null,
+//             [Description("Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below.")]
+//             int includeChildrenDepth = 3
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Prefab_Read", arguments =>
+//             {
+//                 arguments[nameof(instanceID)] = instanceID;
+//                 arguments[nameof(prefabAssetPath)] = prefabAssetPath ?? string.Empty;
+//                 arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Save.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Save.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Save prefab"
         )]
         [Description("Save a prefab. Use it when you are in prefab editing mode in Unity Editor.")]
-        public ValueTask<CallToolResponse> Save()
+        public ValueTask<CallToolResult> Save()
         {
             return ToolRouter.Call("Assets_Prefab_Save");
         }

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.Save.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.Save.cs
@@ -1,23 +1,23 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Prefab
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Prefab_Save",
-            Title = "Save prefab"
-        )]
-        [Description("Save a prefab. Use it when you are in prefab editing mode in Unity Editor.")]
-        public ValueTask<CallToolResult> Save()
-        {
-            return ToolRouter.Call("Assets_Prefab_Save");
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Prefab
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Prefab_Save",
+//             Title = "Save prefab"
+//         )]
+//         [Description("Save a prefab. Use it when you are in prefab editing mode in Unity Editor.")]
+//         public ValueTask<CallToolResult> Save()
+//         {
+//             return ToolRouter.Call("Assets_Prefab_Save");
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Prefab.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Prefab.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Assets_Prefab
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Assets_Prefab
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Read.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Read.cs
@@ -1,36 +1,36 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Read",
-            Title = "Read asset file content"
-        )]
-        [Description(@"Read file asset in the project.")]
-        public ValueTask<CallToolResult> Read
-        (
-            [Description("Path to the asset. See 'Assets_Search' for more details. Starts with 'Assets/'. Priority: 1. (Recommended)")]
-            string? assetPath = null,
-            [Description("GUID of the asset. Priority: 2.")]
-            string? assetGuid = null
-        )
-        {
-            return ToolRouter.Call("Assets_Read", arguments =>
-            {
-                if (assetPath != null && assetPath.Length > 0)
-                    arguments[nameof(assetPath)] = assetPath;
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Read",
+//             Title = "Read asset file content"
+//         )]
+//         [Description(@"Read file asset in the project.")]
+//         public ValueTask<CallToolResult> Read
+//         (
+//             [Description("Path to the asset. See 'Assets_Search' for more details. Starts with 'Assets/'. Priority: 1. (Recommended)")]
+//             string? assetPath = null,
+//             [Description("GUID of the asset. Priority: 2.")]
+//             string? assetGuid = null
+//         )
+//         {
+//             return ToolRouter.Call("Assets_Read", arguments =>
+//             {
+//                 if (assetPath != null && assetPath.Length > 0)
+//                     arguments[nameof(assetPath)] = assetPath;
 
-                if (assetGuid != null && assetGuid.Length > 0)
-                    arguments[nameof(assetGuid)] = assetGuid;
-            });
-        }
-    }
-}
-#endif
+//                 if (assetGuid != null && assetGuid.Length > 0)
+//                     arguments[nameof(assetGuid)] = assetGuid;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Read.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Read.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Read asset file content"
         )]
         [Description(@"Read file asset in the project.")]
-        public ValueTask<CallToolResponse> Read
+        public ValueTask<CallToolResult> Read
         (
             [Description("Path to the asset. See 'Assets_Search' for more details. Starts with 'Assets/'. Priority: 1. (Recommended)")]
             string? assetPath = null,

--- a/Assets/root/Server/Server/API/Tool/Assets.Refresh.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Refresh.cs
@@ -1,25 +1,25 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Refresh",
-            Title = "Assets Refresh"
-        )]
-        [Description(@"Refreshes the AssetDatabase. Use it if any new files were added or updated in the project outside of Unity API.
-Don't need to call it for Scripts manipulations.
-It also triggers scripts recompilation if any changes in '.cs' files.")]
-        public ValueTask<CallToolResult> Refresh()
-        {
-            return ToolRouter.Call("Assets_Refresh");
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Refresh",
+//             Title = "Assets Refresh"
+//         )]
+//         [Description(@"Refreshes the AssetDatabase. Use it if any new files were added or updated in the project outside of Unity API.
+// Don't need to call it for Scripts manipulations.
+// It also triggers scripts recompilation if any changes in '.cs' files.")]
+//         public ValueTask<CallToolResult> Refresh()
+//         {
+//             return ToolRouter.Call("Assets_Refresh");
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Refresh.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Refresh.cs
@@ -16,7 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         [Description(@"Refreshes the AssetDatabase. Use it if any new files were added or updated in the project outside of Unity API.
 Don't need to call it for Scripts manipulations.
 It also triggers scripts recompilation if any changes in '.cs' files.")]
-        public ValueTask<CallToolResponse> Refresh()
+        public ValueTask<CallToolResult> Refresh()
         {
             return ToolRouter.Call("Assets_Refresh");
         }

--- a/Assets/root/Server/Server/API/Tool/Assets.Shader.ListAll.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Shader.ListAll.cs
@@ -1,23 +1,23 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Assets_Shader
-    {
-        [McpServerTool
-        (
-            Name = "Assets_Shader_ListAll",
-            Title = "List all shader names"
-        )]
-        [Description(@"Scans the project assets to find all shaders and to get the name from each of them. Returns the list of shader names.")]
-        public ValueTask<CallToolResult> ListAll()
-        {
-            return ToolRouter.Call("Assets_Shader_ListAll");
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Assets_Shader
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Assets_Shader_ListAll",
+//             Title = "List all shader names"
+//         )]
+//         [Description(@"Scans the project assets to find all shaders and to get the name from each of them. Returns the list of shader names.")]
+//         public ValueTask<CallToolResult> ListAll()
+//         {
+//             return ToolRouter.Call("Assets_Shader_ListAll");
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.Shader.ListAll.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Shader.ListAll.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "List all shader names"
         )]
         [Description(@"Scans the project assets to find all shaders and to get the name from each of them. Returns the list of shader names.")]
-        public ValueTask<CallToolResponse> ListAll()
+        public ValueTask<CallToolResult> ListAll()
         {
             return ToolRouter.Call("Assets_Shader_ListAll");
         }

--- a/Assets/root/Server/Server/API/Tool/Assets.Shader.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.Shader.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Assets_Shader
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Assets_Shader
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Assets.cs
+++ b/Assets/root/Server/Server/API/Tool/Assets.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Assets
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Assets
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Component.GetAll.cs
+++ b/Assets/root/Server/Server/API/Tool/Component.GetAll.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Get list of all Components"
         )]
         [Description("Returns the list of all available components in the project.")]
-        public ValueTask<CallToolResponse> GetAll
+        public ValueTask<CallToolResult> GetAll
         (
             [Description("Substring for searching components. Could be empty.")]
             string search

--- a/Assets/root/Server/Server/API/Tool/Component.GetAll.cs
+++ b/Assets/root/Server/Server/API/Tool/Component.GetAll.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Component
-    {
-        [McpServerTool
-        (
-            Name = "Component_GetAll",
-            Title = "Get list of all Components"
-        )]
-        [Description("Returns the list of all available components in the project.")]
-        public ValueTask<CallToolResult> GetAll
-        (
-            [Description("Substring for searching components. Could be empty.")]
-            string search
-        )
-        {
-            return ToolRouter.Call("Component_GetAll", arguments =>
-            {
-                arguments[nameof(search)] = search;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Component
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Component_GetAll",
+//             Title = "Get list of all Components"
+//         )]
+//         [Description("Returns the list of all available components in the project.")]
+//         public ValueTask<CallToolResult> GetAll
+//         (
+//             [Description("Substring for searching components. Could be empty.")]
+//             string search
+//         )
+//         {
+//             return ToolRouter.Call("Component_GetAll", arguments =>
+//             {
+//                 arguments[nameof(search)] = search;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Component.cs
+++ b/Assets/root/Server/Server/API/Tool/Component.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Component
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Component
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Editor.GetApplicationInformation.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.GetApplicationInformation.cs
@@ -23,7 +23,7 @@ EditorApplication.isUpdating - True if the Editor is currently refreshing the As
 EditorApplication.applicationContentsPath - Path to the Unity editor contents folder. (Read Only)
 EditorApplication.applicationPath - Gets the path to the Unity Editor application. (Read Only)
 EditorApplication.timeSinceStartup - The time since the editor was started. (Read Only)")]
-        public ValueTask<CallToolResponse> GetApplicationInformation()
+        public ValueTask<CallToolResult> GetApplicationInformation()
         {
             return ToolRouter.Call("Editor_GetApplicationInformation");
         }

--- a/Assets/root/Server/Server/API/Tool/Editor.GetApplicationInformation.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.GetApplicationInformation.cs
@@ -1,32 +1,32 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Editor
-    {
-        [McpServerTool
-        (
-            Name = "Editor_GetApplicationInformation",
-            Title = "Get Unity Editor application information"
-        )]
-        [Description(@"Returns list of available information about 'UnityEditor.EditorApplication'.
-Use it to get information about the current state of the Unity Editor application. Such as: playmode, paused state, compilation state, etc.
-EditorApplication.isPlaying - Whether the Editor is in Play mode.
-EditorApplication.isPaused - Whether the Editor is paused.
-EditorApplication.isCompiling - Is editor currently compiling scripts? (Read Only)
-EditorApplication.isPlayingOrWillChangePlaymode - Editor application state which is true only when the Editor is currently in or about to enter Play mode. (Read Only)
-EditorApplication.isUpdating - True if the Editor is currently refreshing the AssetDatabase. (Read Only)
-EditorApplication.applicationContentsPath - Path to the Unity editor contents folder. (Read Only)
-EditorApplication.applicationPath - Gets the path to the Unity Editor application. (Read Only)
-EditorApplication.timeSinceStartup - The time since the editor was started. (Read Only)")]
-        public ValueTask<CallToolResult> GetApplicationInformation()
-        {
-            return ToolRouter.Call("Editor_GetApplicationInformation");
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Editor
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Editor_GetApplicationInformation",
+//             Title = "Get Unity Editor application information"
+//         )]
+//         [Description(@"Returns list of available information about 'UnityEditor.EditorApplication'.
+// Use it to get information about the current state of the Unity Editor application. Such as: playmode, paused state, compilation state, etc.
+// EditorApplication.isPlaying - Whether the Editor is in Play mode.
+// EditorApplication.isPaused - Whether the Editor is paused.
+// EditorApplication.isCompiling - Is editor currently compiling scripts? (Read Only)
+// EditorApplication.isPlayingOrWillChangePlaymode - Editor application state which is true only when the Editor is currently in or about to enter Play mode. (Read Only)
+// EditorApplication.isUpdating - True if the Editor is currently refreshing the AssetDatabase. (Read Only)
+// EditorApplication.applicationContentsPath - Path to the Unity editor contents folder. (Read Only)
+// EditorApplication.applicationPath - Gets the path to the Unity Editor application. (Read Only)
+// EditorApplication.timeSinceStartup - The time since the editor was started. (Read Only)")]
+//         public ValueTask<CallToolResult> GetApplicationInformation()
+//         {
+//             return ToolRouter.Call("Editor_GetApplicationInformation");
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Editor.Selection.Get.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.Selection.Get.cs
@@ -23,7 +23,7 @@ Selection.activeGameObject - Returns the active game object. (The one shown in t
 Selection.activeInstanceID - Returns the instanceID of the actual object selection. Includes Prefabs, non-modifiable objects.
 Selection.activeObject - Returns the actual object selection. Includes Prefabs, non-modifiable objects.
 Selection.activeTransform - Returns the active transform. (The one shown in the inspector).")]
-        public ValueTask<CallToolResponse> Get()
+        public ValueTask<CallToolResult> Get()
         {
             return ToolRouter.Call("Editor_Selection_Get");
         }

--- a/Assets/root/Server/Server/API/Tool/Editor.Selection.Get.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.Selection.Get.cs
@@ -1,32 +1,32 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Editor_Selection
-    {
-        [McpServerTool
-        (
-            Name = "Editor_Selection_Get",
-            Title = "Get current Selection value in Unity Editor"
-        )]
-        [Description(@"'UnityEditor.Selection'. Access to the selection in the editor.
-Use it to get information about selected Assets or GameObjects in a scene.
-Selection.transforms - Returns the top level selection instanceIDs, excluding Prefabs.
-Selection.instanceIDs - The actual unfiltered selection from the Scene returned as instance ids instead of objects.
-Selection.gameObjects - Returns the actual game object selection. Includes Prefabs, non-modifiable objects. (Read Only)
-Selection.assetGUIDs - Returns the guids of the selected assets. (Read Only)
-Selection.activeGameObject - Returns the active game object. (The one shown in the inspector). (Read Only)
-Selection.activeInstanceID - Returns the instanceID of the actual object selection. Includes Prefabs, non-modifiable objects.
-Selection.activeObject - Returns the actual object selection. Includes Prefabs, non-modifiable objects.
-Selection.activeTransform - Returns the active transform. (The one shown in the inspector).")]
-        public ValueTask<CallToolResult> Get()
-        {
-            return ToolRouter.Call("Editor_Selection_Get");
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Editor_Selection
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Editor_Selection_Get",
+//             Title = "Get current Selection value in Unity Editor"
+//         )]
+//         [Description(@"'UnityEditor.Selection'. Access to the selection in the editor.
+// Use it to get information about selected Assets or GameObjects in a scene.
+// Selection.transforms - Returns the top level selection instanceIDs, excluding Prefabs.
+// Selection.instanceIDs - The actual unfiltered selection from the Scene returned as instance ids instead of objects.
+// Selection.gameObjects - Returns the actual game object selection. Includes Prefabs, non-modifiable objects. (Read Only)
+// Selection.assetGUIDs - Returns the guids of the selected assets. (Read Only)
+// Selection.activeGameObject - Returns the active game object. (The one shown in the inspector). (Read Only)
+// Selection.activeInstanceID - Returns the instanceID of the actual object selection. Includes Prefabs, non-modifiable objects.
+// Selection.activeObject - Returns the actual object selection. Includes Prefabs, non-modifiable objects.
+// Selection.activeTransform - Returns the active transform. (The one shown in the inspector).")]
+//         public ValueTask<CallToolResult> Get()
+//         {
+//             return ToolRouter.Call("Editor_Selection_Get");
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Editor.Selection.Set.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.Selection.Set.cs
@@ -1,38 +1,38 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Editor_Selection
-    {
-        [McpServerTool
-        (
-            Name = "Editor_Selection_Set",
-            Title = "Set Selection in Unity Editor"
-        )]
-        [Description(@"'UnityEditor.Selection'. Access to the selection in the editor.
-Use it to select Assets or GameObjects in a scene. Set empty array to clear selection.
-Selection.instanceIDs - The actual unfiltered selection from the Scene returned as instance ids.
-Selection.activeInstanceID -  The 'instanceID' of the actual object selection. Includes Prefabs, non-modifiable objects.")]
-        public ValueTask<CallToolResult> Set
-        (
-            [Description("The 'instanceID' array of the target GameObjects.")]
-            int[]? instanceIDs = null,
-            [Description("The 'instanceID' of the target Object.")]
-            int activeInstanceID = 0
-        )
-        {
-            return ToolRouter.Call("Editor_Selection_Set", arguments =>
-            {
-                if (instanceIDs != null && instanceIDs.Length > 0)
-                    arguments[nameof(instanceIDs)] = instanceIDs;
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Editor_Selection
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Editor_Selection_Set",
+//             Title = "Set Selection in Unity Editor"
+//         )]
+//         [Description(@"'UnityEditor.Selection'. Access to the selection in the editor.
+// Use it to select Assets or GameObjects in a scene. Set empty array to clear selection.
+// Selection.instanceIDs - The actual unfiltered selection from the Scene returned as instance ids.
+// Selection.activeInstanceID -  The 'instanceID' of the actual object selection. Includes Prefabs, non-modifiable objects.")]
+//         public ValueTask<CallToolResult> Set
+//         (
+//             [Description("The 'instanceID' array of the target GameObjects.")]
+//             int[]? instanceIDs = null,
+//             [Description("The 'instanceID' of the target Object.")]
+//             int activeInstanceID = 0
+//         )
+//         {
+//             return ToolRouter.Call("Editor_Selection_Set", arguments =>
+//             {
+//                 if (instanceIDs != null && instanceIDs.Length > 0)
+//                     arguments[nameof(instanceIDs)] = instanceIDs;
 
-                arguments[nameof(activeInstanceID)] = activeInstanceID;
-            });
-        }
-    }
-}
-#endif
+//                 arguments[nameof(activeInstanceID)] = activeInstanceID;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Editor.Selection.Set.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.Selection.Set.cs
@@ -17,7 +17,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
 Use it to select Assets or GameObjects in a scene. Set empty array to clear selection.
 Selection.instanceIDs - The actual unfiltered selection from the Scene returned as instance ids.
 Selection.activeInstanceID -  The 'instanceID' of the actual object selection. Includes Prefabs, non-modifiable objects.")]
-        public ValueTask<CallToolResponse> Set
+        public ValueTask<CallToolResult> Set
         (
             [Description("The 'instanceID' array of the target GameObjects.")]
             int[]? instanceIDs = null,

--- a/Assets/root/Server/Server/API/Tool/Editor.Selection.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.Selection.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Editor_Selection
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Editor_Selection
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Editor.SetApplicationState.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.SetApplicationState.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Set Unity Editor application state"
         )]
         [Description("Control the Unity Editor application state. You can start, stop, or pause the 'playmode'.")]
-        public ValueTask<CallToolResponse> SetApplicationState
+        public ValueTask<CallToolResult> SetApplicationState
         (
             [Description("If true, the 'playmode' will be started. If false, the 'playmode' will be stopped.")]
             bool isPlaying = false,

--- a/Assets/root/Server/Server/API/Tool/Editor.SetApplicationState.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.SetApplicationState.cs
@@ -1,33 +1,33 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Editor
-    {
-        [McpServerTool
-        (
-            Name = "Editor_SetApplicationState",
-            Title = "Set Unity Editor application state"
-        )]
-        [Description("Control the Unity Editor application state. You can start, stop, or pause the 'playmode'.")]
-        public ValueTask<CallToolResult> SetApplicationState
-        (
-            [Description("If true, the 'playmode' will be started. If false, the 'playmode' will be stopped.")]
-            bool isPlaying = false,
-            [Description("If true, the 'playmode' will be paused. If false, the 'playmode' will be resumed.")]
-            bool isPaused = false
-        )
-        {
-            return ToolRouter.Call("Editor_SetApplicationState", arguments =>
-            {
-                arguments[nameof(isPlaying)] = isPlaying;
-                arguments[nameof(isPaused)] = isPaused;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Editor
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Editor_SetApplicationState",
+//             Title = "Set Unity Editor application state"
+//         )]
+//         [Description("Control the Unity Editor application state. You can start, stop, or pause the 'playmode'.")]
+//         public ValueTask<CallToolResult> SetApplicationState
+//         (
+//             [Description("If true, the 'playmode' will be started. If false, the 'playmode' will be stopped.")]
+//             bool isPlaying = false,
+//             [Description("If true, the 'playmode' will be paused. If false, the 'playmode' will be resumed.")]
+//             bool isPaused = false
+//         )
+//         {
+//             return ToolRouter.Call("Editor_SetApplicationState", arguments =>
+//             {
+//                 arguments[nameof(isPlaying)] = isPlaying;
+//                 arguments[nameof(isPaused)] = isPaused;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Editor.cs
+++ b/Assets/root/Server/Server/API/Tool/Editor.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Editor
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Editor
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.AddComponent.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.AddComponent.cs
@@ -1,33 +1,33 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_AddComponent",
-            Title = "Add Component to a GameObject in opened Prefab or in a Scene"
-        )]
-        [Description("Add a component to a GameObject.")]
-        public ValueTask<CallToolResult> AddComponent
-        (
-            [Description("Full name of the Component. It should include full namespace path and the class name.")]
-            string[] componentNames,
-            GameObjectRef gameObjectRef
-        )
-        {
-            return ToolRouter.Call("GameObject_AddComponent", arguments =>
-            {
-                arguments[nameof(componentNames)] = componentNames;
-                arguments[nameof(gameObjectRef)] = gameObjectRef;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_AddComponent",
+//             Title = "Add Component to a GameObject in opened Prefab or in a Scene"
+//         )]
+//         [Description("Add a component to a GameObject.")]
+//         public ValueTask<CallToolResult> AddComponent
+//         (
+//             [Description("Full name of the Component. It should include full namespace path and the class name.")]
+//             string[] componentNames,
+//             GameObjectRef gameObjectRef
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_AddComponent", arguments =>
+//             {
+//                 arguments[nameof(componentNames)] = componentNames;
+//                 arguments[nameof(gameObjectRef)] = gameObjectRef;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.AddComponent.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.AddComponent.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Add Component to a GameObject in opened Prefab or in a Scene"
         )]
         [Description("Add a component to a GameObject.")]
-        public ValueTask<CallToolResponse> AddComponent
+        public ValueTask<CallToolResult> AddComponent
         (
             [Description("Full name of the Component. It should include full namespace path and the class name.")]
             string[] componentNames,

--- a/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
@@ -17,7 +17,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         )]
         [Description(@"Create a new GameObject at specific path.
 if needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.")]
-        public ValueTask<CallToolResponse> Create
+        public ValueTask<CallToolResult> Create
         (
             [Description("Name of the new GameObject.")]
             string name,

--- a/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Create.cs
@@ -1,59 +1,59 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using com.IvanMurzak.Unity.MCP.Server.API.Data;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using com.IvanMurzak.Unity.MCP.Server.API.Data;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_Create",
-            Title = "Create a new GameObject in opened Prefab or in a Scene"
-        )]
-        [Description(@"Create a new GameObject at specific path.
-if needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.")]
-        public ValueTask<CallToolResult> Create
-        (
-            [Description("Name of the new GameObject.")]
-            string name,
-            GameObjectRef? parentGameObjectRef = null,
-            [Description("Transform position of the GameObject.")]
-            Vector3? position = default,
-            [Description("Transform rotation of the GameObject. Euler angles in degrees.")]
-            Vector3? rotation = default,
-            [Description("Transform scale of the GameObject.")]
-            Vector3? scale = default,
-            [Description("World or Local space of transform.")]
-            bool isLocalSpace = false,
-            [Description("-1 - No primitive type; 0 - Cube; 1 - Sphere; 2 - Capsule; 3 - Cylinder; 4 - Plane; 5 - Quad.")]
-            int primitiveType = -1
-        )
-        {
-            return ToolRouter.Call("GameObject_Create", arguments =>
-            {
-                arguments[nameof(name)] = name;
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_Create",
+//             Title = "Create a new GameObject in opened Prefab or in a Scene"
+//         )]
+//         [Description(@"Create a new GameObject at specific path.
+// if needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.")]
+//         public ValueTask<CallToolResult> Create
+//         (
+//             [Description("Name of the new GameObject.")]
+//             string name,
+//             GameObjectRef? parentGameObjectRef = null,
+//             [Description("Transform position of the GameObject.")]
+//             Vector3? position = default,
+//             [Description("Transform rotation of the GameObject. Euler angles in degrees.")]
+//             Vector3? rotation = default,
+//             [Description("Transform scale of the GameObject.")]
+//             Vector3? scale = default,
+//             [Description("World or Local space of transform.")]
+//             bool isLocalSpace = false,
+//             [Description("-1 - No primitive type; 0 - Cube; 1 - Sphere; 2 - Capsule; 3 - Cylinder; 4 - Plane; 5 - Quad.")]
+//             int primitiveType = -1
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_Create", arguments =>
+//             {
+//                 arguments[nameof(name)] = name;
 
-                if (parentGameObjectRef != null)
-                    arguments[nameof(parentGameObjectRef)] = parentGameObjectRef;
+//                 if (parentGameObjectRef != null)
+//                     arguments[nameof(parentGameObjectRef)] = parentGameObjectRef;
 
-                if (position != null)
-                    arguments[nameof(position)] = position;
+//                 if (position != null)
+//                     arguments[nameof(position)] = position;
 
-                if (rotation != null)
-                    arguments[nameof(rotation)] = rotation;
+//                 if (rotation != null)
+//                     arguments[nameof(rotation)] = rotation;
 
-                if (scale != null)
-                    arguments[nameof(scale)] = scale;
+//                 if (scale != null)
+//                     arguments[nameof(scale)] = scale;
 
-                arguments[nameof(isLocalSpace)] = isLocalSpace;
-                arguments[nameof(primitiveType)] = primitiveType;
-            });
-        }
-    }
-}
-#endif
+//                 arguments[nameof(isLocalSpace)] = isLocalSpace;
+//                 arguments[nameof(primitiveType)] = primitiveType;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.Destroy.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Destroy.cs
@@ -16,7 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         )]
         [Description(@"Destroy a GameObject and all nested GameObjects recursively.
 Use 'instanceID' whenever possible, because it finds the exact GameObject, when 'path' may find a wrong one.")]
-        public ValueTask<CallToolResponse> Destroy
+        public ValueTask<CallToolResult> Destroy
         (
             GameObjectRef gameObjectRef
         )

--- a/Assets/root/Server/Server/API/Tool/GameObject.Destroy.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Destroy.cs
@@ -1,31 +1,31 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_Destroy",
-            Title = "Destroy GameObject in opened Prefab or in a Scene"
-        )]
-        [Description(@"Destroy a GameObject and all nested GameObjects recursively.
-Use 'instanceID' whenever possible, because it finds the exact GameObject, when 'path' may find a wrong one.")]
-        public ValueTask<CallToolResult> Destroy
-        (
-            GameObjectRef gameObjectRef
-        )
-        {
-            return ToolRouter.Call("GameObject_Destroy", arguments =>
-            {
-                arguments[nameof(gameObjectRef)] = gameObjectRef;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_Destroy",
+//             Title = "Destroy GameObject in opened Prefab or in a Scene"
+//         )]
+//         [Description(@"Destroy a GameObject and all nested GameObjects recursively.
+// Use 'instanceID' whenever possible, because it finds the exact GameObject, when 'path' may find a wrong one.")]
+//         public ValueTask<CallToolResult> Destroy
+//         (
+//             GameObjectRef gameObjectRef
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_Destroy", arguments =>
+//             {
+//                 arguments[nameof(gameObjectRef)] = gameObjectRef;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.DestroyComponents.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.DestroyComponents.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Destroy Components from a GameObject in opened Prefab or in a Scene"
         )]
         [Description("Destroy one or many components from target GameObject.")]
-        public ValueTask<CallToolResponse> DestroyComponents
+        public ValueTask<CallToolResult> DestroyComponents
         (
             GameObjectRef gameObjectRef,
             ComponentRefList destroyComponentRefs

--- a/Assets/root/Server/Server/API/Tool/GameObject.DestroyComponents.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.DestroyComponents.cs
@@ -1,32 +1,32 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_DestroyComponents",
-            Title = "Destroy Components from a GameObject in opened Prefab or in a Scene"
-        )]
-        [Description("Destroy one or many components from target GameObject.")]
-        public ValueTask<CallToolResult> DestroyComponents
-        (
-            GameObjectRef gameObjectRef,
-            ComponentRefList destroyComponentRefs
-        )
-        {
-            return ToolRouter.Call("GameObject_DestroyComponents", arguments =>
-            {
-                arguments[nameof(gameObjectRef)] = gameObjectRef;
-                arguments[nameof(destroyComponentRefs)] = destroyComponentRefs ?? new();
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_DestroyComponents",
+//             Title = "Destroy Components from a GameObject in opened Prefab or in a Scene"
+//         )]
+//         [Description("Destroy one or many components from target GameObject.")]
+//         public ValueTask<CallToolResult> DestroyComponents
+//         (
+//             GameObjectRef gameObjectRef,
+//             ComponentRefList destroyComponentRefs
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_DestroyComponents", arguments =>
+//             {
+//                 arguments[nameof(gameObjectRef)] = gameObjectRef;
+//                 arguments[nameof(destroyComponentRefs)] = destroyComponentRefs ?? new();
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.Duplicate.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Duplicate.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_Duplicate",
-            Title = "Duplicate GameObjects in opened Prefab and in a Scene"
-        )]
-        [Description(@"Duplicate GameObjects in opened Prefab and in a Scene by 'instanceID' (int) array.")]
-        public ValueTask<CallToolResult> Duplicate
-        (
-            GameObjectRefList gameObjectRefs
-        )
-        {
-            return ToolRouter.Call("GameObject_Duplicate", arguments =>
-            {
-                arguments[nameof(gameObjectRefs)] = gameObjectRefs;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_Duplicate",
+//             Title = "Duplicate GameObjects in opened Prefab and in a Scene"
+//         )]
+//         [Description(@"Duplicate GameObjects in opened Prefab and in a Scene by 'instanceID' (int) array.")]
+//         public ValueTask<CallToolResult> Duplicate
+//         (
+//             GameObjectRefList gameObjectRefs
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_Duplicate", arguments =>
+//             {
+//                 arguments[nameof(gameObjectRefs)] = gameObjectRefs;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.Duplicate.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Duplicate.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Duplicate GameObjects in opened Prefab and in a Scene"
         )]
         [Description(@"Duplicate GameObjects in opened Prefab and in a Scene by 'instanceID' (int) array.")]
-        public ValueTask<CallToolResponse> Duplicate
+        public ValueTask<CallToolResult> Duplicate
         (
             GameObjectRefList gameObjectRefs
         )

--- a/Assets/root/Server/Server/API/Tool/GameObject.Find.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Find.cs
@@ -1,40 +1,40 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_Find",
-            Title = "Find GameObject in opened Prefab or in a Scene"
-        )]
-        [Description(@"Finds specific GameObject by provided information.
-First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene.
-If no opened Prefab it looks into current active scene.
-Returns GameObject information and its children.
-Also, it returns Components preview just for the target GameObject.")]
-        public ValueTask<CallToolResult> Find
-        (
-            GameObjectRef gameObjectRef,
-            [Description("Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below.")]
-            int includeChildrenDepth = 0,
-            [Description("If true, it will print only brief data of the target GameObject.")]
-            bool briefData = false
-        )
-        {
-            return ToolRouter.Call("GameObject_Find", arguments =>
-            {
-                arguments[nameof(gameObjectRef)] = gameObjectRef;
-                arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
-                arguments[nameof(briefData)] = briefData;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_Find",
+//             Title = "Find GameObject in opened Prefab or in a Scene"
+//         )]
+//         [Description(@"Finds specific GameObject by provided information.
+// First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene.
+// If no opened Prefab it looks into current active scene.
+// Returns GameObject information and its children.
+// Also, it returns Components preview just for the target GameObject.")]
+//         public ValueTask<CallToolResult> Find
+//         (
+//             GameObjectRef gameObjectRef,
+//             [Description("Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below.")]
+//             int includeChildrenDepth = 0,
+//             [Description("If true, it will print only brief data of the target GameObject.")]
+//             bool briefData = false
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_Find", arguments =>
+//             {
+//                 arguments[nameof(gameObjectRef)] = gameObjectRef;
+//                 arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
+//                 arguments[nameof(briefData)] = briefData;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.Find.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Find.cs
@@ -19,7 +19,7 @@ First it looks for the opened Prefab, if any Prefab is opened it looks only ther
 If no opened Prefab it looks into current active scene.
 Returns GameObject information and its children.
 Also, it returns Components preview just for the target GameObject.")]
-        public ValueTask<CallToolResponse> Find
+        public ValueTask<CallToolResult> Find
         (
             GameObjectRef gameObjectRef,
             [Description("Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below.")]

--- a/Assets/root/Server/Server/API/Tool/GameObject.Modify.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Modify.cs
@@ -17,7 +17,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         )]
         [Description(@"Modify GameObjects and/or attached component's field and properties.
 You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects.")]
-        public ValueTask<CallToolResponse> Modify
+        public ValueTask<CallToolResult> Modify
         (
             [Description(@"Json Object with required readonly 'instanceID' and 'type' fields.
 Each field and property requires to have 'type' and 'name' fields to identify the exact modification target.

--- a/Assets/root/Server/Server/API/Tool/GameObject.Modify.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.Modify.cs
@@ -1,39 +1,39 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model;
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model;
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_Modify",
-            Title = "Modify GameObjects in opened Prefab or in a Scene"
-        )]
-        [Description(@"Modify GameObjects and/or attached component's field and properties.
-You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects.")]
-        public ValueTask<CallToolResult> Modify
-        (
-            [Description(@"Json Object with required readonly 'instanceID' and 'type' fields.
-Each field and property requires to have 'type' and 'name' fields to identify the exact modification target.
-Follow the object schema to specify what to change, ignore values that should not be modified. Keep the original data structure.
-Any unknown or wrong located fields and properties will be ignored.
-Check the result of this command to see what was changed. The ignored fields and properties will be listed.")]
-            SerializedMemberList gameObjectDiffs,
-            GameObjectRefList gameObjectRefs
-        )
-        {
-            return ToolRouter.Call("GameObject_Modify", arguments =>
-            {
-                arguments[nameof(gameObjectDiffs)] = gameObjectDiffs ?? new();
-                arguments[nameof(gameObjectRefs)] = gameObjectRefs ?? new();
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_Modify",
+//             Title = "Modify GameObjects in opened Prefab or in a Scene"
+//         )]
+//         [Description(@"Modify GameObjects and/or attached component's field and properties.
+// You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects.")]
+//         public ValueTask<CallToolResult> Modify
+//         (
+//             [Description(@"Json Object with required readonly 'instanceID' and 'type' fields.
+// Each field and property requires to have 'type' and 'name' fields to identify the exact modification target.
+// Follow the object schema to specify what to change, ignore values that should not be modified. Keep the original data structure.
+// Any unknown or wrong located fields and properties will be ignored.
+// Check the result of this command to see what was changed. The ignored fields and properties will be listed.")]
+//             SerializedMemberList gameObjectDiffs,
+//             GameObjectRefList gameObjectRefs
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_Modify", arguments =>
+//             {
+//                 arguments[nameof(gameObjectDiffs)] = gameObjectDiffs ?? new();
+//                 arguments[nameof(gameObjectRefs)] = gameObjectRefs ?? new();
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.SetParent.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.SetParent.cs
@@ -1,35 +1,35 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model.Unity;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model.Unity;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_GameObject
-    {
-        [McpServerTool
-        (
-            Name = "GameObject_SetParent",
-            Title = "Set parent GameObject in opened Prefab or in a Scene"
-        )]
-        [Description(@"Set GameObjects in opened Prefab or in a Scene by 'instanceID' (int) array.")]
-        public ValueTask<CallToolResult> SetParent
-        (
-            GameObjectRefList gameObjectRefs,
-            GameObjectRef parentGameObjectRef,
-            [Description("A boolean flag indicating whether the GameObject's world position should remain unchanged when setting its parent.")]
-            bool worldPositionStays = true
-        )
-        {
-            return ToolRouter.Call("GameObject_SetParent", arguments =>
-            {
-                arguments[nameof(gameObjectRefs)] = gameObjectRefs ?? new();
-                arguments[nameof(parentGameObjectRef)] = parentGameObjectRef;
-                arguments[nameof(worldPositionStays)] = worldPositionStays;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_GameObject
+//     {
+//         [McpServerTool
+//         (
+//             Name = "GameObject_SetParent",
+//             Title = "Set parent GameObject in opened Prefab or in a Scene"
+//         )]
+//         [Description(@"Set GameObjects in opened Prefab or in a Scene by 'instanceID' (int) array.")]
+//         public ValueTask<CallToolResult> SetParent
+//         (
+//             GameObjectRefList gameObjectRefs,
+//             GameObjectRef parentGameObjectRef,
+//             [Description("A boolean flag indicating whether the GameObject's world position should remain unchanged when setting its parent.")]
+//             bool worldPositionStays = true
+//         )
+//         {
+//             return ToolRouter.Call("GameObject_SetParent", arguments =>
+//             {
+//                 arguments[nameof(gameObjectRefs)] = gameObjectRefs ?? new();
+//                 arguments[nameof(parentGameObjectRef)] = parentGameObjectRef;
+//                 arguments[nameof(worldPositionStays)] = worldPositionStays;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/GameObject.SetParent.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.SetParent.cs
@@ -15,7 +15,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Set parent GameObject in opened Prefab or in a Scene"
         )]
         [Description(@"Set GameObjects in opened Prefab or in a Scene by 'instanceID' (int) array.")]
-        public ValueTask<CallToolResponse> SetParent
+        public ValueTask<CallToolResult> SetParent
         (
             GameObjectRefList gameObjectRefs,
             GameObjectRef parentGameObjectRef,

--- a/Assets/root/Server/Server/API/Tool/GameObject.cs
+++ b/Assets/root/Server/Server/API/Tool/GameObject.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_GameObject
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_GameObject
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Reflection.MethodCall.cs
+++ b/Assets/root/Server/Server/API/Tool/Reflection.MethodCall.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
 It requires to receive proper method schema.
 Use 'Reflection_MethodFind' to find available method before using it.
 Receives input parameters and returns result.")]
-        public ValueTask<CallToolResponse> MethodCall
+        public ValueTask<CallToolResult> MethodCall
         (
             MethodPointerRef filter,
 

--- a/Assets/root/Server/Server/API/Tool/Reflection.MethodCall.cs
+++ b/Assets/root/Server/Server/API/Tool/Reflection.MethodCall.cs
@@ -1,91 +1,91 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.Collections.Generic;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Reflection_MethodCall",
-            Title = "Call method using C# reflection"
-        )]
-        [Description(@"Call C# method. Any method could be called, even private methods.
-It requires to receive proper method schema.
-Use 'Reflection_MethodFind' to find available method before using it.
-Receives input parameters and returns result.")]
-        public ValueTask<CallToolResult> MethodCall
-        (
-            MethodPointerRef filter,
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Reflection_MethodCall",
+//             Title = "Call method using C# reflection"
+//         )]
+//         [Description(@"Call C# method. Any method could be called, even private methods.
+// It requires to receive proper method schema.
+// Use 'Reflection_MethodFind' to find available method before using it.
+// Receives input parameters and returns result.")]
+//         public ValueTask<CallToolResult> MethodCall
+//         (
+//             MethodPointerRef filter,
 
-            [Description("Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false.")]
-            bool knownNamespace = false,
+//             [Description("Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false.")]
+//             bool knownNamespace = false,
 
-            [Description(@"Minimal match level for 'typeName'.
-0 - ignore 'filter.typeName',
-1 - contains ignoring case (default value),
-2 - contains case sensitive,
-3 - starts with ignoring case,
-4 - starts with case sensitive,
-5 - equals ignoring case,
-6 - equals case sensitive.")]
-            int typeNameMatchLevel = 1,
+//             [Description(@"Minimal match level for 'typeName'.
+// 0 - ignore 'filter.typeName',
+// 1 - contains ignoring case (default value),
+// 2 - contains case sensitive,
+// 3 - starts with ignoring case,
+// 4 - starts with case sensitive,
+// 5 - equals ignoring case,
+// 6 - equals case sensitive.")]
+//             int typeNameMatchLevel = 1,
 
-            [Description(@"Minimal match level for 'MethodName'.
-0 - ignore 'filter.MethodName',
-1 - contains ignoring case (default value),
-2 - contains case sensitive,
-3 - starts with ignoring case,
-4 - starts with case sensitive,
-5 - equals ignoring case,
-6 - equals case sensitive.")]
-            int methodNameMatchLevel = 1,
+//             [Description(@"Minimal match level for 'MethodName'.
+// 0 - ignore 'filter.MethodName',
+// 1 - contains ignoring case (default value),
+// 2 - contains case sensitive,
+// 3 - starts with ignoring case,
+// 4 - starts with case sensitive,
+// 5 - equals ignoring case,
+// 6 - equals case sensitive.")]
+//             int methodNameMatchLevel = 1,
 
-            [Description(@"Minimal match level for 'Parameters'.
-0 - ignore 'filter.Parameters',
-1 - parameters count is the same,
-2 - equals (default value).")]
-            int parametersMatchLevel = 2,
+//             [Description(@"Minimal match level for 'Parameters'.
+// 0 - ignore 'filter.Parameters',
+// 1 - parameters count is the same,
+// 2 - equals (default value).")]
+//             int parametersMatchLevel = 2,
 
-            [Description(@"Specify target object to call method on. Should be null if the method is static or if the is no specific target instance.
-New instance of the specified class will be created if the method is instance method and the targetObject is null.
-Required:
-- type - full type name of the object to call method on.
-- value - serialized object value. It will be deserialized to the specified type.")]
-            SerializedMember? targetObject = null,
+//             [Description(@"Specify target object to call method on. Should be null if the method is static or if the is no specific target instance.
+// New instance of the specified class will be created if the method is instance method and the targetObject is null.
+// Required:
+// - type - full type name of the object to call method on.
+// - value - serialized object value. It will be deserialized to the specified type.")]
+//             SerializedMember? targetObject = null,
 
-            [Description(@"Method input parameters. Per each parameter specify:
-- type - full type name of the object to call method on.
-- name - parameter name.
-- value - serialized object value. It will be deserialized to the specified type.")]
-            List<SerializedMember>? inputParameters = null,
+//             [Description(@"Method input parameters. Per each parameter specify:
+// - type - full type name of the object to call method on.
+// - name - parameter name.
+// - value - serialized object value. It will be deserialized to the specified type.")]
+//             List<SerializedMember>? inputParameters = null,
 
-            [Description(@"Set to true if the method should be executed in the main thread. Otherwise, set to false.")]
-            bool executeInMainThread = true
-        )
-        {
-            return ToolRouter.Call("Reflection_MethodCall", arguments =>
-            {
-                arguments[nameof(filter)] = filter;
-                arguments[nameof(knownNamespace)] = knownNamespace;
-                arguments[nameof(typeNameMatchLevel)] = typeNameMatchLevel;
-                arguments[nameof(methodNameMatchLevel)] = methodNameMatchLevel;
-                arguments[nameof(parametersMatchLevel)] = parametersMatchLevel;
+//             [Description(@"Set to true if the method should be executed in the main thread. Otherwise, set to false.")]
+//             bool executeInMainThread = true
+//         )
+//         {
+//             return ToolRouter.Call("Reflection_MethodCall", arguments =>
+//             {
+//                 arguments[nameof(filter)] = filter;
+//                 arguments[nameof(knownNamespace)] = knownNamespace;
+//                 arguments[nameof(typeNameMatchLevel)] = typeNameMatchLevel;
+//                 arguments[nameof(methodNameMatchLevel)] = methodNameMatchLevel;
+//                 arguments[nameof(parametersMatchLevel)] = parametersMatchLevel;
 
-                if (targetObject != null)
-                    arguments[nameof(targetObject)] = targetObject;
+//                 if (targetObject != null)
+//                     arguments[nameof(targetObject)] = targetObject;
 
-                if (inputParameters != null)
-                    arguments[nameof(inputParameters)] = inputParameters;
+//                 if (inputParameters != null)
+//                     arguments[nameof(inputParameters)] = inputParameters;
 
-                arguments[nameof(executeInMainThread)] = executeInMainThread;
-            });
-        }
-    }
-}
-#endif
+//                 arguments[nameof(executeInMainThread)] = executeInMainThread;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Reflection.MethodFind.cs
+++ b/Assets/root/Server/Server/API/Tool/Reflection.MethodFind.cs
@@ -1,65 +1,65 @@
-#if !UNITY_5_3_OR_NEWER
-using com.IvanMurzak.ReflectorNet.Model;
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using com.IvanMurzak.ReflectorNet.Model;
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Reflection_MethodFind",
-            Title = "Find method using reflection"
-        )]
-        [Description(@"Find method in the project using C# Reflection.
-It looks for all assemblies in the project and finds method by its name, class name and parameters.
-Even private methods are available. Use 'Reflection_MethodCall' to call the method after finding it.")]
-        public ValueTask<CallToolResult> MethodFind
-        (
-            MethodPointerRef filter,
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Reflection_MethodFind",
+//             Title = "Find method using reflection"
+//         )]
+//         [Description(@"Find method in the project using C# Reflection.
+// It looks for all assemblies in the project and finds method by its name, class name and parameters.
+// Even private methods are available. Use 'Reflection_MethodCall' to call the method after finding it.")]
+//         public ValueTask<CallToolResult> MethodFind
+//         (
+//             MethodPointerRef filter,
 
-            [Description("Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false.")]
-            bool knownNamespace = false,
+//             [Description("Set to true if 'Namespace' is known and full namespace name is specified in the 'filter.Namespace' property. Otherwise, set to false.")]
+//             bool knownNamespace = false,
 
-            [Description(@"Minimal match level for 'typeName'.
-0 - ignore 'filter.typeName',
-1 - contains ignoring case (default value),
-2 - contains case sensitive,
-3 - starts with ignoring case,
-4 - starts with case sensitive,
-5 - equals ignoring case,
-6 - equals case sensitive.")]
-            int typeNameMatchLevel = 1,
+//             [Description(@"Minimal match level for 'typeName'.
+// 0 - ignore 'filter.typeName',
+// 1 - contains ignoring case (default value),
+// 2 - contains case sensitive,
+// 3 - starts with ignoring case,
+// 4 - starts with case sensitive,
+// 5 - equals ignoring case,
+// 6 - equals case sensitive.")]
+//             int typeNameMatchLevel = 1,
 
-            [Description(@"Minimal match level for 'MethodName'.
-0 - ignore 'filter.MethodName',
-1 - contains ignoring case (default value),
-2 - contains case sensitive,
-3 - starts with ignoring case,
-4 - starts with case sensitive,
-5 - equals ignoring case,
-6 - equals case sensitive.")]
-            int methodNameMatchLevel = 1,
+//             [Description(@"Minimal match level for 'MethodName'.
+// 0 - ignore 'filter.MethodName',
+// 1 - contains ignoring case (default value),
+// 2 - contains case sensitive,
+// 3 - starts with ignoring case,
+// 4 - starts with case sensitive,
+// 5 - equals ignoring case,
+// 6 - equals case sensitive.")]
+//             int methodNameMatchLevel = 1,
 
-            [Description(@"Minimal match level for 'Parameters'.
-0 - ignore 'filter.Parameters' (default value),
-1 - parameters count is the same,
-2 - equals.")]
-            int parametersMatchLevel = 0
-        )
-        {
-            return ToolRouter.Call("Reflection_MethodFind", arguments =>
-            {
-                arguments[nameof(filter)] = filter;
-                arguments[nameof(knownNamespace)] = knownNamespace;
-                arguments[nameof(typeNameMatchLevel)] = typeNameMatchLevel;
-                arguments[nameof(methodNameMatchLevel)] = methodNameMatchLevel;
-                arguments[nameof(parametersMatchLevel)] = parametersMatchLevel;
-            });
-        }
-    }
-}
-#endif
+//             [Description(@"Minimal match level for 'Parameters'.
+// 0 - ignore 'filter.Parameters' (default value),
+// 1 - parameters count is the same,
+// 2 - equals.")]
+//             int parametersMatchLevel = 0
+//         )
+//         {
+//             return ToolRouter.Call("Reflection_MethodFind", arguments =>
+//             {
+//                 arguments[nameof(filter)] = filter;
+//                 arguments[nameof(knownNamespace)] = knownNamespace;
+//                 arguments[nameof(typeNameMatchLevel)] = typeNameMatchLevel;
+//                 arguments[nameof(methodNameMatchLevel)] = methodNameMatchLevel;
+//                 arguments[nameof(parametersMatchLevel)] = parametersMatchLevel;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Reflection.MethodFind.cs
+++ b/Assets/root/Server/Server/API/Tool/Reflection.MethodFind.cs
@@ -17,7 +17,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
         [Description(@"Find method in the project using C# Reflection.
 It looks for all assemblies in the project and finds method by its name, class name and parameters.
 Even private methods are available. Use 'Reflection_MethodCall' to call the method after finding it.")]
-        public ValueTask<CallToolResponse> MethodFind
+        public ValueTask<CallToolResult> MethodFind
         (
             MethodPointerRef filter,
 

--- a/Assets/root/Server/Server/API/Tool/Reflection.cs
+++ b/Assets/root/Server/Server/API/Tool/Reflection.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Reflection
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Reflection
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Scene.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Create.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Scene_Create",
-            Title = "Create new scene"
-        )]
-        [Description("Create new scene in the project assets.")]
-        public ValueTask<CallToolResult> Create
-        (
-            [Description("Path to the scene file.")]
-            string path
-        )
-        {
-            return ToolRouter.Call("Scene_Create", arguments =>
-            {
-                arguments[nameof(path)] = path;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Scene_Create",
+//             Title = "Create new scene"
+//         )]
+//         [Description("Create new scene in the project assets.")]
+//         public ValueTask<CallToolResult> Create
+//         (
+//             [Description("Path to the scene file.")]
+//             string path
+//         )
+//         {
+//             return ToolRouter.Call("Scene_Create", arguments =>
+//             {
+//                 arguments[nameof(path)] = path;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Scene.Create.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Create.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Create new scene"
         )]
         [Description("Create new scene in the project assets.")]
-        public ValueTask<CallToolResponse> Create
+        public ValueTask<CallToolResult> Create
         (
             [Description("Path to the scene file.")]
             string path

--- a/Assets/root/Server/Server/API/Tool/Scene.GetHierarchy.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.GetHierarchy.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Get Scene Hierarchy"
         )]
         [Description("This tool retrieves the list of root GameObjects in the specified scene.")]
-        public ValueTask<CallToolResponse> GetHierarchy
+        public ValueTask<CallToolResult> GetHierarchy
         (
             [Description("Determines the depth of the hierarchy to include.")]
             int includeChildrenDepth = 3,

--- a/Assets/root/Server/Server/API/Tool/Scene.GetHierarchy.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.GetHierarchy.cs
@@ -1,35 +1,35 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Scene_GetHierarchy",
-            Title = "Get Scene Hierarchy"
-        )]
-        [Description("This tool retrieves the list of root GameObjects in the specified scene.")]
-        public ValueTask<CallToolResult> GetHierarchy
-        (
-            [Description("Determines the depth of the hierarchy to include.")]
-            int includeChildrenDepth = 3,
-            [Description("Name of the loaded scene. If empty string, the active scene will be used.")]
-            string? loadedSceneName = null
-        )
-        {
-            return ToolRouter.Call("Scene_GetHierarchy", arguments =>
-            {
-                arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Scene_GetHierarchy",
+//             Title = "Get Scene Hierarchy"
+//         )]
+//         [Description("This tool retrieves the list of root GameObjects in the specified scene.")]
+//         public ValueTask<CallToolResult> GetHierarchy
+//         (
+//             [Description("Determines the depth of the hierarchy to include.")]
+//             int includeChildrenDepth = 3,
+//             [Description("Name of the loaded scene. If empty string, the active scene will be used.")]
+//             string? loadedSceneName = null
+//         )
+//         {
+//             return ToolRouter.Call("Scene_GetHierarchy", arguments =>
+//             {
+//                 arguments[nameof(includeChildrenDepth)] = includeChildrenDepth;
 
-                if (loadedSceneName != null && loadedSceneName.Length > 0)
-                    arguments[nameof(loadedSceneName)] = loadedSceneName;
-            });
-        }
-    }
-}
-#endif
+//                 if (loadedSceneName != null && loadedSceneName.Length > 0)
+//                     arguments[nameof(loadedSceneName)] = loadedSceneName;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Scene.GetLoaded.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.GetLoaded.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Get list of currently loaded scenes"
         )]
         [Description("Returns the list of currently loaded scenes.")]
-        public ValueTask<CallToolResponse> GetLoaded()
+        public ValueTask<CallToolResult> GetLoaded()
         {
             return ToolRouter.Call("Scene_GetLoaded");
         }

--- a/Assets/root/Server/Server/API/Tool/Scene.GetLoaded.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.GetLoaded.cs
@@ -1,23 +1,23 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Scene_GetLoaded",
-            Title = "Get list of currently loaded scenes"
-        )]
-        [Description("Returns the list of currently loaded scenes.")]
-        public ValueTask<CallToolResult> GetLoaded()
-        {
-            return ToolRouter.Call("Scene_GetLoaded");
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Scene_GetLoaded",
+//             Title = "Get list of currently loaded scenes"
+//         )]
+//         [Description("Returns the list of currently loaded scenes.")]
+//         public ValueTask<CallToolResult> GetLoaded()
+//         {
+//             return ToolRouter.Call("Scene_GetLoaded");
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Scene.Load.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Load.cs
@@ -1,33 +1,33 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Scene_Load",
-            Title = "Load scene"
-        )]
-        [Description("Load scene from the project assets.")]
-        public ValueTask<CallToolResult> Load
-        (
-            [Description("Path to the scene file.")]
-            string path,
-            [Description("Load scene mode. 0 - Single, 1 - Additive.")]
-            int loadSceneMode = 0
-        )
-        {
-            return ToolRouter.Call("Scene_Load", arguments =>
-            {
-                arguments[nameof(path)] = path;
-                arguments[nameof(loadSceneMode)] = loadSceneMode;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Scene_Load",
+//             Title = "Load scene"
+//         )]
+//         [Description("Load scene from the project assets.")]
+//         public ValueTask<CallToolResult> Load
+//         (
+//             [Description("Path to the scene file.")]
+//             string path,
+//             [Description("Load scene mode. 0 - Single, 1 - Additive.")]
+//             int loadSceneMode = 0
+//         )
+//         {
+//             return ToolRouter.Call("Scene_Load", arguments =>
+//             {
+//                 arguments[nameof(path)] = path;
+//                 arguments[nameof(loadSceneMode)] = loadSceneMode;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Scene.Load.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Load.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Load scene"
         )]
         [Description("Load scene from the project assets.")]
-        public ValueTask<CallToolResponse> Load
+        public ValueTask<CallToolResult> Load
         (
             [Description("Path to the scene file.")]
             string path,

--- a/Assets/root/Server/Server/API/Tool/Scene.Save.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Save.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Save scene"
         )]
         [Description("Save scene to asset file with specified path.")]
-        public ValueTask<CallToolResponse> Save
+        public ValueTask<CallToolResult> Save
         (
             [Description("Path to the scene file.")]
             string path,

--- a/Assets/root/Server/Server/API/Tool/Scene.Save.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Save.cs
@@ -1,35 +1,35 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Scene_Save",
-            Title = "Save scene"
-        )]
-        [Description("Save scene to asset file with specified path.")]
-        public ValueTask<CallToolResult> Save
-        (
-            [Description("Path to the scene file.")]
-            string path,
-            [Description("Name of the opened scene. Could be empty if need to save current active scene. It is helpful when multiple scenes are opened.")]
-            string? targetSceneName = null
-        )
-        {
-            return ToolRouter.Call("Scene_Save", arguments =>
-            {
-                arguments[nameof(path)] = path;
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Scene_Save",
+//             Title = "Save scene"
+//         )]
+//         [Description("Save scene to asset file with specified path.")]
+//         public ValueTask<CallToolResult> Save
+//         (
+//             [Description("Path to the scene file.")]
+//             string path,
+//             [Description("Name of the opened scene. Could be empty if need to save current active scene. It is helpful when multiple scenes are opened.")]
+//             string? targetSceneName = null
+//         )
+//         {
+//             return ToolRouter.Call("Scene_Save", arguments =>
+//             {
+//                 arguments[nameof(path)] = path;
 
-                if (!string.IsNullOrEmpty(targetSceneName))
-                    arguments[nameof(targetSceneName)] = targetSceneName;
-            });
-        }
-    }
-}
-#endif
+//                 if (!string.IsNullOrEmpty(targetSceneName))
+//                     arguments[nameof(targetSceneName)] = targetSceneName;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Scene.Unload.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Unload.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Unload scene"
         )]
         [Description("Destroys all GameObjects associated with the given Scene and removes the Scene from the SceneManager.")]
-        public ValueTask<CallToolResponse> Save
+        public ValueTask<CallToolResult> Save
         (
             [Description("Name of the loaded scene.")]
             string name

--- a/Assets/root/Server/Server/API/Tool/Scene.Unload.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.Unload.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Scene
-    {
-        [McpServerTool
-        (
-            Name = "Scene_Unload",
-            Title = "Unload scene"
-        )]
-        [Description("Destroys all GameObjects associated with the given Scene and removes the Scene from the SceneManager.")]
-        public ValueTask<CallToolResult> Save
-        (
-            [Description("Name of the loaded scene.")]
-            string name
-        )
-        {
-            return ToolRouter.Call("Scene_Unload", arguments =>
-            {
-                arguments[nameof(name)] = name;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Scene
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Scene_Unload",
+//             Title = "Unload scene"
+//         )]
+//         [Description("Destroys all GameObjects associated with the given Scene and removes the Scene from the SceneManager.")]
+//         public ValueTask<CallToolResult> Save
+//         (
+//             [Description("Name of the loaded scene.")]
+//             string name
+//         )
+//         {
+//             return ToolRouter.Call("Scene_Unload", arguments =>
+//             {
+//                 arguments[nameof(name)] = name;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Scene.cs
+++ b/Assets/root/Server/Server/API/Tool/Scene.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Scene
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Scene
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Script.Delete.cs
+++ b/Assets/root/Server/Server/API/Tool/Script.Delete.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Delete Script content"
         )]
         [Description("Delete the script file. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResponse> Delete
+        public ValueTask<CallToolResult> Delete
         (
             [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
             string filePath

--- a/Assets/root/Server/Server/API/Tool/Script.Delete.cs
+++ b/Assets/root/Server/Server/API/Tool/Script.Delete.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Script
-    {
-        [McpServerTool
-        (
-            Name = "Script_Delete",
-            Title = "Delete Script content"
-        )]
-        [Description("Delete the script file. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResult> Delete
-        (
-            [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
-            string filePath
-        )
-        {
-            return ToolRouter.Call("Script_Delete", arguments =>
-            {
-                arguments[nameof(filePath)] = filePath;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Script
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Script_Delete",
+//             Title = "Delete Script content"
+//         )]
+//         [Description("Delete the script file. Does AssetDatabase.Refresh() at the end.")]
+//         public ValueTask<CallToolResult> Delete
+//         (
+//             [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
+//             string filePath
+//         )
+//         {
+//             return ToolRouter.Call("Script_Delete", arguments =>
+//             {
+//                 arguments[nameof(filePath)] = filePath;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Script.Read.cs
+++ b/Assets/root/Server/Server/API/Tool/Script.Read.cs
@@ -1,30 +1,30 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Script
-    {
-        [McpServerTool
-        (
-            Name = "Script_Read",
-            Title = "Read Script content"
-        )]
-        [Description("Reads the content of a script file and returns it as a string.")]
-        public ValueTask<CallToolResult> Read
-        (
-            [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
-            string filePath
-        )
-        {
-            return ToolRouter.Call("Script_Read", arguments =>
-            {
-                arguments[nameof(filePath)] = filePath;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Script
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Script_Read",
+//             Title = "Read Script content"
+//         )]
+//         [Description("Reads the content of a script file and returns it as a string.")]
+//         public ValueTask<CallToolResult> Read
+//         (
+//             [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
+//             string filePath
+//         )
+//         {
+//             return ToolRouter.Call("Script_Read", arguments =>
+//             {
+//                 arguments[nameof(filePath)] = filePath;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Script.Read.cs
+++ b/Assets/root/Server/Server/API/Tool/Script.Read.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Read Script content"
         )]
         [Description("Reads the content of a script file and returns it as a string.")]
-        public ValueTask<CallToolResponse> Read
+        public ValueTask<CallToolResult> Read
         (
             [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
             string filePath

--- a/Assets/root/Server/Server/API/Tool/Script.UpdateOrCreate.cs
+++ b/Assets/root/Server/Server/API/Tool/Script.UpdateOrCreate.cs
@@ -1,33 +1,33 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Protocol;
-using ModelContextProtocol.Server;
-using System.ComponentModel;
-using System.Threading.Tasks;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Protocol;
+// using ModelContextProtocol.Server;
+// using System.ComponentModel;
+// using System.Threading.Tasks;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    public partial class Tool_Script
-    {
-        [McpServerTool
-        (
-            Name = "Script_CreateOrUpdate",
-            Title = "Create or Update Script"
-        )]
-        [Description("Creates or updates a script file with the provided content. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResult> UpdateOrCreate
-        (
-            [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
-            string filePath,
-            [Description("C# code - content of the file.")]
-            string content
-        )
-        {
-            return ToolRouter.Call("Script_CreateOrUpdate", arguments =>
-            {
-                arguments[nameof(filePath)] = filePath;
-                arguments[nameof(content)] = content;
-            });
-        }
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     public partial class Tool_Script
+//     {
+//         [McpServerTool
+//         (
+//             Name = "Script_CreateOrUpdate",
+//             Title = "Create or Update Script"
+//         )]
+//         [Description("Creates or updates a script file with the provided content. Does AssetDatabase.Refresh() at the end.")]
+//         public ValueTask<CallToolResult> UpdateOrCreate
+//         (
+//             [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
+//             string filePath,
+//             [Description("C# code - content of the file.")]
+//             string content
+//         )
+//         {
+//             return ToolRouter.Call("Script_CreateOrUpdate", arguments =>
+//             {
+//                 arguments[nameof(filePath)] = filePath;
+//                 arguments[nameof(content)] = content;
+//             });
+//         }
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/API/Tool/Script.UpdateOrCreate.cs
+++ b/Assets/root/Server/Server/API/Tool/Script.UpdateOrCreate.cs
@@ -14,7 +14,7 @@ namespace com.IvanMurzak.Unity.MCP.Server.API
             Title = "Create or Update Script"
         )]
         [Description("Creates or updates a script file with the provided content. Does AssetDatabase.Refresh() at the end.")]
-        public ValueTask<CallToolResponse> UpdateOrCreate
+        public ValueTask<CallToolResult> UpdateOrCreate
         (
             [Description("The path to the file. Sample: \"Assets/Scripts/MyScript.cs\".")]
             string filePath,

--- a/Assets/root/Server/Server/API/Tool/Script.cs
+++ b/Assets/root/Server/Server/API/Tool/Script.cs
@@ -1,11 +1,11 @@
-#if !UNITY_5_3_OR_NEWER
-using ModelContextProtocol.Server;
+// #if !UNITY_5_3_OR_NEWER
+// using ModelContextProtocol.Server;
 
-namespace com.IvanMurzak.Unity.MCP.Server.API
-{
-    [McpServerToolType]
-    public partial class Tool_Script
-    {
-    }
-}
-#endif
+// namespace com.IvanMurzak.Unity.MCP.Server.API
+// {
+//     [McpServerToolType]
+//     public partial class Tool_Script
+//     {
+//     }
+// }
+// #endif

--- a/Assets/root/Server/Server/Client/ClientUtils.cs
+++ b/Assets/root/Server/Server/Client/ClientUtils.cs
@@ -125,7 +125,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
 
                     if (client == null)
                     {
-                        logger.LogWarning($"No connected clients. Retrying [{retryCount}/{maxRetries}]...");
+                        logger.LogWarning("No connected clients. Retrying [{0}/{1}]...", retryCount, maxRetries);
                         await Task.Delay(retryDelayMs, cancellationToken); // Wait before retrying
                         continue;
                     }

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
@@ -51,8 +51,8 @@ namespace com.IvanMurzak.Unity.MCP.Server
                 // logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
                 logger.Trace("ListAll, result");
 
-            // Clear current Tools
-            mcpServerService.McpServer.ServerOptions.Capabilities?.Tools?.ToolCollection?.Clear();
+            // TODO: Replace existed tools, but not clear them all.
+            // mcpServerService.McpServer.ServerOptions.Capabilities?.Tools?.ToolCollection?.Clear();
 
             return result;
         }

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
@@ -48,11 +48,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
             };
 
             if (logger.IsTraceEnabled)
-                // logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
-                logger.Trace("ListAll, result");
-
-            // TODO: Replace existed tools, but not clear them all.
-            // mcpServerService.McpServer.ServerOptions.Capabilities?.Tools?.ToolCollection?.Clear();
+                logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
 
             return result;
         }

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
@@ -47,7 +47,8 @@ namespace com.IvanMurzak.Unity.MCP.Server
                     .ToList()
             };
 
-            logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
+            if (logger.IsTraceEnabled)
+                logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
 
             // Clear current Tools
             mcpServerService.McpServer.ServerOptions.Capabilities?.Tools?.ToolCollection?.Clear();

--- a/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Assets/root/Server/Server/Routing/Tool/ToolRouter.ListAll.cs
@@ -48,7 +48,8 @@ namespace com.IvanMurzak.Unity.MCP.Server
             };
 
             if (logger.IsTraceEnabled)
-                logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
+                // logger.Trace("ListAll, result: {0}", JsonUtils.Serialize(result));
+                logger.Trace("ListAll, result");
 
             // Clear current Tools
             mcpServerService.McpServer.ServerOptions.Capabilities?.Tools?.ToolCollection?.Clear();

--- a/Assets/root/Server/Server/Utils/ToolExtensions.cs
+++ b/Assets/root/Server/Server/Utils/ToolExtensions.cs
@@ -11,17 +11,16 @@ namespace com.IvanMurzak.Unity.MCP.Server
 
     public static class ToolsExtensions
     {
-        public static CallToolResponse SetError(this CallToolResponse target, string message)
+        public static CallToolResult SetError(this CallToolResult target, string message)
         {
             if (target == null)
                 throw new ArgumentNullException(nameof(target));
 
             target.IsError = true;
-            target.Content ??= new List<Content>(1);
-            target.Content.Add(new Content()
+            target.Content ??= new List<ContentBlock>(1);
+            target.Content.Add(new TextContentBlock()
             {
                 Type = "text",
-                MimeType = Consts.MimeType.TextPlain,
                 Text = message
             });
 
@@ -49,7 +48,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
             },
         };
 
-        public static CallToolResponse ToCallToolResponse(this IResponseCallTool response) => new CallToolResponse()
+        public static CallToolResult ToCallToolResult(this IResponseCallTool response) => new CallToolResult()
         {
             IsError = response.IsError,
             Content = response.Content
@@ -57,12 +56,12 @@ namespace com.IvanMurzak.Unity.MCP.Server
                 .ToList()
         };
 
-        public static Content ToContent(this ResponseCallToolContent response) => new Content()
+        public static ContentBlock ToContent(this ResponseCallToolContent response) => new TextContentBlock()
         {
             Type = response.Type,
-            MimeType = response.MimeType,
-            Text = response.Text,
-            Data = response.Data
+            // MimeType = response.MimeType,
+            Text = response.Text ?? string.Empty
+            // Data = response.Data
         };
     }
 }

--- a/Assets/root/Server/Server/Utils/ToolExtensions.cs
+++ b/Assets/root/Server/Server/Utils/ToolExtensions.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using com.IvanMurzak.Unity.MCP.Common;
 using com.IvanMurzak.ReflectorNet.Model;
 using ModelContextProtocol.Protocol;
 
@@ -18,11 +17,17 @@ namespace com.IvanMurzak.Unity.MCP.Server
 
             target.IsError = true;
             target.Content ??= new List<ContentBlock>(1);
-            target.Content.Add(new TextContentBlock()
+
+            var content = new TextContentBlock()
             {
                 Type = "text",
                 Text = message
-            });
+            };
+
+            if (target.Content.Count == 0)
+                target.Content.Add(content);
+            else
+                target.Content[0] = content;
 
             return target;
         }
@@ -52,16 +57,14 @@ namespace com.IvanMurzak.Unity.MCP.Server
         {
             IsError = response.IsError,
             Content = response.Content
-                .Select(x => x.ToContent())
+                .Select(x => x.ToTextContent())
                 .ToList()
         };
 
-        public static ContentBlock ToContent(this ResponseCallToolContent response) => new TextContentBlock()
+        public static ContentBlock ToTextContent(this ResponseCallToolContent response) => new TextContentBlock()
         {
             Type = response.Type,
-            // MimeType = response.MimeType,
             Text = response.Text ?? string.Empty
-            // Data = response.Data
         };
     }
 }

--- a/Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj
+++ b/Assets/root/Server/com.IvanMurzak.Unity.MCP.Server.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="0.1.10" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.3" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.1" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.4.0" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>


### PR DESCRIPTION
This pull request refactors several Unity API tools by commenting out their code and replacing `CallToolResponse` with `CallToolResult` in method signatures. The changes primarily involve deprecating or isolating existing functionality while maintaining the structure for potential future use.

Refactoring of Unity API tools:

* **General refactoring across files**: Commented out the code for various tools, including `Assets.Copy`, `Assets.CreateFolders`, `Assets.Delete`, `Assets.Find`, `Assets.Material.Create`, `Assets.Modify`, `Assets.Move`, and `Assets.Prefab.Close`. This isolates the tools without removing them entirely, preserving their structure for potential future updates. [[1]](diffhunk://#diff-edb7c69765cb79f077591e947c069a1aeaa03486ab0b7c0466c0eb24a971ae6aL1-R33) [[2]](diffhunk://#diff-f5209a1b00ea9e1f5cf99de6e584dc1b8fb3210c24a7de8d28ec3339c4fe5b21L1-R31) [[3]](diffhunk://#diff-57d8a26da11889d76f7765aff9b5da603f0686cd59d5c9eb430ce8526070d2d9L1-R30) [[4]](diffhunk://#diff-2eceee8a1f98858f22a138a61e24bdf1eaf6d3e7b220bca69c3f41ea8f74b91eL1-R66) [[5]](diffhunk://#diff-a1a0f5de9de16a24c8f61ca401055f6499acc131828c1beb8f7279a062c60046L1-R33) [[6]](diffhunk://#diff-da53ffdfc4110fd2955bb26874244ec66baf15a0164a52d5bd86da09411a02a7L1-R39) [[7]](diffhunk://#diff-c5e1751bae22c89f1d11d148da0e58c2f1a0009f966fddce4e6ba5fc00a34526L1-R33) [[8]](diffhunk://#diff-87d5857fd5fc778cb538d8667c2598f603fd6985406f4275ebc6016bf4e3a30aL1-R30)

* **Method signature update**: Replaced `CallToolResponse` with `CallToolResult` in the return type of methods across the tools, ensuring consistency with updated naming conventions or functionality. [[1]](diffhunk://#diff-edb7c69765cb79f077591e947c069a1aeaa03486ab0b7c0466c0eb24a971ae6aL1-R33) [[2]](diffhunk://#diff-f5209a1b00ea9e1f5cf99de6e584dc1b8fb3210c24a7de8d28ec3339c4fe5b21L1-R31) [[3]](diffhunk://#diff-57d8a26da11889d76f7765aff9b5da603f0686cd59d5c9eb430ce8526070d2d9L1-R30) [[4]](diffhunk://#diff-2eceee8a1f98858f22a138a61e24bdf1eaf6d3e7b220bca69c3f41ea8f74b91eL1-R66) [[5]](diffhunk://#diff-a1a0f5de9de16a24c8f61ca401055f6499acc131828c1beb8f7279a062c60046L1-R33) [[6]](diffhunk://#diff-da53ffdfc4110fd2955bb26874244ec66baf15a0164a52d5bd86da09411a02a7L1-R39) [[7]](diffhunk://#diff-c5e1751bae22c89f1d11d148da0e58c2f1a0009f966fddce4e6ba5fc00a34526L1-R33) [[8]](diffhunk://#diff-87d5857fd5fc778cb538d8667c2598f603fd6985406f4275ebc6016bf4e3a30aL1-R30)

Deprecation of specific tools:

* [`Assets.Material.cs`](diffhunk://#diff-1a5051495f378f2af25a90fe2b67d5b56afd32a6be2c77e7454d2b4564a8ad20L1-R11): Commented out the entire class definition for `Tool_Assets_Material`, effectively deprecating this tool while retaining its structure for reference.