### PR TITLE
fix: Configuration with missed folder

### DIFF
--- a/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.ClientConfigure.cs
+++ b/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.ClientConfigure.cs
@@ -163,7 +163,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
             var targetPort = McpPluginUnity.Port.ToString();
             var targetTimeout = McpPluginUnity.TimeoutMs.ToString();
-            
+
             var foundPort = false;
             var foundTimeout = false;
 
@@ -171,7 +171,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             for (int i = 0; i < args.Count; i++)
             {
                 var arg = args[i]?.GetValue<string>();
-                if (string.IsNullOrEmpty(arg)) 
+                if (string.IsNullOrEmpty(arg))
                     continue;
 
                 // Check positional format
@@ -179,7 +179,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                     foundPort = true;
                 else if (i == 1 && arg == targetTimeout)
                     foundTimeout = true;
-                
+
                 // Check named format
                 else if (arg.StartsWith("--port=") && arg.Substring(7) == targetPort)
                     foundPort = true;
@@ -199,6 +199,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             {
                 if (!File.Exists(configPath))
                 {
+                    // Create all necessary directories
+                    Directory.CreateDirectory(Path.GetDirectoryName(configPath));
+
                     // Create the file if it doesn't exist
                     File.WriteAllText(configPath, Startup.RawJsonConfiguration(McpPluginUnity.Port, bodyName, McpPluginUnity.TimeoutMs));
                     return true;

--- a/Assets/root/package.json
+++ b/Assets/root/package.json
@@ -11,7 +11,7 @@
         "MCP",
         "Unity MCP"
     ],
-    "version": "0.13.0",
+    "version": "0.13.1",
     "unity": "2022.3",
     "description": "Bridge between LLM and Unity. It expose Unity API to LLM and allows LLM to control Unity. It is based on Model Context Protocol (MCP) and uses SignalR for communication.",
     "dependencies": {


### PR DESCRIPTION
This pull request introduces a minor version bump and a small but important fix to the MCP client configuration process. The most significant change ensures that all necessary directories are created before attempting to write a configuration file, improving robustness when the configuration path's directories do not exist.

Improvements to configuration file handling:

* Updated `ConfigureMcpClient` in `MainWindowEditor.ClientConfigure.cs` to create all necessary directories before writing the configuration file, preventing potential errors when the target directory does not exist.

Version update:

* Bumped the package version in `package.json` from `0.13.0` to `0.13.1` to reflect the new change.