### PR TITLE
fix: Material population improvements

### DIFF
--- a/Assets/root/Runtime/ReflectionConverters/RS_UnityEngineMaterial.cs
+++ b/Assets/root/Runtime/ReflectionConverters/RS_UnityEngineMaterial.cs
@@ -123,7 +123,7 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Convertor
                     obj = null;
                     return true;
                 }
-                if (material.GetInstanceID() == unityObject?.GetInstanceID())
+                if (material.GetInstanceID() == unityObject.GetInstanceID())
                 {
                     // Recognized as a command to update material
                     return base.TryPopulate(reflector, ref obj, data, fallbackType, depth, stringBuilder, flags, logger);


### PR DESCRIPTION
This pull request updates the material deserialization logic in the `RS_UnityEngineMaterial` reflection converter to improve how Unity material references are resolved and handled. The main focus is on using object references directly rather than relying on instance IDs, which increases robustness and clarity.

Improvements to material deserialization logic:

* Changed the deserialization process to resolve Unity object references using `ToObjectRef` and `FindObject`, instead of relying on instance IDs, making material reference handling more robust.
* Cleaned up unreachable code and improved control flow for the material removal/update logic.…re effectively