### PR TITLE
fix: MCP server unpack

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.Server.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.Server.cs
@@ -49,14 +49,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                     : string.Empty);
 
             // Full path to the server executable
+            // Sample (mac linux): ../Library/mcp-server
+            // Sample   (windows): ../Library/mcp-server
+            public static string ExecutableFolderRootPath
+                => Path.GetFullPath(
+                    Path.Combine(
+                        Application.dataPath,
+                        "../Library",
+                        "mcp-server"
+                    )
+                );
+
+            // Full path to the server executable
             // Sample (mac linux): ../Library/mcp-server/osx-x64
             // Sample   (windows): ../Library/mcp-server/win-x64
             public static string ExecutableFolderPath
                 => Path.GetFullPath(
                     Path.Combine(
-                        Application.dataPath,
-                        "../Library",
-                        "mcp-server",
+                        ExecutableFolderRootPath,
                         PlatformName
                     )
                 );
@@ -119,11 +129,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
             public static Task<bool> DownloadServerBinaryIfNeeded()
             {
-                // if (Application.isBatchMode)
-                // {
-                //     // Ignore in batch mode
-                //     return Task.FromResult(false);
-                // }
                 if (IsCi())
                 {
                     // Ignore in CI environment
@@ -161,11 +166,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
                     // Unpack zip archive
                     Debug.Log($"Unpacking Unity-MCP-Server binary to: <color=yellow>{ExecutableFolderPath}</color>");
-                    ZipFile.ExtractToDirectory(archiveFilePath, ExecutableFolderPath, overwriteFiles: true);
+                    ZipFile.ExtractToDirectory(archiveFilePath, ExecutableFolderRootPath, overwriteFiles: true);
 
                     if (!File.Exists(ExecutableFullPath))
                     {
-                        Debug.LogError($"Failed to unpack server binary to: {ExecutableFullPath}");
+                        Debug.LogError($"Failed to unpack server binary to: {ExecutableFolderRootPath}");
+                        Debug.LogError($"Binary file not found at: {ExecutableFullPath}");
                         return false;
                     }
 

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.cs
@@ -8,7 +8,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
     [InitializeOnLoad]
     public static partial class Startup
     {
-        public const string Version = "0.14.0";
+        public const string Version = "0.14.1";
 
         static Startup()
         {

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Project.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Project.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0718c9cae796e984f99dd93c8251d050
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/GameObject/TestToolGameObject.ModifyComponent.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/GameObject/TestToolGameObject.ModifyComponent.cs
@@ -458,8 +458,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         [UnityTest]
         public IEnumerator SetMaterial()
         {
-            var assetPath = "Assets/Materials/TestMaterial.mat";
+            var folder = "Assets/TestMaterials";
+            var assetPath = $"{folder}/TestMaterial.mat";
             var material = new Material(Shader.Find("Standard"));
+
+            if (!AssetDatabase.IsValidFolder(folder))
+                AssetDatabase.CreateFolder("Assets", "TestMaterials");
+
             AssetDatabase.CreateAsset(material, assetPath);
             try
             {
@@ -504,6 +509,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             finally
             {
                 AssetDatabase.DeleteAsset(assetPath);
+                AssetDatabase.DeleteAsset(folder);
                 AssetDatabase.Refresh();
             }
             yield return null;

--- a/Unity-MCP-Plugin/Assets/root/package.json
+++ b/Unity-MCP-Plugin/Assets/root/package.json
@@ -11,7 +11,7 @@
         "MCP",
         "Unity MCP"
     ],
-    "version": "0.14.0",
+    "version": "0.14.1",
     "unity": "2022.3",
     "description": "Bridge between LLM and Unity. It expose Unity API to LLM and allows LLM to control Unity. It is based on Model Context Protocol (MCP) and uses SignalR for communication.",
     "dependencies": {

--- a/Unity-MCP-Plugin/ProjectSettings/ProjectSettings.asset
+++ b/Unity-MCP-Plugin/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.12156863, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1


### PR DESCRIPTION
This pull request updates the Unity MCP plugin to version 0.14.1 and refactors how the server binary's folder paths are handled. The changes improve clarity and reliability when unpacking and locating the server binary, and add missing metadata for tests.

Version bump:

* Updated the plugin version from `0.14.0` to `0.14.1` in both `Startup.cs` and `package.json` to reflect the new release. [[1]](diffhunk://#diff-038c02b16e212290ea84d9ff62dd1cb88870bf62e958b88df019b4690994bb81L11-R11) [[2]](diffhunk://#diff-5f41e1795cdc58d18ddd9ee0170bf6fdc17a558a3bfeca88bdd00cd76aa84e75L14-R14)

Server binary path handling improvements:

* Introduced a new `ExecutableFolderRootPath` property in `Startup.Server.cs` to clearly represent the root path for the server binary, and refactored `ExecutableFolderPath` to build on top of this new property.
* Updated the extraction logic in `DownloadAndUnpackBinary` to use `ExecutableFolderRootPath` for unpacking, and improved error logging to clarify both the extraction path and the expected binary file location.

Testing and maintenance:

* Added a missing `.meta` file for the `Tests/Editor/Project` folder, ensuring proper asset tracking in Unity.

Other:

* Removed commented-out batch mode check in `DownloadServerBinaryIfNeeded`, relying solely on the CI environment check for skipping downloads.