### PR TITLE
fix: MacOS MCP Server binary

### DIFF
--- a/.github/workflows/deploy_server_executables.yml
+++ b/.github/workflows/deploy_server_executables.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-zip:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The job runner for the `build-and-zip` job has been changed from `ubuntu-latest` to `macos-latest` to ensure compatibility with MacOS-specific build requirements.

- Changed the `runs-on` property for the `build-and-zip` job in `.github/workflows/deploy_server_executables.yml` from `ubuntu-latest` to `macos-latest`.