### PR TITLE
feature: Logging added for `MCP Plugin` < -- > `MCP Server` connection pair

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/src/Connection/Endpoint/HubEndpointConnectionBuilder.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/src/Connection/Endpoint/HubEndpointConnectionBuilder.cs
@@ -12,11 +12,13 @@ namespace com.IvanMurzak.Unity.MCP.Common
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly Reflector _reflector;
+        private readonly ILogger _logger;
 
-        public HubEndpointConnectionBuilder(IServiceProvider serviceProvider, Reflector reflector)
+        public HubEndpointConnectionBuilder(IServiceProvider serviceProvider, Reflector reflector, ILogger<HubConnection> logger)
         {
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _reflector = reflector ?? throw new ArgumentNullException(nameof(reflector));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task<HubConnection> CreateConnectionAsync(string endpoint)
@@ -39,6 +41,9 @@ namespace com.IvanMurzak.Unity.MCP.Common
                 })
                 .ConfigureLogging(logging =>
                 {
+                    logging.ClearProviders();
+                    logging.AddProvider(new ForwardLoggerProvider(_logger,
+                        additionalErrorMessage: "To stop seeing the error, please <b>Stop</b> the connection to MCP server in <b>AI Connector</b> window."));
                     logging.SetMinimumLevel(LogLevel.Trace);
                 })
                 .Build();

--- a/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/src/Utils/ForwardingLogger.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/src/Utils/ForwardingLogger.cs
@@ -1,0 +1,47 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unity.MCP.Common
+{
+    public class ForwardLoggerProvider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+        private readonly string? _additionalErrorMessage;
+
+        public ForwardLoggerProvider(ILogger logger, string? additionalErrorMessage = null)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _additionalErrorMessage = additionalErrorMessage;
+        }
+
+        public ILogger CreateLogger(string categoryName) => new ForwardingLogger(_logger, categoryName, _additionalErrorMessage);
+
+        public void Dispose() { /* No resources to dispose */ }
+
+        private class ForwardingLogger : ILogger
+        {
+            readonly ILogger _logger;
+            readonly string _categoryName;
+            readonly string? _additionalErrorMessage;
+
+            public ForwardingLogger(ILogger logger, string categoryName, string? additionalErrorMessage)
+            {
+                _logger = logger;
+                _categoryName = categoryName;
+                _additionalErrorMessage = additionalErrorMessage;
+            }
+
+            IDisposable? ILogger.BeginScope<TState>(TState state) => _logger.BeginScope(state);
+            bool ILogger.IsEnabled(LogLevel logLevel) => _logger.IsEnabled(logLevel);
+
+            void ILogger.Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                var message = $"[{_categoryName}] {formatter(state, exception)}";
+                _logger.Log(logLevel, eventId, (object)message, exception, (s, e) => s?.ToString() ?? string.Empty);
+
+                if (logLevel >= LogLevel.Error)
+                    _logger.Log(logLevel, _additionalErrorMessage);
+            }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/src/Utils/ForwardingLogger.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/src/Utils/ForwardingLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e07682096f87ce94e85afd5a954488c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Runtime/Utils/UnityLoggerProvider.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Utils/UnityLoggerProvider.cs
@@ -43,9 +43,9 @@ namespace com.IvanMurzak.Unity.MCP.Utils
             {
                 case LogLevelMicrosoft.Critical:
                 case LogLevelMicrosoft.Error:
-                    UnityEngine.Debug.LogError(message);
                     if (exception != null)
                         UnityEngine.Debug.LogException(exception);
+                    UnityEngine.Debug.LogError(message);
                     break;
 
                 case LogLevelMicrosoft.Warning:


### PR DESCRIPTION
This pull request introduces a new logging provider to improve error handling and log forwarding for hub endpoint connections. The main changes include implementing a custom `ForwardLoggerProvider`, updating the `HubEndpointConnectionBuilder` to accept and use this logger, and refining the logging order for error messages.

**Logging Improvements:**

* Added a new file `ForwardingLogger.cs` that implements `ForwardLoggerProvider`, which forwards logs to a provided `ILogger` instance and appends an additional error message for errors and above. This enables better integration and user guidance when errors occur. [[1]](diffhunk://#diff-dbca6b2ac43f1c0dce7e6cee6fdd2d85b474b07459db9f55a055ee2f1931979dR1-R47) [[2]](diffhunk://#diff-705035c50412e32dd09192ea3661b6319d5ab3ef2d0ad26a0d5054b4a6f485d0R1-R11)
* Updated `HubEndpointConnectionBuilder` to accept an `ILogger<HubConnection>` in its constructor and use the new `ForwardLoggerProvider` for logging. This ensures that all logs from the hub connection are routed through the custom provider and that error messages are more informative for users. [[1]](diffhunk://#diff-2a43c4a7f4be476e8396fe04ecc13f894703fb27583d5577a6f5fd630386ccb8R15-R21) [[2]](diffhunk://#diff-2a43c4a7f4be476e8396fe04ecc13f894703fb27583d5577a6f5fd630386ccb8R44-R46)

**Error Logging Behavior:**

* Adjusted the order of error logging in `UnityLoggerProvider` so that exceptions are logged before the error message, ensuring that stack traces appear before the error context in Unity's console.