### PR TITLE
update: MCP server

### DIFF
--- a/Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj
+++ b/Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj
@@ -37,11 +37,11 @@
     <!-- <ProjectReference Include="..\Unity-MCP-Plugin\Assets\root\Runtime\Unity-MCP-Common\Unity-MCP-Common.csproj" /> -->
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="1.0.4" />
     <PackageReference Include="com.IvanMurzak.Unity.MCP.Common" Version="1.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.4" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.4" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="5.4.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="6.0.3" />
     <PackageReference Include="R3" Version="1.3.0" />
   </ItemGroup>
 

--- a/Unity-MCP-Server/src/McpServerService.cs
+++ b/Unity-MCP-Server/src/McpServerService.cs
@@ -63,6 +63,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _logger.LogTrace("{0} StartAsync.", GetType().GetTypeShortName());
+            _disposables.Clear();
 
             _eventAppToolsChange
                 .Subscribe(data => OnListToolUpdated(data, cancellationToken))

--- a/Unity-MCP-Server/src/Program.cs
+++ b/Unity-MCP-Server/src/Program.cs
@@ -101,6 +101,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
                         logger.Debug($"Http transport configuration.");
 
                         options.Stateless = false;
+                        options.PerSessionExecutionContext = true;
                         options.RunSessionHandler = async (context, server, cancellationToken) =>
                         {
                             var connectionGuid = Guid.NewGuid();

--- a/Unity-MCP-Server/src/Routing/Tool/ToolRouter.Call.cs
+++ b/Unity-MCP-Server/src/Routing/Tool/ToolRouter.Call.cs
@@ -104,24 +104,6 @@ namespace com.IvanMurzak.Unity.MCP.Server
                 }
             };
             return Call(request, default);
-
-            // Do we need to return the 'response'? It may work even better.
-
-            // var response = await Call(request, default);
-            // return response;
-
-            // if (response == null)
-            //     return "[Error] Tool response is null";
-
-            // if (response.IsError)
-            //     return response.Content?.FirstOrDefault()?.Text ?? "[Error] Got an error during running tool";
-
-            // var result = response.Content?.FirstOrDefault()?.Text;
-            // if (result == null)
-            //     return "[Error] Tool returned null value";
-
-            // // logger.Trace("Call, result: {0}", JsonSerializer.Serialize(response.Value));
-            // return response.Value.ToCallToolResult();
         }
     }
 }

--- a/Unity-MCP-Server/src/Routing/Tool/ToolRouter.ListAll.cs
+++ b/Unity-MCP-Server/src/Routing/Tool/ToolRouter.ListAll.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
         public static async ValueTask<ListToolsResult> ListAll(RequestContext<ListToolsRequestParams> request, CancellationToken cancellationToken)
         {
             var logger = LogManager.GetCurrentClassLogger();
-            logger.Trace("{0}.ListAll", nameof(ToolRouter));
+            logger.Trace("ListAll");
 
             var mcpServerService = McpServerService.Instance;
             if (mcpServerService == null)


### PR DESCRIPTION
This pull request mainly focuses on dependency updates, minor logging improvements, and code cleanup for the Unity MCP Server project. The most significant changes include upgrading several NuGet package dependencies to newer versions, introducing a new server session option, and cleaning up comments and logging for better maintainability and traceability.

**Dependency Updates:**
* Upgraded `Microsoft.AspNetCore.SignalR.Client` and `Microsoft.Extensions.Hosting` from version 9.0.7 to 9.0.8, and `NLog.Web.AspNetCore` from 5.4.0 to 6.0.3 in the `Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj` file. This keeps the project up-to-date with the latest bug fixes and features from these libraries.

**Server Configuration Improvements:**
* Enabled `PerSessionExecutionContext` in the server options within `Program.cs`, potentially improving session isolation and execution context management for each client session.

**Code Quality and Maintenance:**
* Removed commented-out, unused code in `ToolRouter.Call.cs`, cleaning up the `CallWithJson` method for better readability and maintainability.
* Improved logging by simplifying the trace message in the `ListAll` method of `ToolRouter.ListAll.cs`.

**Service Lifecycle Handling:**
* Added a call to `_disposables.Clear()` at the start of the `StartAsync` method in `McpServerService.cs` to ensure proper disposal management when restarting the service.