### PR TITLE
Update runtime temp content output dir to prevent unwanted artifacts

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Directory.Build.props
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <BaseIntermediateOutputPath>../../../../Temp/obj/</BaseIntermediateOutputPath>
-    <RestoreOutputPath>../../../../Temp/obj/</RestoreOutputPath>
+    <BaseIntermediateOutputPath>../../../../Temp/obj~/</BaseIntermediateOutputPath>
+    <RestoreOutputPath>../../../../Temp/obj~/</RestoreOutputPath>
   </PropertyGroup>
 </Project>

--- a/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Directory.Build.props
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <BaseIntermediateOutputPath>../../../../Temp/obj~/</BaseIntermediateOutputPath>
-    <RestoreOutputPath>../../../../Temp/obj~/</RestoreOutputPath>
+    <BaseIntermediateOutputPath>./Temp~/obj/</BaseIntermediateOutputPath>
+    <RestoreOutputPath>./Temp~/obj/</RestoreOutputPath>
   </PropertyGroup>
 </Project>

--- a/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Unity-MCP-Common.csproj
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Unity-MCP-Common.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
-    <OutputPath>../../../../Temp/bin/$(Configuration)</OutputPath>
+    <OutputPath>../../../../Temp/bin~/$(Configuration)</OutputPath>
 
     <!-- NuGet Package Information -->
     <PackageId>com.IvanMurzak.Unity.MCP.Common</PackageId>

--- a/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Unity-MCP-Common.csproj
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Unity-MCP-Common/Unity-MCP-Common.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
-    <OutputPath>../../../../Temp/bin~/$(Configuration)</OutputPath>
+    <OutputPath>./Temp~/bin/$(Configuration)</OutputPath>
 
     <!-- NuGet Package Information -->
     <PackageId>com.IvanMurzak.Unity.MCP.Common</PackageId>


### PR DESCRIPTION
Temp content output directories updated to be hidden from the Editor to prevent unwanted meta file generation