### PR TITLE
feat: Add deployment workflow for MCP server and Docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,93 @@
+name: deploy
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy-mcp-server-to-nuget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          version=${{ github.event.release.tag_name }}
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Extracted version: $version"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: |
+          cd Unity-MCP-Server
+          dotnet restore
+
+      - name: Build
+        run: |
+          cd Unity-MCP-Server
+          dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: |
+          cd Unity-MCP-Server
+          dotnet test --no-build --verbosity normal --configuration Release
+
+      - name: Pack NuGet package
+        run: |
+          cd Unity-MCP-Server
+          dotnet pack com.IvanMurzak.Unity.MCP.Server.csproj --no-build --configuration Release --output ./nupkg
+
+      - name: Deploy MCP Server NuGet package
+        run: |
+          cd Unity-MCP-Server
+          # Find the generated .nupkg file (there should be only one)
+          nupkg_file=$(find ./nupkg -name "*.nupkg" | head -1)
+          if [ -z "$nupkg_file" ]; then
+            echo "Error: No .nupkg file found in ./nupkg"
+            exit 1
+          fi
+          echo "Deploying NuGet package: $nupkg_file (version: ${{ steps.version.outputs.version }})"
+          dotnet nuget push "$nupkg_file" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+  deploy-docker-image:
+    runs-on: ubuntu-latest
+    needs: deploy-mcp-server-to-nuget
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          version=${{ github.event.release.tag_name }}
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Extracted version: $version"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Unity-MCP-Server
+          push: true
+          tags: |
+            ivanmurzakdev/unity-mcp-server:${{ steps.version.outputs.version }}
+            ivanmurzakdev/unity-mcp-server:latest
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,7 @@ jobs:
   publish-unity-installer:
     runs-on: ubuntu-latest
     needs: release-unity-plugin
+    if: needs.release-unity-plugin.outputs.success == 'true'
     steps:
       - name: Download Unity Package artifact
         uses: actions/download-artifact@v4
@@ -315,6 +316,7 @@ jobs:
   publish-mcp-server:
     runs-on: macos-latest
     needs: release-unity-plugin
+    if: needs.release-unity-plugin.outputs.success == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -332,34 +334,6 @@ jobs:
           tag_name: ${{ needs.release-unity-plugin.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-docker-image:
-    runs-on: ubuntu-latest
-    needs: release-unity-plugin
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./Unity-MCP-Server
-          push: true
-          tags: |
-            ivanmurzakdev/unity-mcp-server:${{ needs.release-unity-plugin.outputs.version }}
-            ivanmurzakdev/unity-mcp-server:latest
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   publish_discord:
     runs-on: ubuntu-latest
@@ -430,7 +404,7 @@ jobs:
   # Cleanup job to remove build artifacts after publishing
   cleanup-artifacts:
     runs-on: ubuntu-latest
-    needs: [publish-mcp-server, publish-unity-installer, publish-docker-image]
+    needs: [publish-mcp-server, publish-unity-installer]
     if: always()
     steps:
       - name: Delete MCP Server artifacts


### PR DESCRIPTION
This pull request introduces a new deployment workflow and refactors the release workflow to improve deployment automation and reliability. The main changes are the addition of a dedicated deployment pipeline for publishing the MCP Server to NuGet and Docker Hub, and the removal of Docker image publishing from the release workflow. Conditional logic is also added to ensure jobs only run on successful plugin releases.

**Deployment automation improvements:**

* Added a new GitHub Actions workflow, `deploy.yml`, that automatically builds, tests, packs, and publishes the MCP Server NuGet package and Docker image when a release is published. This workflow handles version extraction, .NET setup, and Docker multi-platform builds. (.github/workflows/deploy.yml)

**Release workflow refactoring:**

* Removed the `publish-docker-image` job from `release.yml`, delegating Docker image publishing to the new deployment workflow for better separation of concerns. (.github/workflows/release.yml)
* Updated the cleanup job dependencies in `release.yml` to exclude the removed Docker image publishing job. (.github/workflows/release.yml)

**Reliability improvements:**

* Added conditional checks to the `publish-unity-installer` and `publish-mcp-server` jobs in `release.yml` to ensure they only run if the `release-unity-plugin` job succeeds. (.github/workflows/release.yml) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R300) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R319)