### PR TITLE
Use configurable timeout for client invoke

### DIFF
--- a/Unity-MCP-Server/src/Client/ClientUtils.cs
+++ b/Unity-MCP-Server/src/Client/ClientUtils.cs
@@ -139,7 +139,7 @@ namespace com.IvanMurzak.Unity.MCP.Server
                         logger.LogTrace("Invoke '{0}', ConnectionId ='{1}'. RequestData:\n{2}\n{3}", methodName, connectionId, request, allConnections);
                     }
                     var invokeTask = client.InvokeAsync<ResponseData<TResponse>>(methodName, request, cancellationToken);
-                    var completed = await invokeTask.WaitWithTimeout(/*ConnectionConfig.TimeoutMs*/ 2000, cancellationToken);
+                    var completed = await invokeTask.WaitWithTimeout(ConnectionConfig.TimeoutMs, cancellationToken);
                     if (completed)
                     {
                         try


### PR DESCRIPTION
Replaced the hardcoded 2000ms timeout in client.InvokeAsync with ConnectionConfig.TimeoutMs to allow configurable timeout values.