### PR TITLE
Fix: Handle null component in AddComponent when already exists

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/GameObject.AddComponent.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/GameObject.AddComponent.cs
@@ -60,6 +60,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 var newComponent = go.AddComponent(type);
 
+                if (newComponent == null)
+                {
+                    stringBuilder.AppendLine($"[Warning] Component '{componentName}' already exists on GameObject or cannot be added.");
+                    continue;
+                }
+
                 stringBuilder.AppendLine($"[Success] Added component '{componentName}'. Component instanceID='{newComponent.GetInstanceID()}'.");
             }
 


### PR DESCRIPTION
## Fix NullReferenceException in AddComponent tool

Prevents crash when adding a component that already exists and another can't be added on a GameObject (e.g. Canvas component).
Added null check to log warning and continue instead of throwing exception.