### PR TITLE
Add Antigravity (Gemini) client configuration

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.ClientConfigure.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.ClientConfigure.cs
@@ -78,6 +78,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                     ),
                     bodyPath: Consts.MCP.Server.DefaultBodyPath
                 ),
+                new JsonClientConfig(
+                    name: "Antigravity (Gemini)",
+                    configPath: Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        ".gemini",
+                        "antigravity",
+                        "mcp_config.json"
+                    ),
+                    bodyPath: Consts.MCP.Server.DefaultBodyPath
+                ),
                 new TomlClientConfig(
                     name: "Codex",
                     configPath: Path.Combine(
@@ -139,6 +149,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                     configPath: Path.Combine(
                         ".gemini",
                         "settings.json"
+                    ),
+                    bodyPath: Consts.MCP.Server.DefaultBodyPath
+                ),
+                new JsonClientConfig(
+                    name: "Antigravity (Gemini)",
+                    configPath: Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                        ".gemini",
+                        "antigravity",
+                        "mcp_config.json"
                     ),
                     bodyPath: Consts.MCP.Server.DefaultBodyPath
                 ),


### PR DESCRIPTION
Introduce configuration for the Antigravity (Gemini) client in the MainWindowEditor, enabling its integration with the application.

<img width="593" height="142" alt="image" src="https://github.com/user-attachments/assets/617ef604-4b0a-4b7e-8161-5c5bccdb64cd" />
