### PR TITLE
Bump version to 0.24.1 and update download links in documentation

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
@@ -16,7 +16,7 @@ namespace com.IvanMurzak.Unity.MCP.Installer
     public static partial class Installer
     {
         public const string PackageId = "com.ivanmurzak.unity.mcp";
-        public const string Version = "0.24.0";
+        public const string Version = "0.24.1";
 
         static Installer()
         {

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 
 ### Option 1 - Installer
 
-- **[⬇️ Download Installer](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.0/AI-Game-Dev-Installer.unitypackage)**
+- **[⬇️ Download Installer](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.1/AI-Game-Dev-Installer.unitypackage)**
 - **📂 Import installer into Unity project**
   > - You can double-click on the file - Unity will open it automatically
   > - OR: Open Unity Editor first, then click on `Assets/Import Package/Custom Package`, and choose the file

--- a/Unity-MCP-Plugin/Assets/root/README.md
+++ b/Unity-MCP-Plugin/Assets/root/README.md
@@ -97,7 +97,7 @@
 
 ### Option 1 - Installer
 
-- **[⬇️ Download Installer](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.0/AI-Game-Dev-Installer.unitypackage)**
+- **[⬇️ Download Installer](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.1/AI-Game-Dev-Installer.unitypackage)**
 - **📂 Import installer into Unity project**
   > - You can double-click on the file - Unity will open it automatically
   > - OR: Open Unity Editor first, then click on `Assets/Import Package/Custom Package`, and choose the file

--- a/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.cs
@@ -20,7 +20,7 @@ namespace com.IvanMurzak.Unity.MCP
 {
     public partial class UnityMcpPlugin : IDisposable
     {
-        public const string Version = "0.24.0";
+        public const string Version = "0.24.1";
 
         protected readonly CompositeDisposable _disposables = new();
 

--- a/Unity-MCP-Plugin/Assets/root/package.json
+++ b/Unity-MCP-Plugin/Assets/root/package.json
@@ -11,24 +11,24 @@
         "MCP",
         "Unity MCP"
     ],
-    "version": "0.24.0",
+    "version": "0.24.1",
     "unity": "2022.3",
     "description": "Bridge between LLM and Unity. It expose Unity API to LLM and allows LLM to control Unity. It is based on Model Context Protocol (MCP) and uses SignalR for communication.",
     "dependencies": {
         "com.unity.test-framework": "1.1.33",
         "com.unity.modules.uielements": "1.0.0",
         "extensions.unity.playerprefsex": "2.0.2",
-        "org.nuget.microsoft.bcl.memory": "9.0.10",
-        "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.10",
-        "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.10",
+        "org.nuget.microsoft.bcl.memory": "10.0.0",
+        "org.nuget.microsoft.aspnetcore.signalr.client": "10.0.0",
+        "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "10.0.0",
         "org.nuget.microsoft.codeanalysis.csharp": "4.14.0",
-        "org.nuget.microsoft.extensions.caching.abstractions": "9.0.10",
-        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.10",
-        "org.nuget.microsoft.extensions.hosting": "9.0.10",
-        "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.10",
-        "org.nuget.microsoft.extensions.logging.abstractions": "9.0.10",
+        "org.nuget.microsoft.extensions.caching.abstractions": "10.0.0",
+        "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "10.0.0",
+        "org.nuget.microsoft.extensions.hosting": "10.0.0",
+        "org.nuget.microsoft.extensions.hosting.abstractions": "10.0.0",
+        "org.nuget.microsoft.extensions.logging.abstractions": "10.0.0",
         "org.nuget.r3": "1.3.0",
-        "org.nuget.system.text.json": "9.0.10"
+        "org.nuget.system.text.json": "10.0.0"
     },
     "scopedRegistries": [
         {

--- a/Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj
+++ b/Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>unity-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.Unity.MCP.Server</PackageId>
-    <Version>0.24.0</Version>
+    <Version>0.24.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2025 Ivan Murzak</Copyright>

--- a/Unity-MCP-Server/server.json
+++ b/Unity-MCP-Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "Unity-MCP-Server"
   },
-  "version": "0.24.0",
+  "version": "0.24.1",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/unity-mcp-server",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "transport": {
         "type": "stdio"
       },

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -96,7 +96,7 @@
 
 ### Opción 1 - Instalador
 
-- **[⬇️ Descargar Instalador](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.0/AI-Game-Dev-Installer.unitypackage)**
+- **[⬇️ Descargar Instalador](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.1/AI-Game-Dev-Installer.unitypackage)**
 - **📂 Importar instalador al proyecto Unity**
   > - Puedes hacer doble clic en el archivo - Unity lo abrirá automáticamente
   > - O: Abre Unity Editor primero, luego haz clic en `Assets/Import Package/Custom Package`, y elige el archivo

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -96,7 +96,7 @@
 
 ### オプション1 - インストーラー
 
-- **[⬇️ インストーラーをダウンロード](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.0/AI-Game-Dev-Installer.unitypackage)**
+- **[⬇️ インストーラーをダウンロード](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.1/AI-Game-Dev-Installer.unitypackage)**
 - **📂 インストーラーをUnityプロジェクトにインポート**
   > - ファイルをダブルクリック - Unityが自動的に開きます
   > - または：最初にUnityエディターを開き、`Assets/Import Package/Custom Package`をクリックして、ファイルを選択

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -96,7 +96,7 @@
 
 ### 选项1 - 安装程序
 
-- **[⬇️ 下载安装程序](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.0/AI-Game-Dev-Installer.unitypackage)**
+- **[⬇️ 下载安装程序](https://github.com/IvanMurzak/Unity-MCP/releases/download/0.24.1/AI-Game-Dev-Installer.unitypackage)**
 - **📂 将安装程序导入Unity项目**
   > - 您可以双击文件 - Unity会自动打开它
   > - 或者：先打开Unity编辑器，然后点击 `Assets/Import Package/Custom Package`，选择文件


### PR DESCRIPTION
Update the version number to 0.24.1 and modify the download links in the documentation to reflect the new version. Adjust dependencies to their latest versions for improved compatibility.