### PR TITLE
Fix JSON config case sensitivity causing settings to reset on domain reload

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.Editor.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.Editor.cs
@@ -48,7 +48,10 @@ namespace com.IvanMurzak.Unity.MCP
                 {
                     config = string.IsNullOrWhiteSpace(json)
                         ? null
-                        : JsonSerializer.Deserialize<UnityConnectionConfig>(json);
+                        : JsonSerializer.Deserialize<UnityConnectionConfig>(json, new JsonSerializerOptions
+                        {
+                            PropertyNameCaseInsensitive = true
+                        });
                 }
                 catch (Exception e)
                 {
@@ -113,7 +116,11 @@ namespace com.IvanMurzak.Unity.MCP
                     ? enabledResourceNames
                     : UnityConnectionConfig.DefaultEnabledResources;
 
-                var json = JsonSerializer.Serialize(unityConnectionConfig, new JsonSerializerOptions { WriteIndented = true });
+                var json = JsonSerializer.Serialize(unityConnectionConfig, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                });
                 File.WriteAllText(AssetsFilePath, json);
 
                 var assetFile = AssetFile;


### PR DESCRIPTION
## Summary
- Added `PropertyNameCaseInsensitive = true` to JSON deserialization
- Added `PropertyNamingPolicy = JsonNamingPolicy.CamelCase` to serialization

## Problem
When Unity performs a domain reload, the JSON config file was not being deserialized correctly due to case sensitivity mismatch. `System.Text.Json` is case-sensitive by default, so properties like `keepConnected` (camelCase in JSON) weren't matching `KeepConnected` (PascalCase C# property).

This caused `GetOrCreateConfig()` to return null from deserialization, triggering creation of a new default config which overwrote the user's saved settings.

## Test plan
- Disable the plugin via UI (sets `keepConnected: false`)
- Trigger a domain reload (edit and save any script)
- Verify plugin does not auto-reconnect and config values are preserved