### PR TITLE
Update Unity test configurations and project settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
     needs: [build-and-zip-mcp-server, build-unity-installer]
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
-      projectPath: "./Unity-MCP-Plugin"
+      projectPath: "./Unity-Tests/2022.3.62f3"
       unityVersion: "2022.3.62f3"
       testMode: "standalone"
     secrets: inherit
@@ -199,7 +199,7 @@ jobs:
     needs: [build-and-zip-mcp-server, build-unity-installer]
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
-      projectPath: "./Unity-MCP-Plugin"
+      projectPath: "./Unity-Tests/2023.2.22f1"
       unityVersion: "2023.2.22f1"
       testMode: "standalone"
     secrets: inherit
@@ -208,7 +208,7 @@ jobs:
     needs: [build-and-zip-mcp-server, build-unity-installer]
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
-      projectPath: "./Unity-MCP-Plugin"
+      projectPath: "./Unity-Tests/6000.3.1f1"
       unityVersion: "6000.3.1f1"
       testMode: "standalone"
     secrets: inherit

--- a/.github/workflows/test_pull_request_manual.yml
+++ b/.github/workflows/test_pull_request_manual.yml
@@ -28,7 +28,7 @@ jobs:
   test-unity-6000-3-1f1-editmode:
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
-      projectPath: "./Unity-MCP-Plugin"
+      projectPath: "./Unity-Tests/6000.3.1f1"
       unityVersion: "6000.3.1f1"
       testMode: "editmode"
     secrets: inherit

--- a/Unity-Tests/2022.3.62f3/ProjectSettings/ProjectSettings.asset
+++ b/Unity-Tests/2022.3.62f3/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
+  companyName: IvanMurzak
   productName: 2022.3.62f3
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -141,7 +141,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.1
+  bundleVersion: 1.0.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -163,7 +163,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Standalone: com.DefaultCompany.2022.3.62f3
+    Standalone: com.IvanMurzak.2022.3.62f3
   buildNumber:
     Standalone: 0
     VisionOS: 0

--- a/Unity-Tests/2023.2.22f1/ProjectSettings/ProjectSettings.asset
+++ b/Unity-Tests/2023.2.22f1/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
+  companyName: IvanMurzak
   productName: 2023.2.22f1
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -137,7 +137,7 @@ PlayerSettings:
   vulkanEnableLateAcquireNextImage: 0
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
-  bundleVersion: 0.1
+  bundleVersion: 1.0.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
@@ -160,7 +160,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   androidMinAspectRatio: 1
   applicationIdentifier:
-    Standalone: com.DefaultCompany.2023.2.22f1
+    Standalone: com.IvanMurzak.2023.2.22f1
   buildNumber:
     Bratwurst: 0
     Standalone: 0
@@ -685,7 +685,7 @@ PlayerSettings:
   gcIncremental: 1
   gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
-  editorAssembliesCompatibilityLevel: 3
+  editorAssembliesCompatibilityLevel: 2
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: 2023.2.22f1

--- a/Unity-Tests/6000.3.1f1/ProjectSettings/ProjectSettings.asset
+++ b/Unity-Tests/6000.3.1f1/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
+  companyName: IvanMurzak
   productName: 6000.3.1f1
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -143,7 +143,7 @@ PlayerSettings:
   loadStoreDebugModeEnabled: 0
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
-  bundleVersion: 0.1.0
+  bundleVersion: 1.0.0
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
This pull request updates Unity test project configurations and related GitHub Actions workflows to ensure the correct test projects are used and that project metadata is consistent across Unity versions. The main changes include updating workflow paths to point to version-specific test projects and standardizing project settings such as company name, bundle version, and application identifiers.

**GitHub Actions workflow updates:**

- Updated the `projectPath` in `.github/workflows/release.yml` and `.github/workflows/test_pull_request_manual.yml` to use version-specific test projects (`Unity-Tests/<version>`) instead of the generic `Unity-MCP-Plugin` path for all tested Unity versions. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L193-R193) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L202-R202) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L211-R211) [[4]](diffhunk://#diff-3153ab74c544e9cd4298a762536eb3a91574961f4edf8691b262f32ec960166aL31-R31)

**Unity project settings standardization:**

- Changed `companyName` from `DefaultCompany` to `IvanMurzak` in all `ProjectSettings.asset` files for the test projects. [[1]](diffhunk://#diff-90bd7f02a636e17a3b871f70aeff9a219d60be7fdd0946195247495af8d4412bL15-R15) [[2]](diffhunk://#diff-f0120a925c81baa5356d7c0b0314da88014c03de7351cf882a312212f3479abbL15-R15) [[3]](diffhunk://#diff-5c23762ee4a6bafa5deccbe6ec5613b9c42925bb8d0d96c847990541ee3cfa6fL15-R15)
- Updated `bundleVersion` to `1.0.0` across all test projects for consistency. [[1]](diffhunk://#diff-90bd7f02a636e17a3b871f70aeff9a219d60be7fdd0946195247495af8d4412bL144-R144) [[2]](diffhunk://#diff-f0120a925c81baa5356d7c0b0314da88014c03de7351cf882a312212f3479abbL140-R140) [[3]](diffhunk://#diff-5c23762ee4a6bafa5deccbe6ec5613b9c42925bb8d0d96c847990541ee3cfa6fL146-R146)
- Changed the `applicationIdentifier` for the `Standalone` platform to use `com.IvanMurzak.<version>` instead of `com.DefaultCompany.<version>`. [[1]](diffhunk://#diff-90bd7f02a636e17a3b871f70aeff9a219d60be7fdd0946195247495af8d4412bL166-R166) [[2]](diffhunk://#diff-f0120a925c81baa5356d7c0b0314da88014c03de7351cf882a312212f3479abbL163-R163)
- Adjusted `editorAssembliesCompatibilityLevel` from `3` to `2` in the Unity 2023.2.22f1 test project.