### PR TITLE
Update Unity version check for transformHandle in UnityEngine_GameObject_ReflectionConverter

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.cs
@@ -51,7 +51,7 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
             yield return nameof(UnityEngine.GameObject.gameObject);
             yield return nameof(UnityEngine.GameObject.transform);
             yield return nameof(UnityEngine.GameObject.scene);
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_3_OR_NEWER
             yield return nameof(UnityEngine.GameObject.transformHandle);
 #endif
         }


### PR DESCRIPTION
Adjust the Unity version check to support transformHandle for Unity 6000.3 and newer.