### PR TITLE
Fix path formatting in ClientConfig for project root

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.ClientConfigure.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.ClientConfigure.cs
@@ -41,7 +41,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                         ".claude.json"
                     ),
                     bodyPath: $"projects{Consts.MCP.Server.BodyPathDelimiter}"
-                        + $"{ProjectRootPath.Replace("/", "\\")}{Consts.MCP.Server.BodyPathDelimiter}"
+                        + $"{ProjectRootPath}{Consts.MCP.Server.BodyPathDelimiter}"
                         + Consts.MCP.Server.DefaultBodyPath
                 ),
                 new JsonClientConfig(


### PR DESCRIPTION
Correct the path formatting in the ClientConfig to ensure proper handling of the project root.