### PR TITLE
fix: ensure PlayerPrefs are saved after updating version check settings

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Utils/UpdateChecker.cs
@@ -69,7 +69,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         public static bool IsDoNotShowAgain
         {
             get => DoNotShowAgain.Value;
-            set => DoNotShowAgain.Value = value;
+            set
+            {
+                DoNotShowAgain.Value = value;
+                PlayerPrefsEx.Save();
+            }
         }
 
         /// <summary>
@@ -129,6 +133,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         public static void SkipVersion(string version)
         {
             SkippedVersion.Value = version;
+            PlayerPrefsEx.Save();
         }
 
         /// <summary>
@@ -139,6 +144,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
             DoNotShowAgain.Value = false;
             NextCheckTime.Value = string.Empty;
             SkippedVersion.Value = string.Empty;
+            PlayerPrefsEx.Save();
         }
 
         /// <summary>
@@ -204,6 +210,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
                 if (!forceCheck)
                 {
                     NextCheckTime.Value = DateTime.UtcNow.AddHours(1).ToString("O");
+                    PlayerPrefsEx.Save();
                 }
                 isChecking = false;
             }


### PR DESCRIPTION
This pull request improves the reliability of user preferences in the update checker by ensuring changes are consistently saved to persistent storage. The main updates involve calling `PlayerPrefsEx.Save()` after modifying preference values, preventing potential data loss if the application closes unexpectedly.

Persistence improvements:

* Added calls to `PlayerPrefsEx.Save()` after setting the `DoNotShowAgain` value to ensure changes are immediately persisted. (`UpdateChecker.IsDoNotShowAgain` setter)
* Ensured that skipping a version via `SkipVersion` saves preferences right after updating the value.
* Added a save operation after clearing preferences in `ClearPreferences` to persist the reset state.
* When scheduling the next update check, preferences are now saved immediately after updating `NextCheckTime`.