### PR TITLE
Remove Immutable Collections package and update Reflection.MethodCall to use Dictionary

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Reflection.MethodCall.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Reflection.MethodCall.cs
@@ -10,7 +10,6 @@
 
 #nullable enable
 using System;
-using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
@@ -131,7 +130,7 @@ Required:
             {
                 var reflector = McpPlugin.McpPlugin.Instance!.McpManager.Reflector;
 
-                var dictInputParameters = inputParameters?.ToImmutableDictionary(
+                var dictInputParameters = inputParameters?.ToDictionary(
                     keySelector: p => p.name ?? throw new InvalidOperationException($"Input parameter name is null. Please specify 'name' property for each input parameter."),
                     elementSelector: p => reflector.Deserialize(p, logger: McpPlugin.McpPlugin.Instance.Logger)
                 );

--- a/Unity-MCP-Plugin/Packages/manifest.json
+++ b/Unity-MCP-Plugin/Packages/manifest.json
@@ -76,7 +76,6 @@
         "org.nuget.microsoft.extensions.primitives",
         "org.nuget.r3",
         "org.nuget.system.buffers",
-        "org.nuget.system.collections.immutable",
         "org.nuget.system.componentmodel.annotations",
         "org.nuget.system.diagnostics.diagnosticsource",
         "org.nuget.system.diagnostics.eventlog",


### PR DESCRIPTION
This pull request simplifies the handling of input parameters in the reflection method call logic and removes unnecessary dependencies related to immutable collections. The main focus is on using standard collections instead of immutable ones, which streamlines the code and reduces package dependencies.

Dependency cleanup:

* Removed the `System.Collections.Immutable` NuGet package from `Packages/manifest.json` to eliminate unused dependencies.

Code simplification:

* Replaced usage of `ToImmutableDictionary` with `ToDictionary` for converting input parameters in `Reflection.MethodCall.cs`, making the code easier to maintain and removing the need for immutable collections.
* Removed the `using System.Collections.Immutable;` directive from `Reflection.MethodCall.cs` since immutable collections are no longer used.