### PR TITLE
Fixed "Prefab has been modified" popup in unity when closing prefab stage, even after saving

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
@@ -46,6 +46,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (save)
                 PrefabUtility.SaveAsPrefabAsset(prefabGo, assetPath);
 
+            prefabStage.ClearDirtiness();
+
             StageUtility.GoBackToPreviousStage();
 
             UnityEditor.EditorApplication.RepaintHierarchyWindow();

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
@@ -39,6 +39,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var goName = prefabGo.name;
 
             PrefabUtility.SaveAsPrefabAsset(prefabGo, assetPath);
+            prefabStage.ClearDirtiness();
 
             UnityEditor.EditorApplication.RepaintHierarchyWindow();
             UnityEditorInternal.InternalEditorUtility.RepaintAllViews();


### PR DESCRIPTION
When changing anything on the prefab after using `Assets.Prefab.Open` tool, there was always a popup in unity warning about prefab modifications being not saved (even if they was saved with `Assets.Prefab.Save` or as an argument `save:true` when calling `Assets.Prefab.Close`).

<img width="284" height="132" alt="Screenshot_2026-01-14_09-17-43" src="https://github.com/user-attachments/assets/bba54d8b-1aa2-4fce-9605-c24b85da1cc2" />

That popup breaks all next tools execution flow - nothing else will be executed and also `Assets.Prefab.Close` call would never end, giving `No result` for ai agent.

The problem was, that saving prefab doesn't clear dirtiness on prefab stage scene. Also when we don't want to save the changes calling `Assest.Prefab.Close` with `save:false` we should clear dirtiness to not trigger popup. 
I've tested 3 different flows, all working as expected:

A)
1. Open prefab with `Assets.Prefab.Open`
2. Modify
3. Call `Assets.Prefab.Save`
4. Call `Assets.Prefab.Close` (doesn't matter if with `save:false` or `save:true`

Result: Prefab is saved, no popup window


B)
1. Open prefab with `Assets.Prefab.Open`
2. Modify
3. Immediately call `Assets.Prefab.Close` with `save:true`

Result: Prefab is saved, no popup window


C)
1. Open prefab with `Assets.Prefab.Open`
2. Modify
3. Immediately call `Assets.Prefab.Close` with `save:false`

Result: Prefab is not saved, changes are lost, no popup window - this is expected behavior