### PR TITLE
Fixed "Prefab has been modified" popup in unity when closing prefab stage, even after saving

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
@@ -46,6 +46,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (save)
                 PrefabUtility.SaveAsPrefabAsset(prefabGo, assetPath);
 
+            prefabStage.ClearDirtiness();
+
             StageUtility.GoBackToPreviousStage();
 
             UnityEditor.EditorApplication.RepaintHierarchyWindow();

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
@@ -39,6 +39,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var goName = prefabGo.name;
 
             PrefabUtility.SaveAsPrefabAsset(prefabGo, assetPath);
+            prefabStage.ClearDirtiness();
 
             UnityEditor.EditorApplication.RepaintHierarchyWindow();
             UnityEditorInternal.InternalEditorUtility.RepaintAllViews();


### PR DESCRIPTION
## [Original PR](https://github.com/IvanMurzak/Unity-MCP/pull/415)

This pull request improves the prefab editing workflow in the Unity MCP Plugin by ensuring the prefab stage's dirtiness state is properly cleared after saving or closing a prefab. This helps prevent unnecessary prompts to save changes and ensures the editor's internal state remains consistent.

Prefab stage state management improvements:

* Added calls to `prefabStage.ClearDirtiness()` after saving a prefab in both the `Close` and `Save` methods to ensure the prefab stage is marked as clean and no longer prompts for unsaved changes. [[1]](diffhunk://#diff-b4152dd59f272ce68a1bf228fb50c550fcf10b3788b61d0c259cac848446a431R49-R50) [[2]](diffhunk://#diff-2a0976e066ce9736df4bc1f1e52442075bf61d1d2c7d222e32dc0df56842eaddR42)