### PR TITLE
Remove empty scene path check in Scene.Save

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Scene.Save.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Scene.Save.cs
@@ -35,9 +35,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         {
             MainThread.Instance.Run(() =>
             {
-                if (string.IsNullOrEmpty(path))
-                    throw new System.Exception(Error.ScenePathIsEmpty());
-
                 var scene = string.IsNullOrEmpty(openedSceneName)
                     ? SceneUtils.GetActiveScene()
                     : SceneUtils.GetAllOpenedScenes()


### PR DESCRIPTION
Eliminated the check and exception for empty scene path in the Save method. This may allow saving scenes without a specified path, possibly to support new workflows or to defer validation elsewhere.