### PR TITLE
Add retry mechanism for deleting MCP server binaries with user prompt on failure

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.Server.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.Server.cs
@@ -170,6 +170,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             {
                 if (Directory.Exists(ExecutableFolderRootPath))
                 {
+                    // Intentional infinite loop:
+                    // - Deletion can fail while the MCP server binaries are in use (e.g., server still running).
+                    // - The retry/exit behavior is fully controlled by the user via the dialog below.
+                    // - We do not impose a fixed maximum retry count so the user can take as long as needed
+                    //   to shut down their MCP client and release file locks before trying again.
+                    // - The loop terminates when the user selects "Skip", at which point the exception is rethrown.
                     while (true)
                     {
                         try


### PR DESCRIPTION
This pull request improves the robustness of the `DeleteBinaryFolderIfExists` method by adding user-friendly error handling when deleting the MCP server binaries folder fails. If deletion fails (e.g., because the server is still running), the user is prompted to retry or skip, making the process clearer and less error-prone.

**Error handling and user experience improvements:**

* Enhanced `DeleteBinaryFolderIfExists` in `Startup.Server.cs` to repeatedly prompt the user to retry or skip if deleting the MCP server binaries folder fails, providing clear instructions and error messages.