### PR TITLE
Blacklist Addressables AsyncOperationHandle type

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.Converters.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.Converters.cs
@@ -91,7 +91,7 @@ namespace com.IvanMurzak.Unity.MCP
             // Photon IL-weaved types
             reflector.Converters.BlacklistType("Fusion.NetworkBehaviourBuffer");
 
-            // Addressable
+            // Addressables
             reflector.Converters.BlacklistType("UnityEngine.ResourceManagement.AsyncOperations.AsyncOperationHandle");
 
             // Json Converters


### PR DESCRIPTION
Added 'UnityEngine.ResourceManagement.AsyncOperations.AsyncOperationHandle' to the converter blacklist to prevent issues with serialization or reflection involving Addressables async operation handles.