### PR TITLE
Refactor menu item labels and add MCP Inspector launch functionality

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/MenuItems.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/MenuItems.cs
@@ -81,15 +81,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             }
 
             // Run command in a terminal window: npx @modelcontextprotocol/inspector http://localhost:8080 --transport http
-            var arguments = $"-y @modelcontextprotocol/inspector {UnityMcpPlugin.Host} --transport http";
-            Debug.Log($"Launching MCP Inspector with command: npx {arguments}");
+            var npxArgs = $"-y @modelcontextprotocol/inspector {UnityMcpPlugin.Host} --transport http";
+            Debug.Log($"Launching MCP Inspector with command: npx {npxArgs}");
 
             var processInfo = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = "npx",
-                Arguments = arguments,
-                RedirectStandardOutput = false,
-                RedirectStandardError = false,
+                Arguments = npxArgs,
                 UseShellExecute = true,
                 CreateNoWindow = false,
             };


### PR DESCRIPTION
Improve clarity of menu item labels and introduce a new option to launch the MCP Inspector directly from the tools menu.

![Unity_mHV7rsinIU](https://github.com/user-attachments/assets/c1d2366c-e3f8-4c41-aafb-5797642ebf41)
