### PR TITLE
fix for issue 448, prevent circular recursion causing stack overflow from Claude models in vscode

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/Converter/Reflection/UnityEngine_Object_ReflectionConverter.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Converter/Reflection/UnityEngine_Object_ReflectionConverter.cs
@@ -23,6 +23,21 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
         public override bool AllowCascadePropertiesConversion => true;
         public override bool AllowSetValue => true;
 
+        protected override IEnumerable<string> GetIgnoredProperties()
+        {
+            foreach (var property in base.GetIgnoredProperties())
+                yield return property;
+
+            // Ignore common Unity properties that cause circular references
+            // These are properties that reference back to the same object or parent objects
+            yield return nameof(UnityEngine.Component.gameObject);
+            yield return nameof(UnityEngine.Component.transform);
+            yield return nameof(UnityEngine.GameObject.scene);
+#if UNITY_6000_3_OR_NEWER
+            yield return nameof(UnityEngine.Component.transformHandle);
+#endif
+        }
+
         protected virtual IEnumerable<string> RestrictedInValuePropertyNames(Reflector reflector, JsonElement valueJsonElement) => new[]
         {
             nameof(SerializedMember.fields),


### PR DESCRIPTION
Tested in Unity 2022.3. I plan to test in 2023 and 6.0 soon but haven't been able to find time so wanted to push this first. Feel free to keep it waiting til I do more testing if that's more convenient for you. Just let me know :)