### PR TITLE
fix: use absolute paths for skill files and config to prevent CWD-relative placement

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/Startup.cs
@@ -9,10 +9,8 @@
 */
 
 #nullable enable
-using System.IO;
 using com.IvanMurzak.McpPlugin.Skills;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using com.IvanMurzak.Unity.MCP.Utils;
 using Microsoft.Extensions.Logging;
 using UnityEditor;
@@ -56,16 +54,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 return;
             }
 
-            // Resolve relative paths against the project root so skill files are always placed
-            // inside the Unity project regardless of the process working directory.
-            var basePath = UnityMcpPluginEditor.SkillsRootFolder;
-            if (!Path.IsPathRooted(basePath))
-                basePath = Path.GetFullPath(Path.Combine(UnityMcpPluginEditor.ProjectRootPath, basePath));
-
             new SkillFileGenerator(UnityMcpPluginEditor.Instance.Logger).Generate(
                 tools: tools.GetAllTools(),
                 rootFolder: "unity-editor",
-                basePath: basePath
+                basePath: UnityMcpPluginEditor.SkillsRootFolderAbsolutePath
             );
         }
     }

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.CreateGUI.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.CreateGUI.cs
@@ -11,7 +11,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.McpPlugin.Common.Utils;
@@ -947,16 +946,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     return;
                 }
 
-                // Resolve relative paths against the project root so skill files are always placed
-                // inside the Unity project regardless of the process working directory.
-                var basePath = UnityMcpPluginEditor.SkillsRootFolder;
-                if (!Path.IsPathRooted(basePath))
-                    basePath = Path.GetFullPath(Path.Combine(UnityMcpPluginEditor.ProjectRootPath, basePath));
-
                 new SkillFileGenerator(UnityMcpPluginEditor.Instance.Logger).Generate(
                     tools: tools.GetAllTools(),
                     rootFolder: "unity-editor",
-                    basePath: basePath
+                    basePath: UnityMcpPluginEditor.SkillsRootFolderAbsolutePath
                 );
             });
         }

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UnityMcpPluginEditor.Config.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UnityMcpPluginEditor.Config.cs
@@ -36,9 +36,25 @@ namespace com.IvanMurzak.Unity.MCP
 
         /// <summary>
         /// Absolute path to the config file for use with System.IO File/Directory operations.
+        /// Built from <see cref="ProjectRootPath"/> and <see cref="AssetsFilePath"/> to keep paths consistent.
         /// </summary>
-        public static string AssetsFileAbsolutePath => Path.GetFullPath(
-            Path.Combine(Application.dataPath, "..", "UserSettings", $"{ResourcesFileName}.json"));
+        public static string AssetsFileAbsolutePath => Path.GetFullPath(Path.Combine(ProjectRootPath, AssetsFilePath));
+
+        /// <summary>
+        /// Absolute path to the skills root folder for use with System.IO File/Directory operations.
+        /// If <see cref="SkillsRootFolder"/> is already an absolute path it is returned as-is;
+        /// otherwise it is resolved relative to <see cref="ProjectRootPath"/>.
+        /// </summary>
+        public static string SkillsRootFolderAbsolutePath
+        {
+            get
+            {
+                var folder = SkillsRootFolder;
+                return Path.IsPathRooted(folder)
+                    ? folder
+                    : Path.GetFullPath(Path.Combine(ProjectRootPath, folder));
+            }
+        }
 
 #if UNITY_EDITOR
         public static UnityEngine.TextAsset AssetFile => UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEngine.TextAsset>(AssetsFilePath);


### PR DESCRIPTION
Fixes #502

## Changes

When Unity Editor is launched from a directory other than the project root, `System.IO` file operations using relative paths resolve against the process working directory instead of the project root.

- `UnityMcpPluginEditor.Config.cs`: Add `ProjectRootPath` and `AssetsFileAbsolutePath` properties derived from `Application.dataPath`; update all System.IO File/Directory calls to use the absolute path (AssetDatabase calls keep the relative path).
- `Startup.cs`: Resolve `SkillsRootFolder` to an absolute path before passing `basePath` to `SkillFileGenerator.Generate()`.
- `MainWindowEditor.CreateGUI.cs`: Same fix for the manual generate button handler.