### PR TITLE
fix: set GenerateSkillFiles default to false

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.Config.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/UnityMcpPlugin.Config.cs
@@ -49,6 +49,7 @@ namespace com.IvanMurzak.Unity.MCP
                 Host = DefaultHost;
                 KeepConnected = false;
                 KeepServerRunning = false;
+                GenerateSkillFiles = false;
                 TransportMethod = TransportMethod.streamableHttp;
                 AuthOption = AuthOption.none;
                 LogLevel = LogLevel.Warning;


### PR DESCRIPTION
Set `GenerateSkillFiles` default value to `false` in `UnityConnectionConfig.SetDefault()`, making skill file generation opt-in rather than opt-out.

Fixes #508

Generated with [Claude Code](https://claude.ai/code)