### PR TITLE
fix: replace DateTime stale-check with thread-safe Interlocked version counter

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.CreateGUI.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/MainWindowEditor.CreateGUI.cs
@@ -644,7 +644,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             {
                 if (Interlocked.Read(ref _mcpServerDataVersion) != fetchVersion)
                 {
-                    Logger.LogWarning("Skipping MCP server data update because a newer update was applied at {time}",
+                    Logger.LogTrace("Skipping MCP server data update because a newer update was applied at {time}",
                         DateTime.UtcNow);
                     return;
                 }
@@ -822,7 +822,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             {
                 if (Interlocked.Read(ref _aiAgentDataVersion) != fetchVersion)
                 {
-                    Logger.LogWarning("Skipping AI agent data update because a newer update was applied at {time}",
+                    Logger.LogTrace("Skipping AI agent data update because a newer update was applied at {time}",
                         DateTime.UtcNow);
                     return;
                 }


### PR DESCRIPTION
Fixes race conditions in MainWindowEditor.CreateGUI.cs stale-update guard.

The DateTime.UtcNow comparison had same-tick blindness (~15ms resolution on Windows), no memory barrier guarantees across threads, and a TOCTOU window between the thread-pool check and main-thread callback.

Replaced with a thread-safe Interlocked version counter (long) that uniquely identifies each fetch call. Also adds a second version check inside MainThread.Instance.Run to close the TOCTOU window.

Closes #536

Generated with [Claude Code](https://claude.ai/code)