### PR TITLE
fix: handle exceptions when creating metadata references for assemblies

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Script.Execute.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Script.Execute.cs
@@ -133,7 +133,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     .Where(a => !string.IsNullOrEmpty(a.Location))
                     .Select(a =>
                     {
-                        try { return MetadataReference.CreateFromFile(a.Location); }
+                        try
+                        {
+                            return MetadataReference.CreateFromFile(a.Location);
+                        }
                         catch (DirectoryNotFoundException ex)
                         {
                             logger?.LogWarning(ex, "Directory not found for assembly '{AssemblyName}' at '{Location}': {Error}",


### PR DESCRIPTION
This pull request improves error handling when creating metadata references for assemblies in the `ExecuteCSharpCode` method. Now, if an assembly's file location is missing or invalid, or if any error occurs during metadata reference creation, a warning is logged instead of throwing an exception, and the problematic reference is skipped.

Error handling and logging improvements:

* Enhanced the assembly reference creation logic in `Script.Execute.cs` to catch `DirectoryNotFoundException` and general exceptions, log a warning with details, and skip assemblies that cannot be loaded as metadata references. This prevents the process from failing due to missing or problematic assemblies.