### PR TITLE
Setup NuGet trusted publishing via OIDC to replace expiring API key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,13 +23,15 @@ on:
     inputs:
       version: { required: true, type: string }
     secrets:
-      NUGET_API_KEY: { required: true }
       DOCKER_USERNAME: { required: true }
       DOCKER_PASSWORD: { required: true }
 
 jobs:
   deploy-mcp-server-to-nuget:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -76,7 +78,7 @@ jobs:
             exit 1
           fi
           echo "Deploying NuGet package: $nupkg_file (version: ${{ steps.version.outputs.version }})"
-          dotnet nuget push "$nupkg_file" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push "$nupkg_file" --api-key az --source https://api.nuget.org/v3/index.json
 
   deploy-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,6 +443,9 @@ jobs:
   deploy:
     needs: release-unity-plugin
     if: needs.release-unity-plugin.outputs.success == 'true'
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/deploy.yml
     with:
       version: ${{ needs.release-unity-plugin.outputs.version }}


### PR DESCRIPTION
- Remove NUGET_API_KEY secret from deploy.yml workflow_call interface
- Add id-token: write permission to NuGet deploy job for OIDC token
- Replace --api-key secret with --api-key az for OIDC authentication
- Add id-token: write permission to release.yml deploy caller job
  (required because OIDC tokens are minted in the caller's context)

Note: Package owner must configure trusted publisher on nuget.org
for package com.IvanMurzak.Unity.MCP.Server before this will work.

https://claude.ai/code/session_01WB1sWb9v7hVPBpxXXnUgbZ