### PR TITLE
feat: installer self-deletes after successful installation

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.Manifest.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.Manifest.cs
@@ -73,12 +73,12 @@ namespace com.IvanMurzak.Unity.MCP.Installer
             }
         }
 
-        public static void AddScopedRegistryIfNeeded(string manifestPath, int indent = 2)
+        public static bool AddScopedRegistryIfNeeded(string manifestPath, int indent = 2)
         {
             if (!File.Exists(manifestPath))
             {
                 Debug.LogError($"{manifestPath} not found!");
-                return;
+                return false;
             }
             var jsonText = File.ReadAllText(manifestPath)
                 .Replace("{ }", "{\n}")
@@ -90,7 +90,7 @@ namespace com.IvanMurzak.Unity.MCP.Installer
             if (manifestJson == null)
             {
                 Debug.LogError($"Failed to parse {manifestPath} as JSON.");
-                return;
+                return false;
             }
 
             var modified = false;
@@ -162,6 +162,8 @@ namespace com.IvanMurzak.Unity.MCP.Installer
             // --- Write changes back to manifest
             if (modified)
                 File.WriteAllText(manifestPath, manifestJson.ToString(indent).Replace("\" : ", "\": "));
+
+            return true;
         }
     }
 }

--- a/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
@@ -8,7 +8,10 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 #nullable enable
+using System.IO;
+using System.Runtime.CompilerServices;
 using UnityEditor;
+using UnityEngine;
 
 namespace com.IvanMurzak.Unity.MCP.Installer
 {
@@ -21,8 +24,46 @@ namespace com.IvanMurzak.Unity.MCP.Installer
         static Installer()
         {
 #if !IVAN_MURZAK_INSTALLER_PROJECT
-            AddScopedRegistryIfNeeded(ManifestPath);
+            if (AddScopedRegistryIfNeeded(ManifestPath))
+                DeleteSelf();
 #endif
+        }
+
+        static void DeleteSelf([CallerFilePath] string callerFilePath = "")
+        {
+            var dataPath = Application.dataPath.Replace("\\", "/");
+            var filePath = callerFilePath.Replace("\\", "/");
+
+            if (!filePath.StartsWith(dataPath))
+            {
+                Debug.LogWarning($"[Installer] Cannot determine asset path for: {filePath}");
+                return;
+            }
+
+            var relativePath = "Assets" + filePath.Substring(dataPath.Length);
+            var installerFolder = Path.GetDirectoryName(relativePath)!.Replace("\\", "/");
+
+            EditorApplication.delayCall += () =>
+            {
+                if (!AssetDatabase.IsValidFolder(installerFolder))
+                    return;
+
+                AssetDatabase.DeleteAsset(installerFolder);
+                Debug.Log($"[Installer] Deleted installer folder: {installerFolder}");
+
+                var parentFolder = Path.GetDirectoryName(installerFolder)!.Replace("\\", "/");
+                if (AssetDatabase.IsValidFolder(parentFolder))
+                {
+                    var remaining = AssetDatabase.FindAssets("", new[] { parentFolder });
+                    if (remaining.Length == 0)
+                    {
+                        AssetDatabase.DeleteAsset(parentFolder);
+                        Debug.Log($"[Installer] Cleaned up empty parent folder: {parentFolder}");
+                    }
+                }
+
+                AssetDatabase.Refresh();
+            };
         }
     }
 }


### PR DESCRIPTION
After AddScopedRegistryIfNeeded completes successfully, the installer schedules its own folder deletion via EditorApplication.delayCall. On first import the manifest is modified triggering a domain reload; on the subsequent reload the installer detects no changes needed and the delayCall fires to remove the installer assets. Parent folder is cleaned up if empty.