### PR TITLE
Restrict Claude workflow to authorized user

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,11 +22,13 @@ on:
 jobs:
   claude:
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'IvanMurzak' && (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
Added access control to the Claude workflow by restricting execution to a specific authorized user (IvanMurzak).

## Key Changes
- Added `github.actor == 'IvanMurzak'` check as the primary condition in the workflow's `if` statement
- Wrapped all existing trigger conditions in parentheses to ensure proper logical evaluation with the new actor check
- The workflow now only executes when triggered by the authorized user AND one of the existing conditions is met (workflow_dispatch, @claude mentions in comments/reviews, or @claude in issues)

## Implementation Details
This change implements a security measure to prevent unauthorized users from triggering the Claude workflow, while maintaining all existing trigger mechanisms for the authorized user. The actor check is evaluated first, short-circuiting the condition if the user is not authorized.

https://claude.ai/code/session_01HztriVo8ddKTnvGsHaxowx