### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,11 @@ jobs:
 
       - name: Find previous version tag
         id: prev_tag
-        uses: WyriHaximus/github-action-get-previous-tag@v1
+        uses: WyriHaximus/github-action-get-previous-tag@v2
 
       - name: Check if tag exists
         id: tag_exists
-        uses: mukunku/tag-exists-action@v1.6.0
+        uses: mukunku/tag-exists-action@v1.7.0
         with:
           tag: ${{ steps.get_version.outputs.current-version }}
 


### PR DESCRIPTION
## Summary
This PR updates two GitHub Actions used in the release workflow to their latest versions.

## Changes
- Updated `WyriHaximus/github-action-get-previous-tag` from v1 to v2
- Updated `mukunku/tag-exists-action` from v1.6.0 to v1.7.0

## Details
These are routine dependency updates for the CI/CD release workflow. The updates ensure the workflow uses the latest bug fixes and features from these GitHub Actions.

https://claude.ai/code/session_0111mqFbqgxHBikeR7TDzfXk