### PR TITLE
Update deployment workflow: remove auto-release trigger and improve NuGet auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          version=${{ inputs.version || github.event.release.tag_name }}
+          version=${{ inputs.version }}
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "Extracted version: $version"
 
@@ -135,7 +135,7 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          version=${{ inputs.version || github.event.release.tag_name }}
+          version=${{ inputs.version }}
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "Extracted version: $version"
 


### PR DESCRIPTION
## Summary
This PR updates the CI/CD deployment workflow to improve security and flexibility by removing automatic deployment on GitHub releases and implementing trusted publishing for NuGet package deployment. It also updates the Node.js version used in the workflow.

## Key Changes
- **Removed automatic release trigger**: Deleted the `release` event trigger (types: [released]) from the workflow, requiring manual `workflow_dispatch` for all deployments
- **Implemented NuGet Trusted Publishing**: Added `NuGet/login@v1` action to securely authenticate with NuGet using OIDC-based trusted publishing instead of hardcoded API keys
- **Updated NuGet push authentication**: Changed from placeholder `--api-key az` to using the dynamically generated API key from the trusted publishing step (`${{ steps.nuget-login.outputs.NUGET_API_KEY }}`)
- **Updated Node.js version**: Bumped Node.js from version 22 to 24 in the workflow environment

## Implementation Details
The NuGet trusted publishing approach eliminates the need to store and manage API keys as secrets, improving security posture by using OpenID Connect (OIDC) for authentication. All deployments now require explicit manual triggering via `workflow_dispatch`, providing better control over release timing.

https://claude.ai/code/session_01SFa8eax1YRQBe5KZxzCeTj