### PR TITLE
Add publish-test-results workflow & upload event

### DIFF
--- a/.github/workflows/publish_test_results.yml
+++ b/.github/workflows/publish_test_results.yml
@@ -17,6 +17,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   checks: write
   pull-requests: write
 
@@ -37,7 +38,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event file for */event.json
+          event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: artifacts/Test results for */**/*.xml
           comment_mode: changes in failures

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -16,6 +16,15 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  save-event-file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save event file for publish workflow
+        uses: actions/upload-artifact@v6
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+
   test-cli:
     uses: ./.github/workflows/test_cli.yml
 

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -109,10 +109,3 @@ jobs:
           name: Test results for ${{ inputs.unityVersion }} ${{ inputs.testMode }} on ${{ matrix.platform }}
           path: ${{ steps.tests.outputs.artifactsPath }}
 
-      # --------------------------------------------------------------------- #
-      - name: Save event file for publish workflow
-        uses: actions/upload-artifact@v6
-        if: always()
-        with:
-          name: Event file for ${{ inputs.unityVersion }} ${{ inputs.testMode }} on ${{ matrix.platform }}
-          path: ${{ github.event_path }}


### PR DESCRIPTION
Introduce a new workflow (publish_test_results.yml) that runs after the 'test-pull-request' workflow completes, downloads test artifacts, and publishes unit test results using EnricoMi/publish-unit-test-result-action (uses base-repo write token to support fork PRs).

Modify test_unity_plugin.yml to remove the inline publish step and related options (githubToken/checkName/comment_mode) and instead upload the workflow event file as an artifact so the new publish workflow can consume and publish the results.