### PR TITLE
Update unity-editor.ts

### DIFF
--- a/cli/src/utils/unity-editor.ts
+++ b/cli/src/utils/unity-editor.ts
@@ -180,18 +180,21 @@ export function resolveEditorPath(editorDir: string, os: string): string {
     return editorDir;
   }
 
+  // Use platform-appropriate path joining: posix for non-Windows, native for Windows
+  const join = os === 'win32' ? path.join : path.posix.join;
+
   switch (os) {
     case 'win32':
-      return path.join(editorDir, 'Editor', 'Unity.exe');
+      return join(editorDir, 'Editor', 'Unity.exe');
     case 'darwin':
       // If path already ends with .app (e.g. Unity Hub returns ".../Unity.app"),
       // go directly into Contents/MacOS/Unity instead of appending another Unity.app
       if (editorDir.endsWith('.app')) {
-        return path.join(editorDir, 'Contents', 'MacOS', 'Unity');
+        return join(editorDir, 'Contents', 'MacOS', 'Unity');
       }
-      return path.join(editorDir, 'Unity.app', 'Contents', 'MacOS', 'Unity');
+      return join(editorDir, 'Unity.app', 'Contents', 'MacOS', 'Unity');
     default:
-      return path.join(editorDir, 'Editor', 'Unity');
+      return join(editorDir, 'Editor', 'Unity');
   }
 }
 


### PR DESCRIPTION
This pull request updates the `resolveEditorPath` function in `cli/src/utils/unity-editor.ts` to improve cross-platform path handling. The main change is to ensure that path joining uses the correct method for Windows and non-Windows platforms, preventing potential issues with path formatting.

Path handling improvements:

* Introduced a platform-aware `join` function that uses `path.join` for Windows (`win32`) and `path.posix.join` for other operating systems, ensuring paths are constructed correctly across platforms.
* Updated all path joining in the switch statement to use the new `join` function instead of always using `path.join`, improving reliability for macOS and Linux users.