### PR TITLE
feat: add setup alert panel for AI agent configuration

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
@@ -73,6 +73,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
         protected VisualElement? Root { get; private set; }
         protected VisualElement? ContainerUnderHeader { get; private set; }
+        protected VisualElement? ContainerAlert { get; private set; }
         protected VisualElement? ContainerHttp { get; private set; }
         protected VisualElement? ContainerStdio { get; private set; }
         protected VisualElement? ContainerSkills { get; private set; }
@@ -238,12 +239,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             Root = root;
             ContainerUnderHeader = root.Q<VisualElement>("containerUnderHeader") ?? throw new NullReferenceException("VisualElement 'containerUnderHeader' not found in UI.");
+            ContainerAlert = root.Q<VisualElement>("containerAlert") ?? throw new NullReferenceException("VisualElement 'containerAlert' not found in UI.");
             ContainerHttp = root.Q<VisualElement>("containerHttp") ?? throw new NullReferenceException("VisualElement 'containerHttp' not found in UI.");
             ContainerStdio = root.Q<VisualElement>("containerStdio") ?? throw new NullReferenceException("VisualElement 'containerStdio' not found in UI.");
             ContainerSkills = root.Q<VisualElement>("containerSkills") ?? throw new NullReferenceException("VisualElement 'containerSkills' not found in UI.");
 
             OnUICreated(root);
             SetupSkillsUI();
+            SetupAlertPanel();
             McpWindowBase.EnableSmoothFoldoutTransitions(root);
             return root;
         }
@@ -288,7 +291,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             return this;
         }
 
-        protected virtual AiAgentConfigurator SetTutorialUrl(string url, string label = "YouTube")
+        protected virtual AiAgentConfigurator SetTutorialUrl(string url, string label = "YouTube Tutorial")
         {
             ThrowIfRootNotSet();
             var tutorialLink = Root!.Q<Label>("tutorialLink");
@@ -346,12 +349,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 var anyConfigured = ConfigStdio.IsDetected() || ConfigHttp.IsDetected();
                 _configElementStdio.UpdateStatus(isAnyConfigured: anyConfigured);
                 _configElementHttp.UpdateStatus(isAnyConfigured: anyConfigured);
+                UpdateAlertPanel();
             });
             _subscriptionHttp = _configElementHttp.OnConfigured.Subscribe(_ =>
             {
                 var anyConfigured = ConfigStdio.IsDetected() || ConfigHttp.IsDetected();
                 _configElementStdio.UpdateStatus(isAnyConfigured: anyConfigured);
                 _configElementHttp.UpdateStatus(isAnyConfigured: anyConfigured);
+                UpdateAlertPanel();
             });
 
             ContainerStdio!.Add(_configElementStdio.Root);
@@ -397,6 +402,58 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             new UITemplate<VisualElement>("Editor/UI/uxml/agents/elements/TemplateSkillsSection.uxml").Value;
 
         /// <summary>
+        /// Builds the setup alert panel inside <see cref="ContainerAlert"/>.
+        /// Shows a warning when neither skills nor MCP configuration is set up.
+        /// Override in subclasses to suppress (e.g. Custom configurator).
+        /// </summary>
+        protected virtual void SetupAlertPanel()
+        {
+            if (ContainerAlert == null)
+                return;
+
+            ContainerAlert.Clear();
+
+            var title = new Label("Setup Required") { name = "alertTitle" };
+            title.AddToClassList("alert-frame-title");
+
+            var message = new Label("At least one of the following must be configured:") { name = "alertMessage" };
+            message.AddToClassList("alert-frame-message");
+
+            ContainerAlert.Add(title);
+            ContainerAlert.Add(message);
+
+            if (SupportsSkills)
+            {
+                var skillsItem = new Label("\u2022 Skills (Recommended)") { name = "alertItemSkills" };
+                skillsItem.AddToClassList("alert-frame-item");
+                skillsItem.AddToClassList("alert-frame-item-recommended");
+                ContainerAlert.Add(skillsItem);
+            }
+
+            var mcpItem = new Label("\u2022 MCP Configuration") { name = "alertItemMcp" };
+            mcpItem.AddToClassList("alert-frame-item");
+            ContainerAlert.Add(mcpItem);
+
+            ContainerAlert.AddToClassList("alert-frame");
+            UpdateAlertPanel();
+        }
+
+        /// <summary>
+        /// Updates the visibility of the alert panel based on current configuration state.
+        /// </summary>
+        protected virtual void UpdateAlertPanel()
+        {
+            if (ContainerAlert == null)
+                return;
+
+            var isMcpConfigured = ConfigStdio.IsDetected() || ConfigHttp.IsDetected();
+            var hasSkills = SupportsSkills && UnityMcpPluginEditor.IsAutoGenerateSkills(AgentId);
+            var isSetupComplete = isMcpConfigured || hasSkills;
+
+            ContainerAlert.style.display = isSetupComplete ? DisplayStyle.None : DisplayStyle.Flex;
+        }
+
+        /// <summary>
         /// Builds the skills UI inside <see cref="ContainerSkills"/>.
         /// Override in subclasses that need a custom layout (e.g. editable path field).
         /// </summary>
@@ -439,6 +496,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
                 if (evt.newValue)
                     UnityMcpPluginEditor.Instance.McpPluginInstance!.GenerateSkillFiles(UnityMcpPluginEditor.ProjectRootPath);
+
+                UpdateAlertPanel();
             });
 
             // Configure generate button

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/AiAgentConfigurators/Impl/CustomConfigurator.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/AiAgentConfigurators/Impl/CustomConfigurator.cs
@@ -52,12 +52,50 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             return this;
         }
 
+        protected override void SetupAlertPanel()
+        {
+            if (ContainerAlert == null)
+                return;
+
+            ContainerAlert.Clear();
+
+            var title = new Label("Setup Required") { name = "alertTitle" };
+            title.AddToClassList("alert-frame-title");
+
+            var message = new Label("Skills should be configured for AI agents to work properly:") { name = "alertMessage" };
+            message.AddToClassList("alert-frame-message");
+
+            var skillsItem = new Label("\u2022 Enable Auto-generate Skills below") { name = "alertItemSkills" };
+            skillsItem.AddToClassList("alert-frame-item");
+            skillsItem.AddToClassList("alert-frame-item-recommended");
+
+            ContainerAlert.Add(title);
+            ContainerAlert.Add(message);
+            ContainerAlert.Add(skillsItem);
+
+            ContainerAlert.AddToClassList("alert-frame");
+            UpdateAlertPanel();
+        }
+
+        protected override void UpdateAlertPanel()
+        {
+            if (ContainerAlert == null)
+                return;
+
+            // Custom configurator can only validate skills (no MCP config detection)
+            var hasSkills = SupportsSkills && UnityMcpPluginEditor.IsAutoGenerateSkills(AgentId);
+            ContainerAlert.style.display = hasSkills ? DisplayStyle.None : DisplayStyle.Flex;
+        }
+
         protected override void OnUICreated(VisualElement root)
         {
             SetAgentIcon();
             SetTransportMethod(UnityMcpPluginEditor.TransportMethod);
             SetAgentName(AgentName);
             DisableLinksContainer();
+
+            // Add spacing between title and skills section
+            ContainerUnderHeader!.style.marginBottom = 4;
 
             // STDIO Configuration
 
@@ -124,6 +162,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
                 if (evt.newValue)
                     UnityMcpPluginEditor.Instance.McpPluginInstance!.GenerateSkillFiles(UnityMcpPluginEditor.ProjectRootPath);
+
+                UpdateAlertPanel();
             });
 
             // Configure generate button

--- a/Unity-MCP-Plugin/Assets/root/Editor/UI/uss/MainWindow.uss
+++ b/Unity-MCP-Plugin/Assets/root/Editor/UI/uss/MainWindow.uss
@@ -129,6 +129,47 @@
     -unity-font-style: italic;
 }
 
+/* ==========================================================================
+   Alert Frame - Setup required notification panel
+   ========================================================================== */
+
+.alert-frame {
+    background-color: rgba(180, 120, 40, 0.12);
+    border-radius: 10px;
+    border-width: 1px;
+    border-color: rgba(220, 160, 60, 0.45);
+    padding: 10px 12px;
+    margin-top: 8px;
+    margin-bottom: 4px;
+}
+
+.alert-frame-title {
+    font-size: 13px;
+    -unity-font-style: bold;
+    color: rgb(255, 200, 100);
+    margin-bottom: 4px;
+}
+
+.alert-frame-message {
+    font-size: 12px;
+    color: rgb(210, 180, 130);
+    white-space: normal;
+    margin-bottom: 2px;
+}
+
+.alert-frame-item {
+    font-size: 12px;
+    color: rgb(210, 180, 130);
+    white-space: normal;
+    padding-left: 8px;
+    margin-bottom: 1px;
+}
+
+.alert-frame-item-recommended {
+    color: rgb(255, 200, 100);
+    -unity-font-style: bold;
+}
+
 .frame-mcp-server {
     /* background-color: rgba(20, 40, 69, 0.2); */
     border-radius: 10px;

--- a/Unity-MCP-Plugin/Assets/root/Editor/UI/uxml/agents/AiAgentTemplateConfig.uxml
+++ b/Unity-MCP-Plugin/Assets/root/Editor/UI/uxml/agents/AiAgentTemplateConfig.uxml
@@ -16,6 +16,9 @@
         <!-- Under header container -->
         <ui:VisualElement name="containerUnderHeader" />
 
+        <!-- Alert container - shown when setup is incomplete -->
+        <ui:VisualElement name="containerAlert" style="display: none;" />
+
         <!-- Skills container -->
         <ui:VisualElement name="containerSkills" />
 


### PR DESCRIPTION
## Summary
- Add a styled alert frame (amber border, rounded corners) in the AI agent card that warns when neither skills nor MCP configuration is set up
- Alert refreshes reactively on: agent switch, transport/auth/token changes, Configure/Remove button clicks, and skills auto-generate toggle
- Custom agent gets a skills-only alert variant (MCP config can't be validated for custom setups)
- Add spacing between title and skills section in Custom agent UI
- Rename tutorial link label from "YouTube" to "YouTube Tutorial"

## Test plan
- [x] Select an agent with no skills and no MCP configured — alert should be visible
- [x] Click "Configure" for MCP — alert should disappear
- [x] Click "Remove" for MCP config — alert should reappear
- [x] Enable auto-generate skills toggle — alert should disappear
- [x] Disable auto-generate skills toggle (with no MCP config) — alert should reappear
- [x] Switch between agents — alert should refresh based on each agent's state
- [x] Switch transport (stdio/http) — alert should refresh
- [x] Select "Other - Custom" agent — should show skills-only alert variant
- [x] Verify tutorial link now reads "YouTube Tutorial"