### PR TITLE
fix: stop MCP server before installing package update

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
@@ -123,10 +123,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             installButton.SetEnabled(false);
 
-            if (McpServerManager.IsRunning)
+            var currentStatus = McpServerManager.ServerStatus.CurrentValue;
+            if (currentStatus == McpServerStatus.Running || currentStatus == McpServerStatus.Starting ||
+                currentStatus == McpServerStatus.Stopping)
             {
                 installButton.text = "Stopping server...";
-                McpServerManager.StopServer();
+                if (currentStatus != McpServerStatus.Stopping)
+                    McpServerManager.StopServer();
                 _stopSubscription = McpServerManager.ServerStatus
                     .Where(status => status == McpServerStatus.Stopped)
                     .Take(1)


### PR DESCRIPTION
  Fixes #586

  ## Root Cause
  The server process holds open file handles on the binary in  `Library/mcp-server/{platform}/`, so the OS rejects overwrites when UPM  tries to install the update.

  ## Fix
  `OnInstallUpdateClicked()` now checks `McpServerManager.IsRunning`. If the  server is running, the button shows "Stopping server...", `StopServer()` is  called, and an R3 observable waits for `McpServerStatus.Stopped` before  proceeding. Install logic is extracted into `StartPackageInstall()`. The  subscription is disposed in `OnDestroy()` to avoid a dangling callback if  the window is closed mid-wait.

  Reuses the stop-then-act pattern from `MainWindowEditor.AiAgents.cs`  (`RestartServerIfWasRunning`).

  ## Testing
  Verified with MCP server running — button shows "Stopping server..." →  "Installing..." and the package installs without file-lock errors.