### PR TITLE
fix: screenshot tests fail when LogLevel is None

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Screenshot/ScreenshotGameViewTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Screenshot/ScreenshotGameViewTests.cs
@@ -144,14 +144,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             CloseGameView();
 
-            LogAssert.Expect(LogType.Error, new Regex("No Game View window|Game View render texture is not available"));
-            var raw = RunToolRaw("screenshot-game-view", "{}");
+            LogAssert.ignoreFailingMessages = true;
+            try
+            {
+                var raw = RunToolRaw("screenshot-game-view", "{}");
 
-            Assert.IsNotNull(raw, "Raw result must not be null");
-            Assert.IsTrue(
-                raw.Contains("No Game View window") ||
-                raw.Contains("Game View render texture is not available"),
-                $"Expected a known error message. Actual JSON:\n{raw}");
+                Assert.IsNotNull(raw, "Raw result must not be null");
+                Assert.IsTrue(
+                    raw.Contains("No Game View window") ||
+                    raw.Contains("Game View render texture is not available"),
+                    $"Expected a known error message. Actual JSON:\n{raw}");
+            }
+            finally
+            {
+                LogAssert.ignoreFailingMessages = false;
+            }
         }
     }
 }

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Screenshot/ScreenshotSceneViewTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Screenshot/ScreenshotSceneViewTests.cs
@@ -124,13 +124,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             CloseSceneView();
 
-            LogAssert.Expect(LogType.Error, new Regex("No Scene View|Scene View camera"));
-            var raw = RunToolRaw("screenshot-scene-view", @"{""width"": 320, ""height"": 240}");
+            LogAssert.ignoreFailingMessages = true;
+            try
+            {
+                var raw = RunToolRaw("screenshot-scene-view", @"{""width"": 320, ""height"": 240}");
 
-            Assert.IsNotNull(raw, "Raw result should not be null");
-            Assert.IsTrue(
-                raw.Contains("No Scene View") || raw.Contains("Scene View camera"),
-                $"Expected 'No Scene View' error message. Actual JSON:\n{raw}");
+                Assert.IsNotNull(raw, "Raw result should not be null");
+                Assert.IsTrue(
+                    raw.Contains("No Scene View") || raw.Contains("Scene View camera"),
+                    $"Expected 'No Scene View' error message. Actual JSON:\n{raw}");
+            }
+            finally
+            {
+                LogAssert.ignoreFailingMessages = false;
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- Fix `ScreenshotGameView_ViaRunTool_WhenRenderTextureNotReady_ReturnsErrorJson` and `ScreenshotSceneView_ViaRunTool_WhenNoSceneView_ReturnsErrorJson` failing when LogLevel is set to None
- Replace `LogAssert.Expect` with `LogAssert.ignoreFailingMessages` — the MCP framework only emits `Debug.LogError` when logging is enabled, so `LogAssert.Expect` fails with "Expected log did not appear" when LogLevel=None
- `ignoreFailingMessages` works regardless of log level: suppresses error logs when present, no-ops when absent

## Test plan
- [x] Tests pass with LogLevel=None (no expected log to match)
- [x] Tests pass with default LogLevel (error logs are silently ignored)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)