### PR TITLE
fix: add Transform properties to serializable properties list

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Runtime/Converter/Reflection/Component/Impl/UnityEngine_Transform_ReflectionConverter.cs
+++ b/Unity-MCP-Plugin/Assets/root/Runtime/Converter/Reflection/Component/Impl/UnityEngine_Transform_ReflectionConverter.cs
@@ -11,6 +11,8 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.ReflectorNet;
 
 namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
 {
@@ -22,6 +24,19 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
                 yield return property;
 
             yield return "parentInternal";
+        }
+
+        protected override IEnumerable<string> GetKnownSerializableProperties(Reflector reflector, object? obj)
+        {
+            return base.GetKnownSerializableProperties(reflector, obj).Concat(new[]
+            {
+                nameof(UnityEngine.Transform.position),
+                nameof(UnityEngine.Transform.localPosition),
+                nameof(UnityEngine.Transform.eulerAngles),
+                nameof(UnityEngine.Transform.localEulerAngles),
+                nameof(UnityEngine.Transform.localScale),
+                nameof(UnityEngine.Transform.childCount),
+            });
         }
     }
 }


### PR DESCRIPTION
## Problem

`gameobject-component-get` returns empty fields and properties when querying a Transform component. This means AI agents cannot read position, rotation, or scale data from any GameObject.

**Reproduction steps:**
1. Call `gameobject-component-get` on any GameObject's Transform component with `includeFields: true` and `includeProperties: true`
2. The response contains empty Fields and Properties arrays

## Root Cause

`UnityEngine_Transform_ReflectionConverter` does not override `GetKnownSerializableProperties()`. The base class (`UnityEngine_Object_ReflectionConverter`) returns `Enumerable.Empty<string>()` by default, so no Transform properties are included in serialization.

## Fix

Override `GetKnownSerializableProperties()` in the Transform converter to declare the core Transform properties:
- `position`, `localPosition`
- `eulerAngles`, `localEulerAngles`
- `localScale`
- `childCount`

This follows the same pattern already used by `UnityEngine_Material_ReflectionConverter`.

## Testing

After this fix, `gameobject-component-get` on a Transform returns:
```json
{
  "Properties": [
    {"name": "position", "value": {"x": 5.17, "y": -0.06, "z": 0}},
    {"name": "localScale", "value": {"x": 1, "y": 1, "z": 1}},
    ...
  ]
}
```