### PR TITLE
feat(cli): add self-update notification and update command

### DIFF
--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -1,0 +1,90 @@
+import { Command } from 'commander';
+import { spawn } from 'child_process';
+import { platform } from 'os';
+import * as ui from '../utils/ui.js';
+import { fetchLatestVersion, formatUpdateAvailable, isRunningViaNpx } from '../utils/update-check.js';
+import { isNewerVersion } from '../utils/semver.js';
+
+const PACKAGE_NAME = 'unity-mcp-cli';
+
+interface UpdateOptions {
+  check?: boolean;
+}
+
+function npmCommand(): string {
+  return platform() === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+function runNpmInstall(packageSpec: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(npmCommand(), ['install', '-g', packageSpec], {
+      stdio: 'inherit',
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}
+
+export function createUpdateCommand(currentVersion: string): Command {
+  return new Command('update')
+    .description('Update unity-mcp-cli to the latest version')
+    .option('--check', 'Only check for updates without installing')
+    .action(async (options: UpdateOptions) => {
+      if (isRunningViaNpx()) {
+        ui.info('Running via npx — it always fetches the latest published version.');
+        ui.info('No update action needed.');
+        process.exit(0);
+      }
+
+      const spinner = ui.startSpinner('Checking for updates...');
+      let latest: string;
+      try {
+        latest = await fetchLatestVersion();
+      } catch (err) {
+        spinner.error('Failed to check for updates');
+        ui.error((err as Error).message || String(err));
+        process.exit(1);
+        return;
+      }
+
+      if (!isNewerVersion(currentVersion, latest)) {
+        spinner.success(`Already up to date (v${currentVersion})`);
+        process.exit(0);
+      }
+
+      spinner.success(formatUpdateAvailable(currentVersion, latest));
+      console.log();
+
+      // --check mode: exit 2 = outdated (distinct from exit 1 = error)
+      if (options.check) {
+        process.exit(2);
+      }
+
+      ui.info(`Installing ${PACKAGE_NAME}@${latest}...`);
+      console.log();
+
+      try {
+        const exitCode = await runNpmInstall(`${PACKAGE_NAME}@${latest}`);
+
+        if (exitCode !== 0) {
+          console.log();
+          ui.error('Update failed.');
+          if (platform() === 'win32') {
+            ui.info('Try running the terminal as Administrator.');
+          } else {
+            ui.info(`Try: sudo npm install -g ${PACKAGE_NAME}@latest`);
+          }
+          process.exit(1);
+        }
+      } catch (err) {
+        console.log();
+        ui.error(`Could not run npm: ${(err as Error).message}`);
+        ui.info('Make sure npm is installed and in your PATH.');
+        process.exit(1);
+      }
+
+      console.log();
+      ui.success(`Updated to v${latest}`);
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,8 +12,10 @@ import { runSystemToolCommand } from './commands/run-system-tool.js';
 import { setupMcpCommand } from './commands/setup-mcp.js';
 import { setupSkillsCommand } from './commands/setup-skills.js';
 import { statusCommand } from './commands/status.js';
+import { createUpdateCommand } from './commands/update.js';
 import { waitForReadyCommand } from './commands/wait-for-ready.js';
 import { configureStyledHelp, error as uiError, setVerbose } from './utils/ui.js';
+import { checkForUpdate, isRunningViaNpx, printUpdateNotification } from './utils/update-check.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json') as { version: string };
@@ -40,6 +42,7 @@ const subcommands = [
   setupMcpCommand,
   setupSkillsCommand,
   statusCommand,
+  createUpdateCommand(pkg.version),
   waitForReadyCommand,
 ];
 
@@ -65,7 +68,17 @@ program.action(() => {
   program.outputHelp();
 });
 
-program.parseAsync().catch((err) => {
-  uiError((err as Error).message || String(err));
-  process.exit(1);
-});
+// Start update check in background (non-blocking, parallel with command execution)
+const updateCheckPromise = isRunningViaNpx() ? Promise.resolve(null) : checkForUpdate(pkg.version);
+
+program.parseAsync()
+  .then(async () => {
+    const update = await updateCheckPromise;
+    if (update) {
+      printUpdateNotification(update.current, update.latest);
+    }
+  })
+  .catch((err) => {
+    uiError((err as Error).message || String(err));
+    process.exit(1);
+  });

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { isNewerVersion, isValidVersion } from './semver.js';
 import * as ui from './ui.js';
 
 const PACKAGE_ID = 'com.ivanmurzak.unity.mcp';
@@ -81,17 +82,8 @@ export function shouldUpdateVersion(currentVersion: string, newVersion: string):
     return false;
   }
 
-  const numericOnly = /^\d+(\.\d+)*$/;
-  if (numericOnly.test(currentVersion) && numericOnly.test(newVersion)) {
-    const currentParts = currentVersion.split('.').map(Number);
-    const targetParts = newVersion.split('.').map(Number);
-    const len = Math.max(currentParts.length, targetParts.length);
-    for (let i = 0; i < len; i++) {
-      const c = currentParts[i] ?? 0;
-      const t = targetParts[i] ?? 0;
-      if (t !== c) return t > c;
-    }
-    return false;
+  if (isValidVersion(currentVersion) && isValidVersion(newVersion)) {
+    return isNewerVersion(currentVersion, newVersion);
   }
 
   return newVersion.toLowerCase() > currentVersion.toLowerCase();

--- a/cli/src/utils/semver.ts
+++ b/cli/src/utils/semver.ts
@@ -1,0 +1,26 @@
+const SEMVER_NUMERIC = /^\d+(\.\d+)*$/;
+
+/** Returns true if the string is a valid numeric semver (e.g. "1.2.3"). */
+export function isValidVersion(version: string): boolean {
+  return SEMVER_NUMERIC.test(version);
+}
+
+/** Returns -1 if a < b, 0 if equal, 1 if a > b. */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+/** Returns true if `latest` is strictly greater than `current`. */
+export function isNewerVersion(current: string, latest: string): boolean {
+  return compareVersions(current, latest) < 0;
+}

--- a/cli/src/utils/update-check.ts
+++ b/cli/src/utils/update-check.ts
@@ -1,0 +1,110 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+import chalk from 'chalk';
+import { isNewerVersion, isValidVersion } from './semver.js';
+
+const PACKAGE_NAME = 'unity-mcp-cli';
+const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+const CACHE_FILE = join(homedir(), '.unity-mcp-cli-update.json');
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FETCH_TIMEOUT_MS = 3000;
+
+interface UpdateCache {
+  latestVersion: string;
+  lastChecked: number;
+}
+
+interface UpdateInfo {
+  current: string;
+  latest: string;
+}
+
+/** Fetch the latest version string from the npm registry. */
+export async function fetchLatestVersion(): Promise<string> {
+  const response = await fetch(NPM_REGISTRY_URL, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { 'Accept': 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`npm registry returned ${response.status}`);
+  }
+
+  const data = (await response.json()) as { version?: string };
+  if (!data.version) {
+    throw new Error('No version field in registry response');
+  }
+  return data.version;
+}
+
+function readCache(): UpdateCache | null {
+  try {
+    const raw = readFileSync(CACHE_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as UpdateCache;
+    if (parsed.latestVersion && typeof parsed.lastChecked === 'number' && isValidVersion(parsed.latestVersion)) {
+      return parsed;
+    }
+  } catch {
+    // Cache missing or corrupt — ignore
+  }
+  return null;
+}
+
+function writeCache(latestVersion: string): void {
+  try {
+    const data: UpdateCache = { latestVersion, lastChecked: Date.now() };
+    writeFileSync(CACHE_FILE, JSON.stringify(data), 'utf-8');
+  } catch {
+    // Non-critical — ignore write failures
+  }
+}
+
+/**
+ * Check if a newer version is available on npm.
+ * Returns update info if available, null otherwise.
+ * Never throws — all errors are silently caught.
+ */
+export async function checkForUpdate(currentVersion: string): Promise<UpdateInfo | null> {
+  try {
+    // Check cache first
+    const cache = readCache();
+    if (cache && Date.now() - cache.lastChecked < CACHE_TTL_MS) {
+      if (isNewerVersion(currentVersion, cache.latestVersion)) {
+        return { current: currentVersion, latest: cache.latestVersion };
+      }
+      return null;
+    }
+
+    // Fetch fresh
+    const latest = await fetchLatestVersion();
+    writeCache(latest);
+
+    if (isNewerVersion(currentVersion, latest)) {
+      return { current: currentVersion, latest };
+    }
+  } catch {
+    // Best-effort — never disrupt CLI usage
+  }
+  return null;
+}
+
+/** Format the "update available" message with chalk styling. */
+export function formatUpdateAvailable(current: string, latest: string): string {
+  return `Update available: ${chalk.dim(current)} → ${chalk.green(latest)}`;
+}
+
+/** Print a styled update notification to stderr (does not interfere with stdout piping). */
+export function printUpdateNotification(current: string, latest: string): void {
+  console.error();
+  console.error(chalk.yellow(`  ${formatUpdateAvailable(current, latest)}`));
+  console.error(chalk.dim(`  Run ${chalk.cyan(`npm i -g ${PACKAGE_NAME}`)} to update`));
+  console.error();
+}
+
+/** Returns true if the CLI was likely invoked via npx. */
+export function isRunningViaNpx(): boolean {
+  const execPath = process.env['npm_execpath'] ?? '';
+  const npmCommand = process.env['npm_command'] ?? '';
+  return execPath.includes('npx') || npmCommand === 'exec';
+}


### PR DESCRIPTION
## Summary

- **Passive update notification**: On every CLI run, checks npm registry in the background (parallel with command execution) and shows a styled notification after command output if a newer version exists. Cached for 24 hours, 3-second timeout, silent on errors — never disrupts CLI usage. Skipped when running via `npx`.
- **`unity-mcp-cli update` subcommand**: Explicitly updates the globally installed package via `npm install -g`. Includes `--check` flag for scripting (exit 0 = up-to-date, exit 2 = outdated). OS-aware permission error guidance.
- **Shared semver utilities**: Extracted version comparison into `semver.ts`, refactored `manifest.ts` to reuse it (eliminating duplicated comparison logic).

### New files
| File | Purpose |
|---|---|
| `cli/src/utils/semver.ts` | Lightweight version comparison (zero deps) |
| `cli/src/utils/update-check.ts` | npm registry fetch, cache, notification formatting |
| `cli/src/commands/update.ts` | `update` subcommand |

### Modified files
| File | Change |
|---|---|
| `cli/src/index.ts` | Wire up background check + register update command |
| `cli/src/utils/manifest.ts` | Reuse `semver.ts` instead of inline comparison |

**Zero new dependencies** — uses Node's built-in `fetch()` (Node 20+).

## Test plan

- [x] All 173 existing tests pass
- [x] Run `unity-mcp-cli update --check` — should show current vs latest
- [x] Run `unity-mcp-cli update` — should install latest version
- [x] Run `npx unity-mcp-cli update` — should show "running via npx" message
- [x] Run any command (e.g. `unity-mcp-cli --help`) — should show update banner if outdated
- [x] Verify no notification appears when version is current
- [x] Verify no notification appears when offline (silent failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)