### PR TITLE
fix: run console-clear-logs tool on main thread

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Console.ClearLogs.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Console.ClearLogs.cs
@@ -12,6 +12,7 @@
 using System;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
 using UnityEngine;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
@@ -31,16 +32,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "Useful for isolating errors related to a specific action by clearing logs before performing the action.")]
         public void ClearLogs(string? nothing = null)
         {
-            Debug.ClearDeveloperConsole();
+            MainThread.Instance.Run(() =>
+            {
+                Debug.ClearDeveloperConsole();
 
-            if (!UnityMcpPluginEditor.HasInstance)
-                throw new InvalidOperationException("UnityMcpPluginEditor is not initialized.");
+                if (!UnityMcpPluginEditor.HasInstance)
+                    throw new InvalidOperationException("UnityMcpPluginEditor is not initialized.");
 
-            var logCollector = UnityMcpPluginEditor.Instance.LogCollector;
-            if (logCollector == null)
-                throw new InvalidOperationException("LogCollector is not initialized.");
+                var logCollector = UnityMcpPluginEditor.Instance.LogCollector;
+                if (logCollector == null)
+                    throw new InvalidOperationException("LogCollector is not initialized.");
 
-            logCollector.Clear();
+                logCollector.Clear();
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wraps `ClearLogs` tool body in `MainThread.Instance.Run()` to ensure `Debug.ClearDeveloperConsole()` and related Unity API calls execute on the main thread
- Follows the same pattern used by all other MCP tools (e.g., `Assets.Prefab.Open`, `Assets.Copy`, etc.)

Closes #632

## Test plan
- [x] Execute `console-clear-logs` tool via MCP client and verify no errors
- [ ] Verify Unity Editor console is cleared successfully
- [ ] Verify MCP log cache is cleared successfully