### PR TITLE
Add background thread tests and expand MCP tool test coverage

### DIFF
--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/BaseTest.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/BaseTest.cs
@@ -9,9 +9,11 @@
 */
 
 #nullable enable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.ReflectorNet;
 using com.IvanMurzak.Unity.MCP.Utils;
@@ -95,6 +97,40 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.IsFalse(jsonResult.Contains("[Warning]"), $"Tool call contains warnings in JSON: {jsonResult}");
 
             return result;
+        }
+
+        /// <summary>
+        /// Runs an action on a background thread and yields frames until completion.
+        /// This is used to test that tools correctly dispatch to the main thread via MainThread.Instance.Run().
+        /// Between each yield return null, Unity processes EditorApplication.update callbacks,
+        /// which is the mechanism tools use to dispatch work from background threads to the main thread.
+        /// </summary>
+        protected IEnumerator RunOnBackgroundThread(Action action, float timeoutSeconds = 30f)
+        {
+            Exception? capturedException = null;
+
+            var task = Task.Run(() =>
+            {
+                try
+                {
+                    action();
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ex;
+                }
+            });
+
+            var startTime = Time.realtimeSinceStartup;
+            while (!task.IsCompleted && (Time.realtimeSinceStartup - startTime) < timeoutSeconds)
+                yield return null;
+
+            Assert.IsTrue(task.IsCompleted,
+                $"Background thread task did not complete within {timeoutSeconds} seconds. " +
+                "Ensure the tool dispatches work to the main thread via MainThread.Instance.Run().");
+
+            if (capturedException != null)
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(capturedException).Throw();
         }
     }
 }

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsCreateFolderTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsCreateFolderTests.cs
@@ -14,6 +14,7 @@ using com.IvanMurzak.Unity.MCP.Editor.API;
 using com.IvanMurzak.Unity.MCP.Editor.Tests.Utils;
 using NUnit.Framework;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Tests
@@ -168,6 +169,30 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             StringAssert.Contains("folder name is empty or whitespace", jsonResult);
             yield return null;
+        }
+
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator CreateFolder_FromBackgroundThread_Succeeds()
+        {
+            // Setup parent folder on main thread first
+            new CreateFolderExecutor("Assets", TestFolderName).Execute();
+            yield return null;
+
+            // Create child folder from background thread
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Assets.AssetsCreateFolderToolId, $@"{{
+                    ""inputs"": [{{
+                        ""parentFolderPath"": ""Assets/{TestFolderName}"",
+                        ""newFolderName"": ""BGThreadFolder""
+                    }}]
+                }}"));
+
+            // Verify on main thread
+            AssetDatabase.Refresh();
+            Assert.IsTrue(AssetDatabase.IsValidFolder($"Assets/{TestFolderName}/BGThreadFolder"),
+                "Folder created from background thread should exist");
         }
 
         [UnityTest]

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsFindTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsFindTests.cs
@@ -1,0 +1,224 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections;
+using System.Text.Json;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    [TestFixture]
+    public class AssetsFindTests : BaseTest
+    {
+        bool? _originalEnabled;
+
+        [UnitySetUp]
+        public override IEnumerator SetUp()
+        {
+            yield return base.SetUp();
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            Assert.IsNotNull(toolManager, "ToolManager should not be null");
+
+            _originalEnabled = toolManager!.IsToolEnabled(Tool_Assets.AssetsFindToolId);
+            toolManager.SetToolEnabled(Tool_Assets.AssetsFindToolId, true);
+            UnityMcpPluginEditor.Instance.Save();
+        }
+
+        [UnityTearDown]
+        public override IEnumerator TearDown()
+        {
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            if (toolManager != null && _originalEnabled.HasValue)
+            {
+                toolManager.SetToolEnabled(Tool_Assets.AssetsFindToolId, _originalEnabled.Value);
+                UnityMcpPluginEditor.Instance.Save();
+            }
+
+            yield return base.TearDown();
+        }
+
+        // ── assets-find ───────────────────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator AssetsFind_NoFilter_FromMainThread_ReturnsAssets()
+        {
+            yield return null;
+
+            var json = RunTool(Tool_Assets.AssetsFindToolId, @"{
+                ""maxResults"": 5
+            }").Value!.GetMessage()!;
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("result", out var resultEl))
+                root = resultEl;
+
+            Assert.AreEqual(JsonValueKind.Array, root.ValueKind, "Result should be an array");
+            Assert.Greater(root.GetArrayLength(), 0, "Should return at least one asset");
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_NoFilter_FromBackgroundThread_ReturnsAssets()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var json = RunTool(Tool_Assets.AssetsFindToolId, @"{
+                    ""maxResults"": 5
+                }").Value!.GetMessage()!;
+
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("result", out var resultEl))
+                    root = resultEl;
+
+                Assert.AreEqual(JsonValueKind.Array, root.ValueKind, "Result should be an array from background thread");
+                Assert.Greater(root.GetArrayLength(), 0, "Should return at least one asset from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_DirectMethod_ReturnsAssets()
+        {
+            yield return null;
+
+            var tool = new Tool_Assets();
+            var results = tool.Find(maxResults: 5);
+            Assert.IsNotNull(results, "Find() should return non-null");
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_DirectMethod_FromBackgroundThread_ReturnsAssets()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Assets();
+                var results = tool.Find(maxResults: 5);
+                Assert.IsNotNull(results, "Find() should return non-null from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_FilterByScript_FromMainThread_ReturnsScripts()
+        {
+            yield return null;
+
+            var tool = new Tool_Assets();
+            var results = tool.Find(filter: "t:Script", maxResults: 10);
+            Assert.IsNotNull(results, "Find with type filter should return non-null");
+            // All results should be scripts
+            foreach (var asset in results)
+            {
+                Assert.IsNotNull(asset, "Asset reference should not be null");
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_FilterByScript_FromBackgroundThread_ReturnsScripts()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Assets();
+                var results = tool.Find(filter: "t:Script", maxResults: 10);
+                Assert.IsNotNull(results, "Find with type filter from background thread should return non-null");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_ViaRunTool_FilterByScript_FromMainThread_Succeeds()
+        {
+            yield return null;
+
+            RunTool(Tool_Assets.AssetsFindToolId, @"{
+                ""filter"": ""t:Script"",
+                ""maxResults"": 5
+            }");
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_ViaRunTool_FilterByScript_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Assets.AssetsFindToolId, @"{
+                    ""filter"": ""t:Script"",
+                    ""maxResults"": 5
+                }"));
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_WithSearchFolders_FromMainThread_Succeeds()
+        {
+            yield return null;
+
+            RunTool(Tool_Assets.AssetsFindToolId, @"{
+                ""filter"": ""t:Script"",
+                ""searchInFolders"": [""Assets""],
+                ""maxResults"": 5
+            }");
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_WithSearchFolders_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Assets.AssetsFindToolId, @"{
+                    ""filter"": ""t:Script"",
+                    ""searchInFolders"": [""Assets""],
+                    ""maxResults"": 5
+                }"));
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_MaxResultsZero_ThrowsArgumentException()
+        {
+            yield return null;
+
+            var tool = new Tool_Assets();
+            Assert.Throws<ArgumentException>(() => tool.Find(maxResults: 0));
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsFind_MaxResultsZero_FromBackgroundThread_ThrowsArgumentException()
+        {
+            yield return null;
+
+            Exception? caughtException = null;
+            yield return RunOnBackgroundThread(() =>
+            {
+                try
+                {
+                    var tool = new Tool_Assets();
+                    tool.Find(maxResults: 0);
+                }
+                catch (ArgumentException ex)
+                {
+                    caughtException = ex;
+                }
+            });
+
+            Assert.IsNotNull(caughtException, "Should throw ArgumentException from background thread too");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsFindTests.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsFindTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 268a27166b1c454aae06b765876e220b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsShaderTests.BackgroundThread.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsShaderTests.BackgroundThread.cs
@@ -1,0 +1,46 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public partial class AssetsShaderTests : BaseTest
+    {
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator ShaderListAll_FromBackgroundThread_ReturnsShaders()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Assets_Shader();
+                var result = tool.ListAll();
+                Assert.IsNotNull(result, "ListAll() should return non-null from background thread");
+                Assert.Greater(result.Count, 0, "Should return at least one shader from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator ShaderListAll_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Assets_Shader.AssetsShaderListAllToolId, "{}"));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsShaderTests.BackgroundThread.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsShaderTests.BackgroundThread.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c90fb375ccc34477a802957181a24351
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Console/TestToolConsole.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Console/TestToolConsole.cs
@@ -475,6 +475,45 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.IsTrue(result.Contains("'InvalidType'"), "Should contain the invalid value");
             Assert.IsTrue(result.Contains("Valid values:"), "Should list valid values");
         }
+
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator GetLogs_FromBackgroundThread_ReturnsLogs()
+        {
+            Debug.Log("[BG-Thread-Test] Log entry for background thread test");
+            yield return null; // Let the log be captured
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var result = _tool.GetLogs();
+                Assert.IsNotNull(result, "GetLogs() should return non-null from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator GetLogs_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("console-get-logs", "{}"));
+        }
+
+        [UnityTest]
+        public IEnumerator ClearLogs_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                _tool.ClearLogs();
+                // Verify logs are cleared
+                var result = _tool.GetLogs();
+                Assert.IsNotNull(result, "GetLogs() after clear should return non-null");
+                Assert.AreEqual(0, result.Length, "Logs should be empty after clear from background thread");
+            });
+        }
     }
 }
 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f106d8a3420140549fc889a7e8f84eb7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorApplicationTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorApplicationTests.cs
@@ -1,0 +1,116 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections;
+using System.Text.Json;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    [TestFixture]
+    public class EditorApplicationTests : BaseTest
+    {
+        bool? _originalEnabled;
+
+        [UnitySetUp]
+        public override IEnumerator SetUp()
+        {
+            yield return base.SetUp();
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            Assert.IsNotNull(toolManager, "ToolManager should not be null");
+
+            _originalEnabled = toolManager!.IsToolEnabled(Tool_Editor.EditorApplicationGetStateToolId);
+            toolManager.SetToolEnabled(Tool_Editor.EditorApplicationGetStateToolId, true);
+            UnityMcpPluginEditor.Instance.Save();
+        }
+
+        [UnityTearDown]
+        public override IEnumerator TearDown()
+        {
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            if (toolManager != null && _originalEnabled.HasValue)
+            {
+                toolManager.SetToolEnabled(Tool_Editor.EditorApplicationGetStateToolId, _originalEnabled.Value);
+                UnityMcpPluginEditor.Instance.Save();
+            }
+
+            yield return base.TearDown();
+        }
+
+        [UnityTest]
+        public IEnumerator GetApplicationState_FromMainThread_ReturnsValidState()
+        {
+            yield return null;
+
+            var result = RunTool(Tool_Editor.EditorApplicationGetStateToolId, "{}");
+            var json = result.Value!.GetMessage()!;
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("result", out var resultEl))
+                root = resultEl;
+
+            Assert.IsTrue(
+                root.TryGetProperty("isPlaying", out _) ||
+                root.TryGetProperty("IsPlaying", out _),
+                "Response should contain isPlaying field");
+        }
+
+        [UnityTest]
+        public IEnumerator GetApplicationState_DirectMethod_ReturnsNonNull()
+        {
+            yield return null;
+
+            var tool = new Tool_Editor();
+            var state = tool.GetApplicationState();
+
+            Assert.IsNotNull(state, "GetApplicationState should return non-null state");
+        }
+
+        [UnityTest]
+        public IEnumerator GetApplicationState_FromBackgroundThread_ReturnsValidState()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Editor();
+                var state = tool.GetApplicationState();
+                Assert.IsNotNull(state, "GetApplicationState should return non-null state from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator GetApplicationState_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Editor.EditorApplicationGetStateToolId, "{}"));
+        }
+
+        [UnityTest]
+        public IEnumerator GetApplicationState_IsNotInPlayMode_WhenTestRuns()
+        {
+            yield return null;
+
+            var tool = new Tool_Editor();
+            var state = tool.GetApplicationState();
+
+            Assert.IsNotNull(state);
+            Assert.IsFalse(state!.IsPlaying, "Tests should not be running in play mode");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorApplicationTests.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorApplicationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54d2870e4354411eba1de439cbd31f51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorSelectionTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorSelectionTests.cs
@@ -1,0 +1,159 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    [TestFixture]
+    public class EditorSelectionTests : BaseTest
+    {
+        bool? _originalGetEnabled;
+        bool? _originalSetEnabled;
+
+        [UnitySetUp]
+        public override IEnumerator SetUp()
+        {
+            yield return base.SetUp();
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            Assert.IsNotNull(toolManager, "ToolManager should not be null");
+
+            _originalGetEnabled = toolManager!.IsToolEnabled(Tool_Editor_Selection.EditorSelectionGetToolId);
+            _originalSetEnabled = toolManager.IsToolEnabled(Tool_Editor_Selection.EditorSelectionSetToolId);
+
+            toolManager.SetToolEnabled(Tool_Editor_Selection.EditorSelectionGetToolId, true);
+            toolManager.SetToolEnabled(Tool_Editor_Selection.EditorSelectionSetToolId, true);
+            UnityMcpPluginEditor.Instance.Save();
+        }
+
+        [UnityTearDown]
+        public override IEnumerator TearDown()
+        {
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            if (toolManager != null)
+            {
+                if (_originalGetEnabled.HasValue)
+                    toolManager.SetToolEnabled(Tool_Editor_Selection.EditorSelectionGetToolId, _originalGetEnabled.Value);
+                if (_originalSetEnabled.HasValue)
+                    toolManager.SetToolEnabled(Tool_Editor_Selection.EditorSelectionSetToolId, _originalSetEnabled.Value);
+                UnityMcpPluginEditor.Instance.Save();
+            }
+
+            yield return base.TearDown();
+        }
+
+        // ── editor-selection-get ──────────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator SelectionGet_FromMainThread_ReturnsData()
+        {
+            yield return null;
+            RunTool(Tool_Editor_Selection.EditorSelectionGetToolId, "{}");
+        }
+
+        [UnityTest]
+        public IEnumerator SelectionGet_DirectMethod_ReturnsData()
+        {
+            yield return null;
+
+            var tool = new Tool_Editor_Selection();
+            var result = tool.Get();
+            Assert.IsNotNull(result, "Get() should return a non-null SelectionData");
+        }
+
+        [UnityTest]
+        public IEnumerator SelectionGet_FromBackgroundThread_ReturnsData()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Editor_Selection();
+                var result = tool.Get();
+                Assert.IsNotNull(result, "Get() should return non-null from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator SelectionGet_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Editor_Selection.EditorSelectionGetToolId, "{}"));
+        }
+
+        [UnityTest]
+        public IEnumerator SelectionGet_WithIncludeOptions_FromMainThread_Succeeds()
+        {
+            yield return null;
+
+            RunTool(Tool_Editor_Selection.EditorSelectionGetToolId, @"{
+                ""includeGameObjects"": true,
+                ""includeTransforms"": true,
+                ""includeInstanceIDs"": true,
+                ""includeAssetGUIDs"": true,
+                ""includeActiveObject"": true,
+                ""includeActiveTransform"": true
+            }");
+        }
+
+        [UnityTest]
+        public IEnumerator SelectionGet_WithIncludeOptions_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Editor_Selection.EditorSelectionGetToolId, @"{
+                    ""includeGameObjects"": true,
+                    ""includeInstanceIDs"": true,
+                    ""includeActiveObject"": true
+                }"));
+        }
+
+        // ── editor-selection-set ──────────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator SelectionSet_WithGameObject_FromMainThread_Succeeds()
+        {
+            yield return null;
+
+            var go = new GameObject("SelectionTestGO");
+
+            RunTool(Tool_Editor_Selection.EditorSelectionSetToolId, $@"{{
+                ""select"": [{{
+                    ""instanceID"": {go.GetInstanceID()}
+                }}]
+            }}");
+        }
+
+        [UnityTest]
+        public IEnumerator SelectionSet_WithGameObject_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            var go = new GameObject("SelectionTestGO_BG");
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Editor_Selection.EditorSelectionSetToolId, $@"{{
+                    ""select"": [{{
+                        ""instanceID"": {go.GetInstanceID()}
+                    }}]
+                }}"));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorSelectionTests.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Editor/EditorSelectionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87be87897dfb4e9a810d06eff24d9668
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/GameObject/TestToolGameObject.BackgroundThread.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/GameObject/TestToolGameObject.BackgroundThread.cs
@@ -1,0 +1,120 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public partial class TestToolGameObject : BaseTest
+    {
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator Find_FromBackgroundThread_ByInstanceID_Succeeds()
+        {
+            var go = new GameObject("BGFind");
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("gameobject-find", $@"{{
+                    ""gameObjectRef"": {{
+                        ""instanceID"": {go.GetInstanceID()}
+                    }}
+                }}"));
+        }
+
+        [UnityTest]
+        public IEnumerator Create_FromBackgroundThread_Succeeds()
+        {
+            yield return RunOnBackgroundThread(() =>
+                RunTool("gameobject-create", @"{
+                    ""name"": ""BGCreatedObject"",
+                    ""position"": { ""x"": 0, ""y"": 0, ""z"": 0 }
+                }"));
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentListAll_FromBackgroundThread_Succeeds()
+        {
+            yield return RunOnBackgroundThread(() =>
+                RunTool("gameobject-component-list-all", "{}"));
+        }
+
+        [UnityTest]
+        public IEnumerator Destroy_FromBackgroundThread_Succeeds()
+        {
+            var go = new GameObject("BGDestroyObject");
+            var instanceId = go.GetInstanceID();
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("gameobject-destroy", $@"{{
+                    ""gameObjectRefs"": [{{
+                        ""instanceID"": {instanceId}
+                    }}]
+                }}"));
+
+            // Verify destroyed (must check on main thread)
+            var found = UnityEngine.GameObject.FindObjectsByType<GameObject>(
+                FindObjectsInactive.Include, FindObjectsSortMode.None);
+            Assert.IsNull(System.Array.Find(found, x => x.GetInstanceID() == instanceId),
+                "GameObject should be destroyed");
+        }
+
+        [UnityTest]
+        public IEnumerator Modify_FromBackgroundThread_Succeeds()
+        {
+            var go = new GameObject("BGModifyObject");
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("gameobject-modify", $@"{{
+                    ""gameObjectRefs"": [{{
+                        ""instanceID"": {go.GetInstanceID()}
+                    }}],
+                    ""name"": ""BGModifiedObject""
+                }}"));
+
+            Assert.AreEqual("BGModifiedObject", go.name,
+                "GameObject name should be modified from background thread");
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentGet_FromBackgroundThread_Succeeds()
+        {
+            var go = new GameObject("BGComponentGetObject");
+            go.AddComponent<BoxCollider>();
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("gameobject-component-get", $@"{{
+                    ""gameObjectRef"": {{
+                        ""instanceID"": {go.GetInstanceID()}
+                    }},
+                    ""componentTypeName"": ""UnityEngine.BoxCollider""
+                }}"));
+        }
+
+        [UnityTest]
+        public IEnumerator Duplicate_FromBackgroundThread_Succeeds()
+        {
+            var go = new GameObject("BGDuplicateSource");
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("gameobject-duplicate", $@"{{
+                    ""gameObjectRefs"": [{{
+                        ""instanceID"": {go.GetInstanceID()}
+                    }}]
+                }}"));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/GameObject/TestToolGameObject.BackgroundThread.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/GameObject/TestToolGameObject.BackgroundThread.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d45b3b7b747f4be1b268771fc259ed4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Object/ObjectGetDataTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Object/ObjectGetDataTests.cs
@@ -10,10 +10,12 @@
 
 #nullable enable
 using System;
+using System.Collections;
 using com.IvanMurzak.Unity.MCP.Editor.API;
 using com.IvanMurzak.Unity.MCP.Runtime.Data;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 {
@@ -291,6 +293,37 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 // Cleanup
                 UnityEngine.Object.DestroyImmediate(material);
             }
+        }
+
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator GetData_FromBackgroundThread_ValidGameObject_ReturnsSerializedData()
+        {
+            var go = new GameObject("BGThreadObject");
+            var objectRef = new ObjectRef(go);
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Object();
+                var result = tool.GetData(objectRef);
+                Assert.IsNotNull(result, "Result should not be null from background thread");
+                Assert.AreEqual("BGThreadObject", result!.name, "Name should match from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator GetData_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            var go = new GameObject("BGRunToolObject");
+            var objectRef = new ObjectRef(go);
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("object-get-data", $@"{{
+                    ""objectRef"": {{
+                        ""instanceID"": {go.GetInstanceID()}
+                    }}
+                }}"));
         }
     }
 }

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Package.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Package.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c57af51917964d1abe185da651ccc1ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Package/PackageListTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Package/PackageListTests.cs
@@ -1,0 +1,187 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections;
+using System.Text.Json;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    [TestFixture]
+    public class PackageListTests : BaseTest
+    {
+        bool? _originalEnabled;
+
+        [UnitySetUp]
+        public override IEnumerator SetUp()
+        {
+            yield return base.SetUp();
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            Assert.IsNotNull(toolManager, "ToolManager should not be null");
+
+            _originalEnabled = toolManager!.IsToolEnabled(Tool_Package.PackageListToolId);
+            toolManager.SetToolEnabled(Tool_Package.PackageListToolId, true);
+            UnityMcpPluginEditor.Instance.Save();
+        }
+
+        [UnityTearDown]
+        public override IEnumerator TearDown()
+        {
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            if (toolManager != null && _originalEnabled.HasValue)
+            {
+                toolManager.SetToolEnabled(Tool_Package.PackageListToolId, _originalEnabled.Value);
+                UnityMcpPluginEditor.Instance.Save();
+            }
+
+            yield return base.TearDown();
+        }
+
+        [UnityTest]
+        public IEnumerator PackageList_NoFilter_FromMainThread_ReturnsPackages()
+        {
+            yield return null;
+
+            var json = RunTool(Tool_Package.PackageListToolId, "{}").Value!.GetMessage()!;
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("result", out var resultEl))
+                root = resultEl;
+
+            Assert.AreEqual(JsonValueKind.Array, root.ValueKind, "Result should be an array of packages");
+            Assert.Greater(root.GetArrayLength(), 0, "Should return at least one installed package");
+        }
+
+        [UnityTest]
+        public IEnumerator PackageList_NoFilter_FromBackgroundThread_ReturnsPackages()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var json = RunTool(Tool_Package.PackageListToolId, "{}").Value!.GetMessage()!;
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("result", out var resultEl))
+                    root = resultEl;
+                Assert.AreEqual(JsonValueKind.Array, root.ValueKind, "Result should be an array from background thread");
+            }, timeoutSeconds: 60f);
+        }
+
+        [UnityTest]
+        public IEnumerator PackageList_EachPackageHasNameAndVersion()
+        {
+            yield return null;
+
+            var json = RunTool(Tool_Package.PackageListToolId, "{}").Value!.GetMessage()!;
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("result", out var resultEl))
+                root = resultEl;
+
+            Assert.Greater(root.GetArrayLength(), 0, "Should have at least one package");
+
+            var first = root[0];
+            Assert.IsTrue(
+                first.TryGetProperty("name", out var name) || first.TryGetProperty("Name", out name),
+                "Package should have a name field");
+            Assert.IsTrue(
+                first.TryGetProperty("version", out var version) || first.TryGetProperty("Version", out version),
+                "Package should have a version field");
+            Assert.IsFalse(string.IsNullOrEmpty(name.GetString()), "Package name should not be empty");
+        }
+
+        [UnityTest]
+        public IEnumerator PackageList_WithNameFilter_FiltersResults()
+        {
+            yield return null;
+
+            // "core" is a very common substring present in many Unity packages
+            var json = RunTool(Tool_Package.PackageListToolId, @"{
+                ""nameFilter"": ""com.unity""
+            }").Value!.GetMessage()!;
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("result", out var resultEl))
+                root = resultEl;
+
+            Assert.AreEqual(JsonValueKind.Array, root.ValueKind, "Filtered result should be an array");
+            // All results should contain "com.unity" (case-insensitive)
+            for (int i = 0; i < root.GetArrayLength(); i++)
+            {
+                var pkg = root[i];
+                var name = (pkg.TryGetProperty("name", out var n) || pkg.TryGetProperty("Name", out n))
+                    ? n.GetString() ?? string.Empty
+                    : string.Empty;
+                var displayName = (pkg.TryGetProperty("displayName", out var dn) || pkg.TryGetProperty("DisplayName", out dn))
+                    ? dn.GetString() ?? string.Empty
+                    : string.Empty;
+                var description = (pkg.TryGetProperty("description", out var d) || pkg.TryGetProperty("Description", out d))
+                    ? d.GetString() ?? string.Empty
+                    : string.Empty;
+
+                var matchesFilter =
+                    name.IndexOf("com.unity", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    displayName.IndexOf("com.unity", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    description.IndexOf("com.unity", System.StringComparison.OrdinalIgnoreCase) >= 0;
+
+                Assert.IsTrue(matchesFilter, $"Package '{name}' should match filter 'com.unity'");
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator PackageList_WithNameFilter_FromBackgroundThread_FiltersResults()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Package.PackageListToolId, @"{
+                    ""nameFilter"": ""com.unity""
+                }"), timeoutSeconds: 60f);
+        }
+
+        [UnityTest]
+        public IEnumerator PackageList_DirectDependenciesOnly_ReturnsFewer()
+        {
+            yield return null;
+
+            var allJson = RunTool(Tool_Package.PackageListToolId, @"{
+                ""directDependenciesOnly"": false
+            }").Value!.GetMessage()!;
+
+            using var allDoc = JsonDocument.Parse(allJson);
+            var allRoot = allDoc.RootElement;
+            if (allRoot.TryGetProperty("result", out var allResultEl))
+                allRoot = allResultEl;
+            var allCount = allRoot.GetArrayLength();
+
+            var directJson = RunTool(Tool_Package.PackageListToolId, @"{
+                ""directDependenciesOnly"": true
+            }").Value!.GetMessage()!;
+
+            using var directDoc = JsonDocument.Parse(directJson);
+            var directRoot = directDoc.RootElement;
+            if (directRoot.TryGetProperty("result", out var directResultEl))
+                directRoot = directResultEl;
+            var directCount = directRoot.GetArrayLength();
+
+            Assert.LessOrEqual(directCount, allCount,
+                "Direct dependencies only should return same or fewer packages than all packages");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Package/PackageListTests.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Package/PackageListTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18ee77932ca6469dac8df8de9618f36f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Scene.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Scene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ea34698a13d4caa9b1a37116869869d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Scene/SceneTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Scene/SceneTests.cs
@@ -1,0 +1,225 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections;
+using System.Text.Json;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using NUnit.Framework;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    [TestFixture]
+    public class SceneTests : BaseTest
+    {
+        bool? _originalListOpenedEnabled;
+        bool? _originalGetDataEnabled;
+
+        [UnitySetUp]
+        public override IEnumerator SetUp()
+        {
+            yield return base.SetUp();
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            Assert.IsNotNull(toolManager, "ToolManager should not be null");
+
+            _originalListOpenedEnabled = toolManager!.IsToolEnabled(Tool_Scene.SceneListOpenedToolId);
+            _originalGetDataEnabled = toolManager.IsToolEnabled(Tool_Scene.SceneGetDataToolId);
+
+            toolManager.SetToolEnabled(Tool_Scene.SceneListOpenedToolId, true);
+            toolManager.SetToolEnabled(Tool_Scene.SceneGetDataToolId, true);
+            UnityMcpPluginEditor.Instance.Save();
+        }
+
+        [UnityTearDown]
+        public override IEnumerator TearDown()
+        {
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            if (toolManager != null)
+            {
+                if (_originalListOpenedEnabled.HasValue)
+                    toolManager.SetToolEnabled(Tool_Scene.SceneListOpenedToolId, _originalListOpenedEnabled.Value);
+                if (_originalGetDataEnabled.HasValue)
+                    toolManager.SetToolEnabled(Tool_Scene.SceneGetDataToolId, _originalGetDataEnabled.Value);
+                UnityMcpPluginEditor.Instance.Save();
+            }
+
+            yield return base.TearDown();
+        }
+
+        // ── scene-list-opened ─────────────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator SceneListOpened_FromMainThread_ReturnsAtLeastOneScene()
+        {
+            yield return null;
+
+            var json = RunTool(Tool_Scene.SceneListOpenedToolId, "{}").Value!.GetMessage()!;
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("result", out var resultEl))
+                root = resultEl;
+
+            Assert.AreEqual(JsonValueKind.Array, root.ValueKind, "Result should be an array");
+            Assert.Greater(root.GetArrayLength(), 0, "Should have at least one opened scene");
+        }
+
+        [UnityTest]
+        public IEnumerator SceneListOpened_DirectMethod_ReturnsScenes()
+        {
+            yield return null;
+
+            var tool = new Tool_Scene();
+            var scenes = tool.ListOpened();
+            Assert.IsNotNull(scenes, "ListOpened() should return non-null");
+        }
+
+        [UnityTest]
+        public IEnumerator SceneListOpened_FromBackgroundThread_ReturnsScenes()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Scene();
+                var scenes = tool.ListOpened();
+                Assert.IsNotNull(scenes, "ListOpened() should return non-null from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator SceneListOpened_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Scene.SceneListOpenedToolId, "{}"));
+        }
+
+        // ── scene-get-data ────────────────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator SceneGetData_ActiveScene_FromMainThread_ReturnsData()
+        {
+            yield return null;
+
+            var json = RunTool(Tool_Scene.SceneGetDataToolId, @"{
+                ""includeRootGameObjects"": true,
+                ""includeChildrenDepth"": 1
+            }").Value!.GetMessage()!;
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("result", out var resultEl))
+                root = resultEl;
+
+            Assert.IsTrue(
+                root.TryGetProperty("name", out _) || root.TryGetProperty("Name", out _),
+                "Scene data should contain a name field");
+        }
+
+        [UnityTest]
+        public IEnumerator SceneGetData_DirectMethod_ReturnsData()
+        {
+            yield return null;
+
+            var tool = new Tool_Scene();
+            var data = tool.GetData(includeRootGameObjects: false);
+            Assert.IsNotNull(data, "GetData() should return non-null");
+        }
+
+        [UnityTest]
+        public IEnumerator SceneGetData_FromBackgroundThread_ReturnsData()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var tool = new Tool_Scene();
+                var data = tool.GetData(includeRootGameObjects: false);
+                Assert.IsNotNull(data, "GetData() should return non-null from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator SceneGetData_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Scene.SceneGetDataToolId, @"{
+                    ""includeRootGameObjects"": false
+                }"));
+        }
+
+        [UnityTest]
+        public IEnumerator SceneGetData_ByName_ActiveScene_Succeeds()
+        {
+            yield return null;
+
+            var activeSceneName = SceneManager.GetActiveScene().name;
+            RunTool(Tool_Scene.SceneGetDataToolId, $@"{{
+                ""openedSceneName"": ""{activeSceneName}"",
+                ""includeRootGameObjects"": false
+            }}");
+        }
+
+        [UnityTest]
+        public IEnumerator SceneGetData_ByName_ActiveScene_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            var activeSceneName = SceneManager.GetActiveScene().name;
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Scene.SceneGetDataToolId, $@"{{
+                    ""openedSceneName"": ""{activeSceneName}"",
+                    ""includeRootGameObjects"": false
+                }}"));
+        }
+
+        // ── scene-list-opened + scene-get-data combined background tests ──
+
+        [UnityTest]
+        public IEnumerator SceneListAndGetData_Sequential_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            // List scenes, then get data for the active one — both from background thread
+            yield return RunOnBackgroundThread(() =>
+            {
+                var listTool = new Tool_Scene();
+                var scenes = listTool.ListOpened();
+                Assert.IsNotNull(scenes, "ListOpened should return non-null");
+                Assert.Greater(scenes.Length, 0, "Should have at least one scene");
+
+                var dataTool = new Tool_Scene();
+                var data = dataTool.GetData(includeRootGameObjects: false);
+                Assert.IsNotNull(data, "GetData should return non-null");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator SceneListOpened_ReturnsSceneWithValidName()
+        {
+            yield return null;
+
+            var tool = new Tool_Scene();
+            var scenes = tool.ListOpened();
+            Assert.IsNotNull(scenes);
+            Assert.Greater(scenes.Length, 0);
+
+            foreach (var scene in scenes)
+                Assert.IsNotNull(scene, "Each scene data entry should be non-null");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Scene/SceneTests.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Scene/SceneTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f6b8acd5d14461faceb4383e691a7af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Screenshot/ScreenshotCameraTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Screenshot/ScreenshotCameraTests.cs
@@ -9,6 +9,7 @@
 */
 
 #nullable enable
+using System.Collections;
 using System.Text.RegularExpressions;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.Unity.MCP.Editor.API;
@@ -147,6 +148,40 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 ""width"": 16,
                 ""height"": 16
             }}");
+        }
+
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator ScreenshotCamera_DirectMethod_FromBackgroundThread_ReturnsImage()
+        {
+            var go = new GameObject("BGThreadCamera");
+            go.AddComponent<Camera>();
+            var cameraRef = new GameObjectRef { InstanceID = go.GetInstanceID() };
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var result = new Tool_Screenshot().ScreenshotCamera(cameraRef: cameraRef, width: 64, height: 64);
+                Assert.IsNotNull(result, "Should return non-null result from background thread");
+                Assert.AreNotEqual(ResponseStatus.Error, result.Status,
+                    "Should succeed when camera is valid, called from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator ScreenshotCamera_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            var go = new GameObject("BGRunToolCamera");
+            go.AddComponent<Camera>();
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("screenshot-camera", $@"{{
+                    ""cameraRef"": {{
+                        ""instanceID"": {go.GetInstanceID()}
+                    }},
+                    ""width"": 16,
+                    ""height"": 16
+                }}"));
         }
     }
 }

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Script/ScriptExecuteTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Script/ScriptExecuteTests.cs
@@ -9,10 +9,12 @@
 */
 
 #nullable enable
+using System.Collections;
 using com.IvanMurzak.Unity.MCP.Editor.API;
 using com.IvanMurzak.Unity.MCP.Editor.Tests.Utils;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 {
@@ -112,6 +114,29 @@ public class Script
                     Assert.IsTrue(gameObjectEx.GameObject!.activeSelf, "GameObject should be enabled after script execution");
                 })
                 .Execute();
+        }
+
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator Script_Execute_FromBackgroundThread_Succeeds()
+        {
+            var csharpCode = @"using UnityEngine;
+public class Script
+{
+    public static void Main()
+    {
+        Debug.Log(""Background thread script execution test"");
+    }
+}";
+            var go = new GameObject(GO_ABC + "_BG");
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("script-execute", $@"{{
+                    ""csharpCode"": {JsonEscape(csharpCode)},
+                    ""className"": ""Script"",
+                    ""methodName"": ""Main""
+                }}"));
         }
 
         private static string JsonEscape(string value)

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Script/ScriptReadTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Script/ScriptReadTests.cs
@@ -1,0 +1,241 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections;
+using System.IO;
+using System.Text.RegularExpressions;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    [TestFixture]
+    public class ScriptReadTests : BaseTest
+    {
+        bool? _originalEnabled;
+
+        // Use this very file's source as a known existing .cs file for read tests
+        const string TestScriptPath = "Assets/root/Tests/Editor/Tool/Script/ScriptReadTests.cs";
+
+        [UnitySetUp]
+        public override IEnumerator SetUp()
+        {
+            yield return base.SetUp();
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            Assert.IsNotNull(toolManager, "ToolManager should not be null");
+
+            _originalEnabled = toolManager!.IsToolEnabled(Tool_Script.ScriptReadToolId);
+            toolManager.SetToolEnabled(Tool_Script.ScriptReadToolId, true);
+            UnityMcpPluginEditor.Instance.Save();
+        }
+
+        [UnityTearDown]
+        public override IEnumerator TearDown()
+        {
+            var toolManager = UnityMcpPluginEditor.Instance.Tools;
+            if (toolManager != null && _originalEnabled.HasValue)
+            {
+                toolManager.SetToolEnabled(Tool_Script.ScriptReadToolId, _originalEnabled.Value);
+                UnityMcpPluginEditor.Instance.Save();
+            }
+
+            yield return base.TearDown();
+        }
+
+        static string GetTestScriptAbsolutePath()
+        {
+            // Convert Unity relative path to absolute path
+            var unityProjectPath = Directory.GetCurrentDirectory();
+            return Path.Combine(unityProjectPath, TestScriptPath.Replace('/', Path.DirectorySeparatorChar));
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_BaseTestFile_FromMainThread_ReturnsContent()
+        {
+            yield return null;
+
+            // Use BaseTest.cs since it definitely exists
+            const string baseTestPath = "Assets/root/Tests/Editor/BaseTest.cs";
+            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(),
+                baseTestPath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (!File.Exists(absolutePath))
+            {
+                Assert.Ignore($"Test script not found at {absolutePath}, skipping test.");
+                yield break;
+            }
+
+            var result = Tool_Script.Read(baseTestPath);
+            Assert.IsNotNull(result, "Read() should return content");
+            Assert.IsNotEmpty(result, "Read() should return non-empty content");
+            StringAssert.Contains("BaseTest", result, "Content should contain 'BaseTest'");
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_BaseTestFile_FromBackgroundThread_ReturnsContent()
+        {
+            yield return null;
+
+            const string baseTestPath = "Assets/root/Tests/Editor/BaseTest.cs";
+            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(),
+                baseTestPath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (!File.Exists(absolutePath))
+            {
+                Assert.Ignore($"Test script not found at {absolutePath}, skipping test.");
+                yield break;
+            }
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var result = Tool_Script.Read(baseTestPath);
+                Assert.IsNotNull(result, "Read() should return content from background thread");
+                Assert.IsNotEmpty(result, "Read() should return non-empty content from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_ViaRunTool_FromMainThread_Succeeds()
+        {
+            yield return null;
+
+            const string baseTestPath = "Assets/root/Tests/Editor/BaseTest.cs";
+            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(),
+                baseTestPath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (!File.Exists(absolutePath))
+            {
+                Assert.Ignore($"Test script not found at {absolutePath}, skipping test.");
+                yield break;
+            }
+
+            RunTool(Tool_Script.ScriptReadToolId, $@"{{
+                ""filePath"": ""{baseTestPath}""
+            }}");
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            const string baseTestPath = "Assets/root/Tests/Editor/BaseTest.cs";
+            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(),
+                baseTestPath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (!File.Exists(absolutePath))
+            {
+                Assert.Ignore($"Test script not found at {absolutePath}, skipping test.");
+                yield break;
+            }
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Script.ScriptReadToolId, $@"{{
+                    ""filePath"": ""{baseTestPath}""
+                }}"));
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_WithLineRange_ReturnsPartialContent()
+        {
+            yield return null;
+
+            const string baseTestPath = "Assets/root/Tests/Editor/BaseTest.cs";
+            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(),
+                baseTestPath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (!File.Exists(absolutePath))
+            {
+                Assert.Ignore($"Test script not found at {absolutePath}, skipping test.");
+                yield break;
+            }
+
+            var fullContent = Tool_Script.Read(baseTestPath);
+            var partialContent = Tool_Script.Read(baseTestPath, lineFrom: 1, lineTo: 5);
+
+            Assert.IsNotEmpty(partialContent, "Partial read should return content");
+            Assert.LessOrEqual(partialContent.Length, fullContent.Length,
+                "Partial read should return less than or equal to full content");
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_WithLineRange_FromBackgroundThread_ReturnsContent()
+        {
+            yield return null;
+
+            const string baseTestPath = "Assets/root/Tests/Editor/BaseTest.cs";
+            var absolutePath = Path.Combine(Directory.GetCurrentDirectory(),
+                baseTestPath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (!File.Exists(absolutePath))
+            {
+                Assert.Ignore($"Test script not found at {absolutePath}, skipping test.");
+                yield break;
+            }
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var result = Tool_Script.Read(baseTestPath, lineFrom: 1, lineTo: 10);
+                Assert.IsNotEmpty(result, "Partial read from background thread should return content");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_EmptyPath_ThrowsArgumentException()
+        {
+            yield return null;
+
+            Assert.Throws<ArgumentException>(() => Tool_Script.Read(string.Empty));
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_NonCsFile_ThrowsArgumentException()
+        {
+            yield return null;
+
+            Assert.Throws<ArgumentException>(() => Tool_Script.Read("Assets/SomeFile.txt"));
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_NonExistentFile_ThrowsFileNotFoundException()
+        {
+            yield return null;
+
+            Assert.Throws<FileNotFoundException>(() =>
+                Tool_Script.Read("Assets/NonExistentScript12345.cs"));
+        }
+
+        [UnityTest]
+        public IEnumerator ScriptRead_EmptyPath_FromBackgroundThread_ThrowsArgumentException()
+        {
+            yield return null;
+
+            Exception? caughtException = null;
+            yield return RunOnBackgroundThread(() =>
+            {
+                try
+                {
+                    Tool_Script.Read(string.Empty);
+                }
+                catch (ArgumentException ex)
+                {
+                    caughtException = ex;
+                }
+            });
+
+            Assert.IsNotNull(caughtException, "Should throw ArgumentException from background thread too");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Script/ScriptReadTests.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Script/ScriptReadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca43d8492dfc43c99e8778c49a949a05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Tool/ToolListTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Tool/ToolListTests.cs
@@ -348,6 +348,40 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             }
         }
 
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator List_FromBackgroundThread_ReturnsTools()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var json = RunTool(Tool_Tool.ToolListId, "{}").Value!.GetMessage()!;
+                using var doc = JsonDocument.Parse(json);
+                var arr = GetResultArray(doc);
+                Assert.Greater(arr.GetArrayLength(), 0, "Should return tools from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator List_WithRegex_FromBackgroundThread_FiltersTools()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var json = RunTool(Tool_Tool.ToolListId, @"{
+                    ""regexSearch"": ""^tool-list$""
+                }").Value!.GetMessage()!;
+
+                using var doc = JsonDocument.Parse(json);
+                var arr = GetResultArray(doc);
+                Assert.AreEqual(1, arr.GetArrayLength(), "Exact regex should match one tool from background thread");
+                Assert.AreEqual("tool-list", arr[0].GetProperty("name").GetString());
+            });
+        }
+
         static JsonElement GetResultArray(JsonDocument doc)
         {
             var root = doc.RootElement;

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Tool/ToolSetEnabledStateTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Tool/ToolSetEnabledStateTests.cs
@@ -372,6 +372,53 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             }
         }
 
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator SetEnabled_FromBackgroundThread_DisablesTool()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var json = RunTool(Tool_Tool.ToolSetEnabledStateId, $@"{{
+                    ""tools"": [{{ ""name"": ""{_testToolName}"", ""enabled"": false }}],
+                    ""includeLogs"": false
+                }}").Value!.GetMessage()!;
+
+                Assert.IsTrue(GetSuccessValue(json, _testToolName!),
+                    $"Should successfully disable tool '{_testToolName}' from background thread");
+            });
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools!;
+            Assert.IsFalse(toolManager.IsToolEnabled(_testToolName!),
+                $"Tool '{_testToolName}' should be disabled after background thread call");
+        }
+
+        [UnityTest]
+        public IEnumerator SetEnabled_FromBackgroundThread_MultipleTimes_Succeeds()
+        {
+            yield return null;
+
+            // Disable from background thread
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Tool.ToolSetEnabledStateId, $@"{{
+                    ""tools"": [{{ ""name"": ""{_testToolName}"", ""enabled"": false }}],
+                    ""includeLogs"": false
+                }}"));
+
+            // Re-enable from background thread
+            yield return RunOnBackgroundThread(() =>
+                RunTool(Tool_Tool.ToolSetEnabledStateId, $@"{{
+                    ""tools"": [{{ ""name"": ""{_testToolName}"", ""enabled"": true }}],
+                    ""includeLogs"": false
+                }}"));
+
+            var toolManager = UnityMcpPluginEditor.Instance.Tools!;
+            Assert.IsTrue(toolManager.IsToolEnabled(_testToolName!),
+                $"Tool '{_testToolName}' should be enabled after background thread re-enable");
+        }
+
         [UnityTest]
         public IEnumerator SetEnabled_LogLevelNone_AllToolsDisabled_ShouldStillWork()
         {

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Type/TypeGetJsonSchemaTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Type/TypeGetJsonSchemaTests.cs
@@ -16,6 +16,7 @@ using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.API;
 using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using NUnit.Framework;
 using UnityEngine.TestTools;
 using static com.IvanMurzak.Unity.MCP.Editor.API.Tool_Type;
@@ -315,6 +316,32 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 Assert.IsNotNull(ItemsDescription(schema));
 
             yield return null;
+        }
+
+        // ── background thread tests ───────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator GetJsonSchema_FromBackgroundThread_ReturnsSchema()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+            {
+                var result = _tool.GetJsonSchema(AssetObjectRefName);
+                Assert.IsNotNull(result, "Should return schema from background thread");
+                Assert.IsNotEmpty(result, "Schema should not be empty from background thread");
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator GetJsonSchema_ViaRunTool_FromBackgroundThread_Succeeds()
+        {
+            yield return null;
+
+            yield return RunOnBackgroundThread(() =>
+                RunTool("type-get-json-schema", $@"{{
+                    ""typeName"": ""{typeof(UnityEngine.Vector3).AssemblyQualifiedName}""
+                }}"));
         }
     }
 }


### PR DESCRIPTION
Closes #633

## Summary
- Add `RunOnBackgroundThread` helper to `BaseTest` to standardize background thread testing pattern
- Create new test files for previously untested tools (EditorApplication, EditorSelection, Scene, Package, ScriptRead, AssetsFind)
- Add background thread test variants to all existing and new test classes

Generated with [Claude Code](https://claude.ai/code)