### PR TITLE
feat: enhance assets-prefab-create tool with variant support and tests (#645)

### DIFF
--- a/Unity-MCP-Plugin/.claude/skills/assets-prefab-create/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-prefab-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assets-prefab-create
-description: Create a prefab from a GameObject in the current active scene. The prefab will be saved in the project assets at the specified path. Use 'gameobject-find' tool to find the target GameObject first.
+description: Create a prefab from a GameObject in the current active scene. The prefab will be saved in the project assets at the specified path. Creates folders recursively if they do not exist. If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. To create a Prefab Variant from an existing prefab asset, provide 'sourcePrefabAssetPath' instead of 'gameObjectRef'. Use 'gameobject-find' tool to find the target GameObject first.
 ---
 
 # Assets / Prefab / Create
@@ -11,7 +11,8 @@ description: Create a prefab from a GameObject in the current active scene. The 
 unity-mcp-cli run-tool assets-prefab-create --input '{
   "prefabAssetPath": "string_value",
   "gameObjectRef": "string_value",
-  "replaceGameObjectWithPrefab": false
+  "sourcePrefabAssetPath": "string_value",
+  "connectGameObjectToPrefab": false
 }'
 ```
 
@@ -38,8 +39,9 @@ Read the /unity-initial-setup skill for detailed installation instructions.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | `prefabAssetPath` | `string` | Yes | Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'. |
-| `gameObjectRef` | `any` | Yes | Find GameObject in opened Prefab or in the active Scene. |
-| `replaceGameObjectWithPrefab` | `boolean` | No | If true, the prefab will replace the GameObject in the scene. |
+| `gameObjectRef` | `any` | No | Reference to a scene GameObject to create the prefab from. If the GameObject is already a prefab instance, a Prefab Variant is created when 'connectGameObjectToPrefab' is true. Optional if 'sourcePrefabAssetPath' is provided. |
+| `sourcePrefabAssetPath` | `string` | No | Path to an existing prefab asset to create a Prefab Variant from (e.g. 'Assets/Prefabs/Base.prefab'). When provided, a temporary instance is created, saved as a Prefab Variant, and cleaned up. Optional if 'gameObjectRef' is provided. |
+| `connectGameObjectToPrefab` | `boolean` | No | If true, the scene GameObject will be connected to the new prefab (becoming a prefab instance). If the source is already a prefab instance, this creates a Prefab Variant. If false, the prefab asset is created but the scene GameObject remains unchanged. Ignored when 'sourcePrefabAssetPath' is used (always creates a variant). |
 
 ### Input JSON Schema
 
@@ -53,7 +55,10 @@ Read the /unity-initial-setup skill for detailed installation instructions.
     "gameObjectRef": {
       "$ref": "#/$defs/com.IvanMurzak.Unity.MCP.Runtime.Data.GameObjectRef"
     },
-    "replaceGameObjectWithPrefab": {
+    "sourcePrefabAssetPath": {
+      "type": "string"
+    },
+    "connectGameObjectToPrefab": {
       "type": "boolean"
     }
   },
@@ -96,8 +101,7 @@ Read the /unity-initial-setup skill for detailed installation instructions.
     }
   },
   "required": [
-    "prefabAssetPath",
-    "gameObjectRef"
+    "prefabAssetPath"
   ]
 }
 ```

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
@@ -84,7 +84,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     // Create a Prefab Variant from an existing prefab asset
                     var sourcePrefab = AssetDatabase.LoadAssetAtPath<UnityEngine.GameObject>(sourcePrefabAssetPath);
                     if (sourcePrefab == null)
-                        throw new ArgumentException(Error.NotFoundPrefabAtPath(sourcePrefabAssetPath), nameof(sourcePrefabAssetPath));
+                        throw new ArgumentException(Error.NotFoundPrefabAtPath(sourcePrefabAssetPath!), nameof(sourcePrefabAssetPath));
 
                     var tempInstance = PrefabUtility.InstantiatePrefab(sourcePrefab) as UnityEngine.GameObject;
                     if (tempInstance == null)

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
@@ -58,8 +58,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 if (string.IsNullOrEmpty(prefabAssetPath))
                     throw new ArgumentException(Error.PrefabPathIsEmpty(), nameof(prefabAssetPath));
 
+                if (!prefabAssetPath.StartsWith("Assets/"))
+                    throw new ArgumentException(Error.PrefabPathIsInvalid(prefabAssetPath), nameof(prefabAssetPath));
+
                 if (!prefabAssetPath.EndsWith(".prefab"))
                     throw new ArgumentException(Error.PrefabPathIsInvalid(prefabAssetPath), nameof(prefabAssetPath));
+
+                if (gameObjectRef != null && !string.IsNullOrEmpty(sourcePrefabAssetPath))
+                    throw new ArgumentException("Provide either 'gameObjectRef' or 'sourcePrefabAssetPath', not both.", nameof(sourcePrefabAssetPath));
 
                 // Create parent folders recursively if they do not exist
                 var lastSlash = prefabAssetPath.LastIndexOf('/');
@@ -88,7 +94,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                     var tempInstance = PrefabUtility.InstantiatePrefab(sourcePrefab) as UnityEngine.GameObject;
                     if (tempInstance == null)
-                        throw new Exception($"Failed to instantiate prefab from '{sourcePrefabAssetPath}'.");
+                        throw new InvalidOperationException($"Failed to instantiate prefab from '{sourcePrefabAssetPath}'.");
 
                     try
                     {
@@ -114,7 +120,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         ? PrefabUtility.SaveAsPrefabAssetAndConnect(go, prefabAssetPath, InteractionMode.UserAction, out _)
                         : PrefabUtility.SaveAsPrefabAsset(go, prefabAssetPath);
 
-                    if (prefabGo != null)
+                    if (connectGameObjectToPrefab && prefabGo != null)
                         EditorUtility.SetDirty(go);
                 }
 

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
@@ -30,14 +30,27 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Create a prefab from a GameObject in the current active scene. " +
             "The prefab will be saved in the project assets at the specified path. " +
+            "Creates folders recursively if they do not exist. " +
+            "If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. " +
+            "To create a Prefab Variant from an existing prefab asset, provide 'sourcePrefabAssetPath' instead of 'gameObjectRef'. " +
             "Use '" + Tool_GameObject.GameObjectFindToolId + "' tool to find the target GameObject first.")]
         public AssetObjectRef Create
         (
             [Description("Prefab asset path. Should be in the format 'Assets/Path/To/Prefab.prefab'.")]
             string prefabAssetPath,
-            GameObjectRef gameObjectRef,
-            [Description("If true, the prefab will replace the GameObject in the scene.")]
-            bool replaceGameObjectWithPrefab = true
+            [Description("Reference to a scene GameObject to create the prefab from. " +
+                "If the GameObject is already a prefab instance, a Prefab Variant is created when 'connectGameObjectToPrefab' is true. " +
+                "Optional if 'sourcePrefabAssetPath' is provided.")]
+            GameObjectRef? gameObjectRef = null,
+            [Description("Path to an existing prefab asset to create a Prefab Variant from (e.g. 'Assets/Prefabs/Base.prefab'). " +
+                "When provided, a temporary instance is created, saved as a Prefab Variant, and cleaned up. " +
+                "Optional if 'gameObjectRef' is provided.")]
+            string? sourcePrefabAssetPath = null,
+            [Description("If true, the scene GameObject will be connected to the new prefab (becoming a prefab instance). " +
+                "If the source is already a prefab instance, this creates a Prefab Variant. " +
+                "If false, the prefab asset is created but the scene GameObject remains unchanged. " +
+                "Ignored when 'sourcePrefabAssetPath' is used (always creates a variant).")]
+            bool connectGameObjectToPrefab = true
         )
         {
             return MainThread.Instance.Run(() =>
@@ -48,18 +61,59 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 if (!prefabAssetPath.EndsWith(".prefab"))
                     throw new ArgumentException(Error.PrefabPathIsInvalid(prefabAssetPath), nameof(prefabAssetPath));
 
-                var go = gameObjectRef.FindGameObject(out var error);
-                if (go == null)
-                    throw new ArgumentException(error, nameof(gameObjectRef));
+                // Create all folders in the path recursively if they do not exist
+                var segments = prefabAssetPath.Split('/');
+                for (int i = 1; i < segments.Length - 1; i++) // skip "Assets" (index 0) and filename (last)
+                {
+                    var parentPath = string.Join("/", segments, 0, i);
+                    var folderName = segments[i];
+                    if (!AssetDatabase.IsValidFolder(parentPath + "/" + folderName))
+                        AssetDatabase.CreateFolder(parentPath, folderName);
+                }
 
-                var prefabGo = replaceGameObjectWithPrefab
-                    ? PrefabUtility.SaveAsPrefabAsset(go, prefabAssetPath)
-                    : PrefabUtility.SaveAsPrefabAssetAndConnect(go, prefabAssetPath, InteractionMode.UserAction, out _);
+                UnityEngine.GameObject prefabGo;
+
+                if (!string.IsNullOrEmpty(sourcePrefabAssetPath))
+                {
+                    // Create a Prefab Variant from an existing prefab asset
+                    var sourcePrefab = AssetDatabase.LoadAssetAtPath<UnityEngine.GameObject>(sourcePrefabAssetPath);
+                    if (sourcePrefab == null)
+                        throw new ArgumentException(Error.NotFoundPrefabAtPath(sourcePrefabAssetPath), nameof(sourcePrefabAssetPath));
+
+                    var tempInstance = PrefabUtility.InstantiatePrefab(sourcePrefab) as UnityEngine.GameObject;
+                    if (tempInstance == null)
+                        throw new Exception($"Failed to instantiate prefab from '{sourcePrefabAssetPath}'.");
+
+                    try
+                    {
+                        // SaveAsPrefabAssetAndConnect on a prefab instance creates a Prefab Variant
+                        prefabGo = PrefabUtility.SaveAsPrefabAssetAndConnect(tempInstance, prefabAssetPath, InteractionMode.UserAction, out _);
+                    }
+                    finally
+                    {
+                        UnityEngine.Object.DestroyImmediate(tempInstance);
+                    }
+                }
+                else
+                {
+                    // Create from a scene GameObject
+                    if (gameObjectRef == null)
+                        throw new ArgumentException("Either 'gameObjectRef' or 'sourcePrefabAssetPath' must be provided.", nameof(gameObjectRef));
+
+                    var go = gameObjectRef.FindGameObject(out var error);
+                    if (go == null)
+                        throw new ArgumentException(error, nameof(gameObjectRef));
+
+                    prefabGo = connectGameObjectToPrefab
+                        ? PrefabUtility.SaveAsPrefabAssetAndConnect(go, prefabAssetPath, InteractionMode.UserAction, out _)
+                        : PrefabUtility.SaveAsPrefabAsset(go, prefabAssetPath);
+
+                    if (prefabGo != null)
+                        EditorUtility.SetDirty(go);
+                }
 
                 if (prefabGo == null)
                     throw new Exception(Error.NotFoundPrefabAtPath(prefabAssetPath));
-
-                EditorUtility.SetDirty(go);
 
                 EditorUtils.RepaintAllEditorWindows();
 

--- a/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
+++ b/Unity-MCP-Plugin/Assets/root/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
@@ -61,14 +61,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 if (!prefabAssetPath.EndsWith(".prefab"))
                     throw new ArgumentException(Error.PrefabPathIsInvalid(prefabAssetPath), nameof(prefabAssetPath));
 
-                // Create all folders in the path recursively if they do not exist
-                var segments = prefabAssetPath.Split('/');
-                for (int i = 1; i < segments.Length - 1; i++) // skip "Assets" (index 0) and filename (last)
+                // Create parent folders recursively if they do not exist
+                var lastSlash = prefabAssetPath.LastIndexOf('/');
+                var directoryPath = lastSlash > 0 ? prefabAssetPath.Substring(0, lastSlash) : null;
+                if (directoryPath != null && !AssetDatabase.IsValidFolder(directoryPath))
                 {
-                    var parentPath = string.Join("/", segments, 0, i);
-                    var folderName = segments[i];
-                    if (!AssetDatabase.IsValidFolder(parentPath + "/" + folderName))
-                        AssetDatabase.CreateFolder(parentPath, folderName);
+                    var segments = prefabAssetPath.Split('/');
+                    var currentPath = segments[0]; // "Assets"
+                    for (int i = 1; i < segments.Length - 1; i++)
+                    {
+                        var nextPath = currentPath + "/" + segments[i];
+                        if (!AssetDatabase.IsValidFolder(nextPath))
+                            AssetDatabase.CreateFolder(currentPath, segments[i]);
+                        currentPath = nextPath;
+                    }
                 }
 
                 UnityEngine.GameObject prefabGo;
@@ -117,8 +123,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 EditorUtils.RepaintAllEditorWindows();
 
-                var assetPrefab = AssetDatabase.LoadAssetAtPath<UnityEngine.GameObject>(prefabAssetPath);
-                return new AssetObjectRef(assetPrefab);
+                return new AssetObjectRef(prefabGo);
             });
         }
     }

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsPrefabCreateTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsPrefabCreateTests.cs
@@ -1,0 +1,360 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections;
+using System.Text.RegularExpressions;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public class AssetsPrefabCreateTests : BaseTest
+    {
+        const string TestFolderName = "Unity-MCP-Test-PrefabCreate";
+        const string TestFolder = "Assets/" + TestFolderName;
+
+        [TearDown]
+        public void PrefabTearDown()
+        {
+            if (AssetDatabase.IsValidFolder(TestFolder))
+                AssetDatabase.DeleteAsset(TestFolder);
+        }
+
+        void EnsureTestFolder()
+        {
+            if (!AssetDatabase.IsValidFolder(TestFolder))
+                AssetDatabase.CreateFolder("Assets", TestFolderName);
+        }
+
+        // ================================================================
+        // Main thread — create from scene GameObject
+        // ================================================================
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_Connected_MainThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/Connected_Main.prefab";
+            var go = new GameObject("TestGO_Connected_Main");
+            var id = go.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}},""connectGameObjectToPrefab"":true}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at: {prefabPath}");
+            Assert.IsTrue(PrefabUtility.IsPartOfPrefabInstance(go),
+                "Scene GameObject should be connected to the prefab (prefab instance).");
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_NotConnected_MainThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/Disconnected_Main.prefab";
+            var go = new GameObject("TestGO_Disconnected_Main");
+            var id = go.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}},""connectGameObjectToPrefab"":false}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at: {prefabPath}");
+            Assert.IsFalse(PrefabUtility.IsPartOfPrefabInstance(go),
+                "Scene GameObject should NOT be connected to the prefab.");
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_DefaultConnected_MainThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/Default_Main.prefab";
+            var go = new GameObject("TestGO_Default_Main");
+            var id = go.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}}}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at: {prefabPath}");
+            Assert.IsTrue(PrefabUtility.IsPartOfPrefabInstance(go),
+                "Default should connect scene GameObject to the prefab.");
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_AutoCreatesFolders_MainThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/Nested/Deep/Folder/AutoCreated.prefab";
+            var go = new GameObject("TestGO_Nested_Main");
+            var id = go.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}}}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at nested path: {prefabPath}");
+            Assert.IsTrue(AssetDatabase.IsValidFolder($"{TestFolder}/Nested/Deep/Folder"),
+                "Nested folders should have been created.");
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_WithComponents_MainThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/Components_Main.prefab";
+            var go = new GameObject("TestGO_Components_Main");
+            go.AddComponent<BoxCollider>();
+            go.AddComponent<Rigidbody>();
+            var id = go.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}},""connectGameObjectToPrefab"":false}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at: {prefabPath}");
+            Assert.IsNotNull(prefab!.GetComponent<BoxCollider>(), "Prefab should have BoxCollider.");
+            Assert.IsNotNull(prefab.GetComponent<Rigidbody>(), "Prefab should have Rigidbody.");
+        }
+
+        // ================================================================
+        // Main thread — Prefab Variant from scene prefab instance
+        // ================================================================
+
+        [UnityTest]
+        public IEnumerator Prefab_CreateVariant_FromScenePrefabInstance_MainThread()
+        {
+            EnsureTestFolder();
+
+            // Step 1: create a base prefab
+            var basePath = $"{TestFolder}/Base_Variant.prefab";
+            var baseGo = new GameObject("TestGO_Base_Variant");
+            baseGo.AddComponent<BoxCollider>();
+            var baseId = baseGo.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{basePath}"",""gameObjectRef"":{{""instanceID"":{baseId}}},""connectGameObjectToPrefab"":true}}");
+
+            // baseGo is now a prefab instance — modify it and save as variant
+            baseGo.AddComponent<SphereCollider>();
+            var variantPath = $"{TestFolder}/Variant_FromInstance.prefab";
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{variantPath}"",""gameObjectRef"":{{""instanceID"":{baseId}}},""connectGameObjectToPrefab"":true}}");
+
+            var variant = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+            Assert.IsNotNull(variant, $"Variant prefab should be created at: {variantPath}");
+            Assert.IsTrue(PrefabUtility.IsPartOfVariantPrefab(variant!),
+                "Created prefab should be a Prefab Variant.");
+        }
+
+        // ================================================================
+        // Main thread — Prefab Variant from asset path
+        // ================================================================
+
+        [UnityTest]
+        public IEnumerator Prefab_CreateVariant_FromAssetPath_MainThread()
+        {
+            EnsureTestFolder();
+
+            // Step 1: create a base prefab
+            var basePath = $"{TestFolder}/Base_AssetVariant.prefab";
+            var baseGo = new GameObject("TestGO_Base_AssetVariant");
+            baseGo.AddComponent<BoxCollider>();
+            var baseId = baseGo.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{basePath}"",""gameObjectRef"":{{""instanceID"":{baseId}}},""connectGameObjectToPrefab"":false}}");
+
+            // Step 2: create a variant from the asset path
+            var variantPath = $"{TestFolder}/Variant_FromAsset.prefab";
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{variantPath}"",""sourcePrefabAssetPath"":""{basePath}""}}");
+
+            var variant = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+            Assert.IsNotNull(variant, $"Variant prefab should be created at: {variantPath}");
+            Assert.IsTrue(PrefabUtility.IsPartOfVariantPrefab(variant!),
+                "Created prefab from asset path should be a Prefab Variant.");
+            Assert.IsNotNull(variant!.GetComponent<BoxCollider>(),
+                "Variant should inherit BoxCollider from the base prefab.");
+        }
+
+        // ================================================================
+        // Background thread tests
+        // ================================================================
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_Connected_BackgroundThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/Connected_Bg.prefab";
+            var go = new GameObject("TestGO_Connected_Bg");
+            var id = go.GetInstanceID();
+
+            yield return RunToolFromBackgroundThread(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}},""connectGameObjectToPrefab"":true}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at: {prefabPath}");
+            Assert.IsTrue(PrefabUtility.IsPartOfPrefabInstance(go),
+                "Scene GameObject should be connected to the prefab (background thread).");
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_NotConnected_BackgroundThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/Disconnected_Bg.prefab";
+            var go = new GameObject("TestGO_Disconnected_Bg");
+            var id = go.GetInstanceID();
+
+            yield return RunToolFromBackgroundThread(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}},""connectGameObjectToPrefab"":false}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at: {prefabPath}");
+            Assert.IsFalse(PrefabUtility.IsPartOfPrefabInstance(go),
+                "Scene GameObject should NOT be connected to the prefab (background thread).");
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_AutoCreatesFolders_BackgroundThread()
+        {
+            EnsureTestFolder();
+            var prefabPath = $"{TestFolder}/NestedBg/DeepBg/AutoCreatedBg.prefab";
+            var go = new GameObject("TestGO_Nested_Bg");
+            var id = go.GetInstanceID();
+
+            yield return RunToolFromBackgroundThread(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{prefabPath}"",""gameObjectRef"":{{""instanceID"":{id}}}}}");
+
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(prefab, $"Prefab should be created at nested path (background thread): {prefabPath}");
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_CreateVariant_FromAssetPath_BackgroundThread()
+        {
+            EnsureTestFolder();
+
+            // Step 1: create a base prefab (on main thread for setup)
+            var basePath = $"{TestFolder}/Base_AssetVariant_Bg.prefab";
+            var baseGo = new GameObject("TestGO_Base_AssetVariant_Bg");
+            var baseId = baseGo.GetInstanceID();
+
+            yield return RunToolMainThreadCoop(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{basePath}"",""gameObjectRef"":{{""instanceID"":{baseId}}},""connectGameObjectToPrefab"":false}}");
+
+            // Step 2: create variant from background thread
+            var variantPath = $"{TestFolder}/Variant_FromAsset_Bg.prefab";
+            yield return RunToolFromBackgroundThread(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{variantPath}"",""sourcePrefabAssetPath"":""{basePath}""}}");
+
+            var variant = AssetDatabase.LoadAssetAtPath<GameObject>(variantPath);
+            Assert.IsNotNull(variant, $"Variant prefab should be created at: {variantPath}");
+            Assert.IsTrue(PrefabUtility.IsPartOfVariantPrefab(variant!),
+                "Created prefab from asset path should be a Prefab Variant (background thread).");
+        }
+
+        // ================================================================
+        // Error cases
+        // ================================================================
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_EmptyPath_ReturnsError()
+        {
+            var go = new GameObject("TestGO_EmptyPath");
+            var id = go.GetInstanceID();
+
+            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
+            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
+            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+
+            var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":"""",""gameObjectRef"":{{""instanceID"":{id}}}}}");
+
+            StringAssert.Contains("Prefab path is empty", jsonResult);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_InvalidExtension_ReturnsError()
+        {
+            EnsureTestFolder();
+            var go = new GameObject("TestGO_InvalidExt");
+            var id = go.GetInstanceID();
+
+            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
+            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
+            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+
+            var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{TestFolder}/NotAPrefab.txt"",""gameObjectRef"":{{""instanceID"":{id}}}}}");
+
+            StringAssert.Contains("invalid", jsonResult);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_InvalidGameObjectRef_ReturnsError()
+        {
+            EnsureTestFolder();
+
+            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
+            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
+            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+
+            var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{TestFolder}/ShouldFail.prefab"",""gameObjectRef"":{{""instanceID"":-999999}}}}");
+
+            Assert.IsTrue(jsonResult.Contains("[Error]") || jsonResult.Contains("not found") || jsonResult.Contains("Error"),
+                $"Expected error for invalid gameObjectRef, got: {jsonResult}");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_NoGameObjectRefOrSourcePath_ReturnsError()
+        {
+            EnsureTestFolder();
+
+            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
+            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
+            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+
+            var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{TestFolder}/ShouldFail.prefab""}}");
+
+            Assert.IsTrue(jsonResult.Contains("[Error]") || jsonResult.Contains("must be provided") || jsonResult.Contains("Error"),
+                $"Expected error when neither gameObjectRef nor sourcePrefabAssetPath is provided, got: {jsonResult}");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Prefab_Create_InvalidSourcePrefabPath_ReturnsError()
+        {
+            EnsureTestFolder();
+
+            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
+            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
+            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+
+            var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
+                $@"{{""prefabAssetPath"":""{TestFolder}/ShouldFail.prefab"",""sourcePrefabAssetPath"":""{TestFolder}/NonExistent.prefab""}}");
+
+            Assert.IsTrue(jsonResult.Contains("[Error]") || jsonResult.Contains("not found") || jsonResult.Contains("Error"),
+                $"Expected error for invalid sourcePrefabAssetPath, got: {jsonResult}");
+            yield return null;
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsPrefabCreateTests.cs
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsPrefabCreateTests.cs
@@ -271,15 +271,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         // Error cases
         // ================================================================
 
+        static void ExpectToolErrorLogs()
+        {
+            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
+            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
+            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+        }
+
         [UnityTest]
         public IEnumerator Prefab_Create_EmptyPath_ReturnsError()
         {
             var go = new GameObject("TestGO_EmptyPath");
             var id = go.GetInstanceID();
 
-            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
-            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
-            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+            ExpectToolErrorLogs();
 
             var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
                 $@"{{""prefabAssetPath"":"""",""gameObjectRef"":{{""instanceID"":{id}}}}}");
@@ -295,9 +300,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var go = new GameObject("TestGO_InvalidExt");
             var id = go.GetInstanceID();
 
-            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
-            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
-            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+            ExpectToolErrorLogs();
 
             var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
                 $@"{{""prefabAssetPath"":""{TestFolder}/NotAPrefab.txt"",""gameObjectRef"":{{""instanceID"":{id}}}}}");
@@ -311,15 +314,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             EnsureTestFolder();
 
-            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
-            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
-            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+            ExpectToolErrorLogs();
 
             var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
                 $@"{{""prefabAssetPath"":""{TestFolder}/ShouldFail.prefab"",""gameObjectRef"":{{""instanceID"":-999999}}}}");
 
-            Assert.IsTrue(jsonResult.Contains("[Error]") || jsonResult.Contains("not found") || jsonResult.Contains("Error"),
-                $"Expected error for invalid gameObjectRef, got: {jsonResult}");
+            StringAssert.Contains("Not found", jsonResult);
             yield return null;
         }
 
@@ -328,15 +328,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             EnsureTestFolder();
 
-            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
-            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
-            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+            ExpectToolErrorLogs();
 
             var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
                 $@"{{""prefabAssetPath"":""{TestFolder}/ShouldFail.prefab""}}");
 
-            Assert.IsTrue(jsonResult.Contains("[Error]") || jsonResult.Contains("must be provided") || jsonResult.Contains("Error"),
-                $"Expected error when neither gameObjectRef nor sourcePrefabAssetPath is provided, got: {jsonResult}");
+            StringAssert.Contains("must be provided", jsonResult);
             yield return null;
         }
 
@@ -345,15 +342,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             EnsureTestFolder();
 
-            LogAssert.Expect(LogType.Exception, new Regex("ArgumentException"));
-            LogAssert.Expect(LogType.Error, new Regex("Tool execution failed"));
-            LogAssert.Expect(LogType.Error, new Regex("Error Response to AI"));
+            ExpectToolErrorLogs();
 
             var jsonResult = RunToolRaw(Tool_Assets_Prefab.AssetsPrefabCreateToolId,
                 $@"{{""prefabAssetPath"":""{TestFolder}/ShouldFail.prefab"",""sourcePrefabAssetPath"":""{TestFolder}/NonExistent.prefab""}}");
 
-            Assert.IsTrue(jsonResult.Contains("[Error]") || jsonResult.Contains("not found") || jsonResult.Contains("Error"),
-                $"Expected error for invalid sourcePrefabAssetPath, got: {jsonResult}");
+            StringAssert.Contains("not found", jsonResult);
             yield return null;
         }
     }

--- a/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsPrefabCreateTests.cs.meta
+++ b/Unity-MCP-Plugin/Assets/root/Tests/Editor/Tool/Assets/AssetsPrefabCreateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07cb2fd9c0c219940a0d9d396dfeb997
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- **Fix inverted ternary**: `connectGameObjectToPrefab=true` now correctly uses `SaveAsPrefabAssetAndConnect` (was using `SaveAsPrefabAsset` — the logic was backwards)
- **Rename parameter**: `replaceGameObjectWithPrefab` → `connectGameObjectToPrefab` with clearer description
- **Prefab Variant from asset**: New `sourcePrefabAssetPath` parameter creates Prefab Variants from existing prefab assets directly (instantiates temp instance, saves as variant, cleans up)
- **Auto folder creation**: Recursively creates parent folders via `AssetDatabase.CreateFolder` when they don't exist
- **16 tests**: Main thread + background thread coverage for create, connect/disconnect, variants, folder creation, components, and 5 error cases

Closes #645

## Test plan
- [x] All 16 `AssetsPrefabCreateTests` pass (EditMode)
- [x] No test artifacts left after cleanup (`TearDown` deletes test folder)
- [x] Prefab connected to scene GO (`SaveAsPrefabAssetAndConnect`)
- [x] Prefab not connected (`SaveAsPrefabAsset`)
- [x] Prefab Variant from scene prefab instance
- [x] Prefab Variant from asset path (`sourcePrefabAssetPath`)
- [x] Recursive folder creation
- [x] Component preservation (BoxCollider, Rigidbody)
- [x] Background thread safety for all operations
- [x] Error handling: empty path, invalid extension, invalid GO ref, missing source prefab, no input provided