### PR TITLE
fix: GitHub Copilot CLI uses project-local .mcp.json (#656)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
@@ -28,7 +28,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "GitHub Copilot CLI";
         public override string AgentId => "github-copilot-cli";
         public override string DownloadUrl => "https://github.com/features/copilot/cli";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".github", "skills");
+        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
 
         protected override string? IconFileName => "github-copilot-64.png";
 
@@ -47,6 +47,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             $"{Args.Authorization}={UnityMcpPluginEditor.AuthOption}",
             $"{Args.Token}={UnityMcpPluginEditor.Token}"
         }, requiredForConfiguration: true)
+        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("url")
         .SetPropertyToRemove("type");
 
@@ -63,6 +64,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             $"{Args.Authorization}={UnityMcpPluginEditor.AuthOption}",
             $"{Args.Token}={UnityMcpPluginEditor.Token}"
         }, requiredForConfiguration: true)
+        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("url")
         .SetPropertyToRemove("type");
 
@@ -73,6 +75,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         )
         .SetProperty("type", JsonValue.Create("http"), requiredForConfiguration: true)
         .SetProperty("url", JsonValue.Create(UnityMcpPluginEditor.Host), requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("command")
         .SetPropertyToRemove("args");
 
@@ -83,6 +86,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         )
         .SetProperty("type", JsonValue.Create("http"), requiredForConfiguration: true)
         .SetProperty("url", JsonValue.Create(UnityMcpPluginEditor.Host), requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
+        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("command")
         .SetPropertyToRemove("args");
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
@@ -9,7 +9,6 @@
 */
 
 #nullable enable
-using System;
 using System.IO;
 using System.Text.Json.Nodes;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
@@ -20,6 +19,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 {
     /// <summary>
     /// Configurator for Copilot CLI AI agent.
+    /// Uses project-local `.mcp.json` in the Unity project root. Copilot CLI v1.0.12+
+    /// discovers workspace-local MCP configs from the working directory up to the git
+    /// root, so the same `.mcp.json` is shared with Claude Code.
     /// </summary>
     public class GitHubCopilotCliConfigurator : AiAgentConfigurator
     {
@@ -30,15 +32,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
         protected override string? IconFileName => "github-copilot-64.png";
 
-        private static string GlobalConfigPath => Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".copilot",
-            "mcp-config.json"
-        );
+        private static string LocalConfigPath => Path.Combine(ProjectRootPath, ".mcp.json");
 
         protected override AiAgentConfig CreateConfigStdioWindows() => new JsonAiAgentConfig(
             name: AgentName,
-            configPath: GlobalConfigPath,
+            configPath: LocalConfigPath,
             bodyPath: DefaultBodyPath
         )
         .SetProperty("command", JsonValue.Create(McpServerManager.ExecutableFullPath.Replace('\\', '/')), requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
@@ -49,13 +47,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             $"{Args.Authorization}={UnityMcpPluginEditor.AuthOption}",
             $"{Args.Token}={UnityMcpPluginEditor.Token}"
         }, requiredForConfiguration: true)
-        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("url")
         .SetPropertyToRemove("type");
 
         protected override AiAgentConfig CreateConfigStdioMacLinux() => new JsonAiAgentConfig(
             name: AgentName,
-            configPath: GlobalConfigPath,
+            configPath: LocalConfigPath,
             bodyPath: DefaultBodyPath
         )
         .SetProperty("command", JsonValue.Create(McpServerManager.ExecutableFullPath.Replace('\\', '/')), requiredForConfiguration: true, comparison: ValueComparisonMode.Path)
@@ -66,29 +63,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             $"{Args.Authorization}={UnityMcpPluginEditor.AuthOption}",
             $"{Args.Token}={UnityMcpPluginEditor.Token}"
         }, requiredForConfiguration: true)
-        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("url")
         .SetPropertyToRemove("type");
 
         protected override AiAgentConfig CreateConfigHttpWindows() => new JsonAiAgentConfig(
             name: AgentName,
-            configPath: GlobalConfigPath,
+            configPath: LocalConfigPath,
             bodyPath: DefaultBodyPath
         )
         .SetProperty("type", JsonValue.Create("http"), requiredForConfiguration: true)
         .SetProperty("url", JsonValue.Create(UnityMcpPluginEditor.Host), requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
-        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("command")
         .SetPropertyToRemove("args");
 
         protected override AiAgentConfig CreateConfigHttpMacLinux() => new JsonAiAgentConfig(
             name: AgentName,
-            configPath: GlobalConfigPath,
+            configPath: LocalConfigPath,
             bodyPath: DefaultBodyPath
         )
         .SetProperty("type", JsonValue.Create("http"), requiredForConfiguration: true)
         .SetProperty("url", JsonValue.Create(UnityMcpPluginEditor.Host), requiredForConfiguration: true, comparison: ValueComparisonMode.Url)
-        .SetProperty("tools", new JsonArray { "*" }, requiredForConfiguration: false)
         .SetPropertyToRemove("command")
         .SetPropertyToRemove("args");
 
@@ -107,7 +101,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             var manualStepsContainer = TemplateFoldout("Manual Configuration Steps");
 
-            manualStepsContainer!.Add(TemplateLabelDescription("1. Open or create file '%User%/.copilot/mcp-config.json'"));
+            manualStepsContainer!.Add(TemplateLabelDescription("1. Open or create file '.mcp.json' in the Unity project root"));
             manualStepsContainer!.Add(TemplateLabelDescription("2. Copy and paste the configuration json into the file."));
             manualStepsContainer!.Add(TemplateTextFieldReadOnly(ConfigStdio.ExpectedFileContent));
 
@@ -115,6 +109,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             var troubleshootingContainerStdio = TemplateFoldout("Troubleshooting");
 
+            troubleshootingContainerStdio.Add(TemplateLabelDescription("- Ensure Copilot CLI is launched from the Unity project root (the folder containing '.mcp.json')"));
+            troubleshootingContainerStdio.Add(TemplateLabelDescription("- Requires GitHub Copilot CLI v1.0.12+ which discovers '.mcp.json' at project level"));
             troubleshootingContainerStdio.Add(TemplateLabelDescription("- Ensure MCP configuration file doesn't have syntax errors"));
             troubleshootingContainerStdio.Add(TemplateLabelDescription("- Restart Copilot CLI after configuration changes"));
 
@@ -131,7 +127,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             var manualStepsContainerHttp = TemplateFoldout("Manual Configuration Steps");
 
-            manualStepsContainerHttp!.Add(TemplateLabelDescription("1. Open or create file '%User%/.copilot/mcp-config.json'"));
+            manualStepsContainerHttp!.Add(TemplateLabelDescription("1. Open or create file '.mcp.json' in the Unity project root"));
             manualStepsContainerHttp!.Add(TemplateLabelDescription("2. Copy and paste the configuration json into the file."));
             manualStepsContainerHttp!.Add(TemplateTextFieldReadOnly(ConfigHttp.ExpectedFileContent));
 
@@ -139,6 +135,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             var troubleshootingContainerHttp = TemplateFoldout("Troubleshooting");
 
+            troubleshootingContainerHttp.Add(TemplateLabelDescription("- Ensure Copilot CLI is launched from the Unity project root (the folder containing '.mcp.json')"));
+            troubleshootingContainerHttp.Add(TemplateLabelDescription("- Requires GitHub Copilot CLI v1.0.12+ which discovers '.mcp.json' at project level"));
             troubleshootingContainerHttp.Add(TemplateLabelDescription("- Ensure MCP configuration file doesn't have syntax errors"));
             troubleshootingContainerHttp.Add(TemplateLabelDescription("- Restart Copilot CLI after configuration changes"));
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCodeCopilotConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCodeCopilotConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "vscode-copilot";
         public override string DownloadUrl => "https://code.visualstudio.com/download";
         public override string TutorialUrl => "https://www.youtube.com/watch?v=ZhP7Ju91mOE";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".github", "skills");
+        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
 
         protected override string? IconFileName => "vs-code-64.png";
 


### PR DESCRIPTION
## Summary

- Switch `GitHubCopilotCliConfigurator` from the global `~/.copilot/mcp-config.json` to the project-local `.mcp.json` in the Unity project root.
- Reuse the `mcpServers` wrapper (default `bodyPath`), so Copilot CLI shares the same file that `ClaudeCodeConfigurator` already writes — one `.mcp.json` per project, two agents.
- Update UI manual-configuration steps and troubleshooting hints: reference `.mcp.json`, note that Copilot CLI must be launched from the project root, and mention the v1.0.12+ requirement.

Closes #656.

## Why

Copilot CLI v1.0.12+ discovers workspace-local MCP configs by walking from the current working directory up to the git root, and accepts the `mcpServers` wrapper format. Using the project-local file means:

- Per-project port/token travel with the Unity project (no reconfiguration when switching projects).
- Config matches Claude Code's layout — both agents read one file.
- Teams can optionally commit `.mcp.json` to share MCP access across the team.

## Test plan

- [x] Open the Unity-MCP plugin UI, select **GitHub Copilot CLI**, and click **Configure**.
- [x] Verify `.mcp.json` is created/updated in the Unity project root with a `mcpServers.<server>` entry.
- [x] Verify the global file `~/.copilot/mcp-config.json` is **not** modified.
- [x] With Claude Code already configured, re-run Copilot CLI configuration and confirm existing Claude Code entries are preserved (and vice-versa when toggling transports).
- [x] Launch `copilot` from the Unity project root and confirm the Unity MCP server is discovered.
- [x] Verify manual-configuration UI text shows `.mcp.json` and the new troubleshooting hints.