### PR TITLE
fix: correct upside-down GameView screenshot on DirectX/Metal

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
@@ -51,20 +51,43 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 var rtField = gameViewType.GetField("m_RenderTexture",
                     BindingFlags.NonPublic | BindingFlags.Instance);
-                var rt = rtField?.GetValue(gameView) as RenderTexture;
+                var sourceRt = rtField?.GetValue(gameView) as RenderTexture;
 
-                if (rt == null || !rt.IsCreated())
+                if (sourceRt == null || !sourceRt.IsCreated())
                     return ResponseCallTool.Error("Game View render texture is not available. " +
                         "Ensure the Game View window is open and visible.");
+
+                // Read pixels from the GameView's internal render texture, then correct the
+                // orientation for graphics APIs that render with the origin at the top-left.
+                // Reading directly from the GameView RT produces a vertically flipped image on
+                // DirectX/Metal because Unity performs a Y-flip at display-blit time — a step
+                // bypassed when ReadPixels runs against the GameView RT directly.
+                // `SystemInfo.graphicsUVStartsAtTop` identifies the APIs that need the flip.
+                var width = sourceRt.width;
+                var height = sourceRt.height;
 
                 var prevActive = RenderTexture.active;
                 Texture2D? tex = null;
                 byte[]? pngBytes = null;
                 try
                 {
-                    RenderTexture.active = rt;
-                    tex = new Texture2D(rt.width, rt.height, TextureFormat.RGB24, false);
-                    tex.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+                    RenderTexture.active = sourceRt;
+                    tex = new Texture2D(width, height, TextureFormat.RGB24, false);
+                    tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+
+                    if (SystemInfo.graphicsUVStartsAtTop)
+                    {
+                        var pixels = tex.GetPixels32();
+                        var flipped = new Color32[pixels.Length];
+                        for (var y = 0; y < height; y++)
+                        {
+                            var srcRow = y * width;
+                            var dstRow = (height - 1 - y) * width;
+                            Array.Copy(pixels, srcRow, flipped, dstRow, width);
+                        }
+                        tex.SetPixels32(flipped);
+                    }
+
                     tex.Apply();
                     pngBytes = tex.EncodeToPNG();
                 }
@@ -76,7 +99,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 }
 
                 return ResponseCallTool.Image(pngBytes, McpPlugin.Common.Consts.MimeType.ImagePng,
-                    $"Screenshot from Game View ({rt.width}x{rt.height})");
+                    $"Screenshot from Game View ({width}x{height})");
             });
         }
     }


### PR DESCRIPTION
## Summary

- `screenshot-game-view` was returning a vertically flipped PNG on graphics APIs whose UV origin is at the top (DirectX, Metal). Root cause: the tool grabs the GameView's internal `m_RenderTexture` via reflection and calls `ReadPixels` against it directly, which bypasses the Y-flip that Unity normally performs at display-blit time. `screenshot-scene-view` and `screenshot-camera` are unaffected because they render a camera into a fresh RT they own.
- Gated a row-by-row pixel flip on `SystemInfo.graphicsUVStartsAtTop` so the image is correctly oriented on DirectX/Metal while leaving OpenGL paths unchanged.
- Verified the fix live against a running Unity Editor (Windows, DirectX): `screenshot-game-view` output now matches the orientation of `screenshot-camera` for the same scene (sky at top, ground at bottom).

## Audit of sibling screenshot tools

To rule out the same bug elsewhere, `Screenshot.SceneView.cs` and `Screenshot.Camera.cs` were re-read and live-tested against the same running Editor (Windows/DirectX):

- **`screenshot-camera`** — allocates a fresh `RenderTexture`, points the chosen camera at it via `targetTexture`, calls `camera.Render()`, then `ReadPixels`. The RT receives the camera's native top-left render output and `ReadPixels` samples with the matching top-left origin. No display blit is involved. Not affected by `graphicsUVStartsAtTop`.
- **`screenshot-scene-view`** — same pattern as `screenshot-camera`, using `sceneView.camera` (a regular `Camera` component) rendering into a caller-owned RT. Not affected.
- **`screenshot-game-view` (pre-fix)** — reads the GameView's display-bound backbuffer-space RT (`m_RenderTexture`) without the final display-time Y-flip, so on `graphicsUVStartsAtTop` APIs the data is inverted. Fixed by the row-flip in this PR.

Empirical live verification on Windows/DirectX after the fix — all three tools produce correctly oriented images (sky at top, ground at bottom) against the same scene.

## Test plan

- [x] Unity EditMode tests pass locally (779/779 passed)
- [x] PlayMode tests — not run; change is Editor-only
- [x] CLI tests — not run; `cli/` untouched
- [x] Visual verification on Windows/DirectX — fixed `screenshot-game-view` matches `screenshot-camera` reference composition
- [x] Orientation audit of `screenshot-scene-view` and `screenshot-camera` — no flip bug, no code changes needed

Closes #654