### PR TITLE
feat: tests-run aborts when any open scene is dirty

### DIFF
--- a/Unity-MCP-Plugin/.claude/skills/tests-run/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/tests-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tests-run
-description: Execute Unity tests and return detailed results. Supports filtering by test mode, assembly, namespace, class, and method. Recommended to use 'EditMode' for faster iteration during development.
+description: "Execute Unity tests and return detailed results. Supports filtering by test mode, assembly, namespace, class, and method. Recommended to use 'EditMode' for faster iteration during development. Precondition: every open scene MUST be saved (no unsaved changes). If any open scene is dirty, this tool throws an InvalidOperationException listing the dirty scenes; save them and retry."
 ---
 
 # Tests / Run

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
@@ -37,7 +37,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Execute Unity tests and return detailed results. " +
             "Supports filtering by test mode, assembly, namespace, class, and method. " +
-            "Recommended to use '" + nameof(TestMode.EditMode) + "' for faster iteration during development.")]
+            "Recommended to use '" + nameof(TestMode.EditMode) + "' for faster iteration during development. " +
+            "Precondition: every open scene MUST be saved (no unsaved changes). If any open scene is dirty, " +
+            "this tool throws an InvalidOperationException listing the dirty scenes; save them and retry.")]
         public static async Task<ResponseCallValueTool<TestRunResponse>> Run
         (
             [Description("Test mode to run. Options: '" + nameof(TestMode.EditMode) + "', '" + nameof(TestMode.PlayMode) + "'. Default: '" + nameof(TestMode.EditMode) + "'")]
@@ -74,6 +76,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             return await MainThread.Instance.RunAsync(async () =>
             {
+                // Abort before any state mutation if any open scene has unsaved changes.
+                // Running tests against a dirty scene is unsafe: Unity may reload the scene on
+                // play-mode entry, silently discarding edits and producing non-reproducible
+                // results. Throws InvalidOperationException listing every dirty scene so the
+                // caller can save and retry. MUST run before PlayerPrefs writes and before
+                // AssetDatabase.Refresh so nothing is side-effected on abort.
+                ThrowIfAnyOpenSceneIsDirty();
+
                 // Save display options to PlayerPrefs BEFORE AssetDatabase.Refresh —
                 // these must be persisted before a potential domain reload
                 TestResultCollector.TestCallRequestID.Value = requestId;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
@@ -9,15 +9,19 @@
 */
 
 #nullable enable
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.Unity.MCP.Editor.API.TestRunner;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
@@ -166,6 +170,61 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             var filter = CreateTestFilter(testMode, filterParams);
             TestRunnerApi.Execute(new ExecutionSettings(filter));
+        }
+
+        /// <summary>
+        /// Throws <see cref="InvalidOperationException"/> if any currently open scene has unsaved
+        /// changes (<see cref="Scene.isDirty"/>). The exception message lists every dirty scene's
+        /// name and path so the caller (LLM agent or human) can save them and retry.
+        ///
+        /// Running tests while a scene is dirty is unsafe: Unity may reload the scene when
+        /// entering play mode, silently discarding the unsaved edits and producing a test run
+        /// against a scene state that does not match either the in-memory scene or the asset
+        /// on disk. This check aborts before any state is mutated (no PlayerPrefs, no
+        /// AssetDatabase.Refresh, no domain reload is triggered).
+        ///
+        /// MUST be called on the Unity main thread.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if one or more open scenes have unsaved changes.
+        /// </exception>
+        internal static void ThrowIfAnyOpenSceneIsDirty()
+        {
+            var dirtyScenes = GetDirtyOpenScenes();
+            if (dirtyScenes.Count == 0)
+                return;
+
+            throw new InvalidOperationException(FormatDirtyScenesMessage(dirtyScenes));
+        }
+
+        /// <summary>
+        /// Returns every open scene whose <see cref="Scene.isDirty"/> is true.
+        /// MUST be called on the Unity main thread.
+        /// </summary>
+        internal static List<Scene> GetDirtyOpenScenes()
+        {
+            var result = new List<Scene>(capacity: EditorSceneManager.sceneCount);
+            for (var i = 0; i < EditorSceneManager.sceneCount; i++)
+            {
+                var scene = EditorSceneManager.GetSceneAt(i);
+                if (scene.isDirty)
+                    result.Add(scene);
+            }
+            return result;
+        }
+
+        internal static string FormatDirtyScenesMessage(IReadOnlyList<Scene> dirtyScenes)
+        {
+            var details = string.Join(", ", dirtyScenes.Select(FormatSceneForMessage));
+            return $"Cannot run tests: {dirtyScenes.Count} open scene(s) have unsaved changes: {details}. " +
+                "Save the scene(s) and try again.";
+        }
+
+        static string FormatSceneForMessage(Scene scene)
+        {
+            var name = string.IsNullOrEmpty(scene.name) ? "(untitled)" : scene.name;
+            var path = string.IsNullOrEmpty(scene.path) ? "(unsaved)" : scene.path;
+            return $"'{name}' ({path})";
         }
 
         private static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9072a1726bebcb419054de248bb697b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests/TestsRunDirtySceneTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests/TestsRunDirtySceneTests.cs
@@ -1,0 +1,122 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Tests for the precondition check in <c>tests-run</c>: the tool must throw
+    /// <see cref="InvalidOperationException"/> if any currently open scene has
+    /// unsaved changes, so the caller can save them before retrying.
+    /// </summary>
+    public class TestsRunDirtySceneTests
+    {
+        // The active scene is reused across tests in the Editor test runner, so we
+        // must always leave it non-dirty on teardown. We achieve that by creating a
+        // fresh empty untitled scene both before and after each test, which
+        // guarantees no accidental cross-test pollution.
+
+        [SetUp]
+        public void EnsureCleanScene()
+        {
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+        }
+
+        [TearDown]
+        public void RestoreCleanScene()
+        {
+            // Reset to a fresh empty scene so the next test (or the next session)
+            // never sees the dirty marker we may have set.
+            EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+        }
+
+        [Test]
+        public void GetDirtyOpenScenes_WhenNoSceneIsDirty_ReturnsEmptyList()
+        {
+            // Fresh empty scene from SetUp — nothing dirty.
+            var dirty = Tool_Tests.GetDirtyOpenScenes();
+
+            Assert.IsNotNull(dirty);
+            Assert.AreEqual(0, dirty.Count,
+                "Expected no dirty scenes immediately after creating a fresh empty scene.");
+        }
+
+        [Test]
+        public void ThrowIfAnyOpenSceneIsDirty_WhenNoSceneIsDirty_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() => Tool_Tests.ThrowIfAnyOpenSceneIsDirty());
+        }
+
+        [Test]
+        public void ThrowIfAnyOpenSceneIsDirty_WhenActiveSceneIsDirty_Throws()
+        {
+            MarkActiveSceneDirty();
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => Tool_Tests.ThrowIfAnyOpenSceneIsDirty());
+
+            Assert.IsNotNull(ex);
+            StringAssert.Contains("Cannot run tests", ex!.Message);
+            StringAssert.Contains("unsaved changes", ex.Message);
+            StringAssert.Contains("Save the scene", ex.Message);
+        }
+
+        [Test]
+        public void ThrowIfAnyOpenSceneIsDirty_Message_ContainsDirtySceneCount()
+        {
+            MarkActiveSceneDirty();
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => Tool_Tests.ThrowIfAnyOpenSceneIsDirty());
+
+            Assert.IsNotNull(ex);
+            // The untitled fresh scene counts as 1 dirty scene; the message must
+            // surface that count so the caller can see how many scenes to save.
+            StringAssert.Contains("1 open scene(s)", ex!.Message);
+        }
+
+        [Test]
+        public void GetDirtyOpenScenes_WhenActiveSceneIsDirty_ReturnsThatScene()
+        {
+            MarkActiveSceneDirty();
+
+            var dirty = Tool_Tests.GetDirtyOpenScenes();
+
+            Assert.AreEqual(1, dirty.Count,
+                "Exactly one open scene should be reported as dirty.");
+            Assert.IsTrue(dirty[0].isDirty,
+                "The returned scene must actually be dirty.");
+        }
+
+        // --- helpers ---------------------------------------------------------
+
+        /// <summary>
+        /// Marks the active scene as dirty by creating a GameObject inside it.
+        /// Any change to scene content flips the <c>isDirty</c> flag.
+        /// </summary>
+        static void MarkActiveSceneDirty()
+        {
+            // Spawn a GameObject — this is the simplest reliable way to make a
+            // scene dirty without depending on EditorSceneManager.MarkSceneDirty
+            // being available in every test configuration.
+            var go = new GameObject("TestsRunDirtyScene_Marker");
+            // Ensure it's parented in the active scene (default behavior).
+            var activeScene = UnityEngine.SceneManagement.SceneManager.GetActiveScene();
+            UnityEngine.SceneManagement.SceneManager.MoveGameObjectToScene(go, activeScene);
+            // Belt-and-braces: also explicitly mark the scene dirty.
+            EditorSceneManager.MarkSceneDirty(activeScene);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests/TestsRunDirtySceneTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests/TestsRunDirtySceneTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04b9914fb7e84b3408aa06b3b6daa096
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- `tests-run` previously allowed test execution while the active scene had unsaved changes. Running tests in that state is unsafe: Unity may reload the scene when entering play mode, silently discarding in-memory edits and producing a test run against a scene that matches neither the asset on disk nor the original in-memory state — giving non-reproducible results.
- Inspect every open scene's `Scene.isDirty` flag at the very top of the `Run` lambda (before any PlayerPrefs writes or `AssetDatabase.Refresh`) and **throw `InvalidOperationException`** if any are dirty.
- Exception message lists every dirty scene by name and path so the caller (LLM agent or human) knows exactly which scenes to save and retry.
- Tool `[Description]` updated to document the precondition; skill manifest regenerated accordingly.

## Design notes

- The check is deliberately OUTSIDE the existing `try/catch` block in the `Run` lambda. If it were inside, the catch handler would convert the exception into a structured `ResponseCallValueTool<TestRunResponse>.Error(...)` — a soft error that the issue explicitly rejects. Placing the check at the top lets the exception propagate out of the tool body as a hard signal, as requested.
- Helpers (`ThrowIfAnyOpenSceneIsDirty`, `GetDirtyOpenScenes`, `FormatDirtyScenesMessage`) are `internal static` on the existing `Tool_Tests` partial so the test assembly (already wired via `InternalsVisibleTo`) can exercise the dirty-scene branch directly without invoking `tests-run` recursively (the existing test suite deliberately does NOT call `tests-run` from inside tests).

## Test plan

- [x] Unity EditMode tests pass locally (784/784 — +5 new tests in `TestsRunDirtySceneTests`)
- [ ] PlayMode tests — not run; change is Editor-only
- [ ] CLI tests — not run; `cli/` untouched

Closes #661