### PR TITLE
feat: `unity-mcp-cli open` defaults to current directory

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -235,12 +235,16 @@ unity-mcp-cli install-unity --path ./MyGame
 Open a Unity project in the Unity Editor. By default, sets MCP connection environment variables if connection options are provided. Use `--no-connect` to open without MCP connection.
 
 ```bash
+# Explicit path
 unity-mcp-cli open ./MyGame
+
+# From inside the Unity project folder — path defaults to the current directory
+cd ./MyGame && unity-mcp-cli open
 ```
 
 | Option | Env Variable | Required | Description |
 |---|---|---|---|
-| `[path]` | — | Yes | Path to the Unity project (positional or `--path`) |
+| `[path]` | — | No | Path to the Unity project (positional or `--path`). Defaults to the current working directory. |
 | `--unity <version>` | — | No | Specific Unity Editor version to use (defaults to version from project settings, falls back to highest installed) |
 | `--no-connect` | — | No | Open without MCP connection environment variables |
 | `--url <url>` | `UNITY_MCP_HOST` | No | MCP server URL to connect to |

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -7,10 +7,50 @@ import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
 import { readConfig, isCloudMode, writeConfig } from '../utils/config.js';
 
+export interface ResolveProjectPathResult {
+  /** Absolute, resolved path to the project directory. */
+  projectPath: string;
+  /** True if no path was supplied and we fell back to `process.cwd()`. */
+  usedCwdFallback: boolean;
+}
+
+/**
+ * Resolve the project path from the positional argument, `--path` option, or
+ * the current working directory when neither is provided.
+ *
+ * Exported for unit testing.
+ */
+export function resolveOpenProjectPath(
+  positionalPath: string | undefined,
+  optionPath: string | undefined,
+  cwd: string,
+): ResolveProjectPathResult {
+  const explicit = positionalPath ?? optionPath;
+  const resolvedPath = explicit ?? cwd;
+  return {
+    projectPath: path.resolve(resolvedPath),
+    usedCwdFallback: explicit === undefined,
+  };
+}
+
+/**
+ * Returns true if `projectPath` looks like a Unity project — i.e. it contains
+ * an `Assets/` directory and a `ProjectSettings/ProjectVersion.txt` file.
+ *
+ * Exported for unit testing.
+ */
+export function isUnityProjectDir(projectPath: string): boolean {
+  const hasAssets = fs.existsSync(path.join(projectPath, 'Assets'));
+  const hasProjectVersion = fs.existsSync(
+    path.join(projectPath, 'ProjectSettings', 'ProjectVersion.txt'),
+  );
+  return hasAssets && hasProjectVersion;
+}
+
 export const openCommand = new Command('open')
   .description('Open a Unity project in Unity Editor, optionally passing MCP connection env vars when connection options (--url, --token, etc.) are provided. Use --no-connect to suppress all MCP env vars.')
-  .argument('[path]', 'Path to the Unity project')
-  .option('--path <path>', 'Path to the Unity project')
+  .argument('[path]', 'Path to the Unity project (defaults to current directory)')
+  .option('--path <path>', 'Path to the Unity project (defaults to current directory)')
   .option('--unity <version>', 'Specific Unity Editor version to use')
   .option('--no-connect', 'Open without MCP connection environment variables')
   .option('--url <url>', 'MCP server URL to connect to (sets UNITY_MCP_HOST)')
@@ -32,18 +72,34 @@ export const openCommand = new Command('open')
     transport?: string;
     startServer?: string;
   }) => {
-    const resolvedPath = positionalPath ?? options.path;
-    if (!resolvedPath) {
-      ui.error('Path is required. Usage: unity-mcp-cli open <path> or --path <path>');
-      process.exit(1);
-    }
-    const projectPath = path.resolve(resolvedPath);
+    const { projectPath, usedCwdFallback } = resolveOpenProjectPath(
+      positionalPath,
+      options.path,
+      process.cwd(),
+    );
 
     if (!fs.existsSync(projectPath)) {
       ui.error(`Project path does not exist: ${projectPath}`);
       process.exit(1);
     }
 
+    // Validate the directory looks like a Unity project. We require the
+    // presence of both `Assets/` and `ProjectSettings/ProjectVersion.txt`
+    // to avoid launching the Editor against an unrelated folder — this
+    // matters most when the user omits the path and we fall back to cwd.
+    if (!isUnityProjectDir(projectPath)) {
+      if (usedCwdFallback) {
+        ui.error(`Current directory is not a Unity project: ${projectPath}`);
+        ui.info('Run this command from a Unity project folder, or pass a path: unity-mcp-cli open <path>');
+      } else {
+        ui.error(`Not a Unity project (missing Assets/ or ProjectSettings/ProjectVersion.txt): ${projectPath}`);
+      }
+      process.exit(1);
+    }
+
+    if (usedCwdFallback) {
+      verbose(`No path provided — using current directory: ${projectPath}`);
+    }
     verbose(`open invoked for project: ${projectPath}`);
     verbose(`--no-connect: ${options.connect === false}`);
 

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -263,10 +263,12 @@ describe('CLI integration', () => {
       expect(stdout).toContain('--start-server');
     });
 
-    it('requires a project path', () => {
+    it('falls back to cwd and fails when cwd is not a Unity project', () => {
+      // With no arguments the CLI defaults to process.cwd(); when the cwd
+      // is not a Unity project it should exit 1 with a helpful message.
       const { exitCode, stdout } = runCli(['open']);
       expect(exitCode).toBe(1);
-      expect(stdout).toContain('Path is required');
+      expect(stdout).toContain('Current directory is not a Unity project');
     });
   });
 

--- a/cli/tests/open.test.ts
+++ b/cli/tests/open.test.ts
@@ -1,16 +1,24 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { isUnityProjectDir, resolveOpenProjectPath } from '../src/commands/open.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
 
-function runCli(args: string[]): { stdout: string; exitCode: number } {
+interface RunCliOptions {
+  cwd?: string;
+}
+
+function runCli(args: string[], opts: RunCliOptions = {}): { stdout: string; exitCode: number } {
   try {
     const stdout = execFileSync('node', [CLI_PATH, ...args], {
       encoding: 'utf-8',
       timeout: 10000,
+      cwd: opts.cwd,
     });
     return { stdout, exitCode: 0 };
   } catch (err: unknown) {
@@ -20,6 +28,17 @@ function runCli(args: string[]): { stdout: string; exitCode: number } {
       exitCode: error.status ?? 1,
     };
   }
+}
+
+/** Create a minimal Unity-project-shaped directory (Assets + ProjectVersion.txt). */
+function makeFakeUnityProject(dir: string): void {
+  fs.mkdirSync(path.join(dir, 'Assets'), { recursive: true });
+  const settingsDir = path.join(dir, 'ProjectSettings');
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(settingsDir, 'ProjectVersion.txt'),
+    'm_EditorVersion: 6000.0.0f1\n',
+  );
 }
 
 describe('open command (merged open + connect)', () => {
@@ -47,15 +66,116 @@ describe('open command (merged open + connect)', () => {
     expect(stdout).toContain('--unity');
   });
 
-  it('fails when no path is provided', () => {
-    const { exitCode, stdout } = runCli(['open']);
-    expect(exitCode).toBe(1);
-    expect(stdout).toContain('Path is required');
+  it('documents the path argument as optional in help', () => {
+    const { stdout, exitCode } = runCli(['open', '--help']);
+    expect(exitCode).toBe(0);
+    // Commander renders optional positionals with square brackets.
+    expect(stdout).toContain('[path]');
+    expect(stdout).toContain('current directory');
   });
 
   it('fails when project path does not exist', () => {
     const { exitCode, stdout } = runCli(['open', '/nonexistent/path/12345']);
     expect(exitCode).toBe(1);
     expect(stdout).toContain('does not exist');
+  });
+
+  it('rejects an existing path that is not a Unity project', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-open-test-'));
+    try {
+      const { exitCode, stdout } = runCli(['open', tmpDir]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('Not a Unity project');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('open command — cwd fallback (no path argument)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-open-cwd-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('fails with a helpful message when cwd is not a Unity project', () => {
+    const { exitCode, stdout } = runCli(['open'], { cwd: tmpDir });
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Current directory is not a Unity project');
+    // The hint should mention the explicit-path workaround.
+    expect(stdout).toContain('unity-mcp-cli open <path>');
+  });
+});
+
+// ── Unit tests for the extracted validation helpers ───────────────────────────
+//
+// These exercise the pure helpers directly so we can cover the positive path
+// (cwd IS a Unity project) without risking a real Unity Editor launch inside a
+// subprocess test.
+
+describe('resolveOpenProjectPath', () => {
+  it('returns the positional argument resolved to absolute when provided', () => {
+    const result = resolveOpenProjectPath('some/path', undefined, '/fake/cwd');
+    expect(result.projectPath).toBe(path.resolve('some/path'));
+    expect(result.usedCwdFallback).toBe(false);
+  });
+
+  it('prefers the positional argument over --path when both are given', () => {
+    const result = resolveOpenProjectPath('positional/path', 'option/path', '/fake/cwd');
+    expect(result.projectPath).toBe(path.resolve('positional/path'));
+    expect(result.usedCwdFallback).toBe(false);
+  });
+
+  it('falls back to --path when no positional argument is given', () => {
+    const result = resolveOpenProjectPath(undefined, 'option/path', '/fake/cwd');
+    expect(result.projectPath).toBe(path.resolve('option/path'));
+    expect(result.usedCwdFallback).toBe(false);
+  });
+
+  it('falls back to cwd when neither positional nor --path is given', () => {
+    const cwd = path.resolve('/fake/cwd');
+    const result = resolveOpenProjectPath(undefined, undefined, cwd);
+    expect(result.projectPath).toBe(cwd);
+    expect(result.usedCwdFallback).toBe(true);
+  });
+});
+
+describe('isUnityProjectDir', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-is-unity-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns false for an empty directory', () => {
+    expect(isUnityProjectDir(tmpDir)).toBe(false);
+  });
+
+  it('returns false when only Assets/ exists', () => {
+    fs.mkdirSync(path.join(tmpDir, 'Assets'));
+    expect(isUnityProjectDir(tmpDir)).toBe(false);
+  });
+
+  it('returns false when only ProjectSettings/ProjectVersion.txt exists', () => {
+    fs.mkdirSync(path.join(tmpDir, 'ProjectSettings'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'ProjectSettings', 'ProjectVersion.txt'),
+      'm_EditorVersion: 6000.0.0f1\n',
+    );
+    expect(isUnityProjectDir(tmpDir)).toBe(false);
+  });
+
+  it('returns true when both Assets/ and ProjectSettings/ProjectVersion.txt exist', () => {
+    makeFakeUnityProject(tmpDir);
+    expect(isUnityProjectDir(tmpDir)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- `unity-mcp-cli open` now falls back to `process.cwd()` when no positional path and no `--path` option are supplied, so running the command from inside a Unity project folder works with no arguments.
- The resolved directory is validated as a Unity project (must contain both `Assets/` and `ProjectSettings/ProjectVersion.txt`) before launching the Editor, with a tailored error when the cwd fallback lands on a non-Unity folder.
- `--help` output and `cli/README.md` now document the positional path as optional.

## Implementation notes

- Extracted two small pure helpers (`resolveOpenProjectPath`, `isUnityProjectDir`) from `cli/src/commands/open.ts` so the path-resolution and validation logic can be unit-tested without spawning the Editor.
- No behavioural change for the existing `unity-mcp-cli open <path>` and `unity-mcp-cli open --path <path>` usages aside from the stricter Unity-project validation (previously there was none at this layer — the Editor would be asked to open any existing directory).

## Test plan

- [x] `npm test` in `cli/` — 183/183 tests pass locally (Windows)
- [x] Added unit tests for `resolveOpenProjectPath` (positional / `--path` / cwd-fallback precedence)
- [x] Added unit tests for `isUnityProjectDir` (empty dir, Assets-only, ProjectVersion-only, both)
- [x] Added CLI integration test: `unity-mcp-cli open` in non-Unity cwd prints `Current directory is not a Unity project` and exits 1
- [x] Updated existing `cli.test.ts` "requires a project path" case to reflect the new cwd fallback behaviour
- [x] Updated existing `open.test.ts` "fails when no path is provided" case to cover the explicit-non-Unity-path path
- [x] Verified `--help` output manually shows `[path]` as optional and mentions "defaults to current directory"

Closes #655