### PR TITLE
fix(commands): add missing name frontmatter to all speckit commands

### DIFF
--- a/.claude/commands/speckit.analyze.md
+++ b/.claude/commands/speckit.analyze.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.analyze
 description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
 ---
 

--- a/.claude/commands/speckit.checklist.md
+++ b/.claude/commands/speckit.checklist.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.checklist
 description: Generate a custom checklist for the current feature based on user requirements.
 ---
 

--- a/.claude/commands/speckit.clarify.md
+++ b/.claude/commands/speckit.clarify.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.clarify
 description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
 handoffs: 
   - label: Build Technical Plan

--- a/.claude/commands/speckit.constitution.md
+++ b/.claude/commands/speckit.constitution.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.constitution
 description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
 handoffs: 
   - label: Build Specification

--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.implement
 description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
 ---
 

--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.plan
 description: Execute the implementation planning workflow using the plan template to generate design artifacts.
 handoffs: 
   - label: Create Tasks

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.specify
 description: Create or update the feature specification from a natural language feature description.
 handoffs: 
   - label: Build Technical Plan

--- a/.claude/commands/speckit.tasks.md
+++ b/.claude/commands/speckit.tasks.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.tasks
 description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
 handoffs: 
   - label: Analyze For Consistency

--- a/.claude/commands/speckit.taskstoissues.md
+++ b/.claude/commands/speckit.taskstoissues.md
@@ -1,4 +1,5 @@
 ---
+name: speckit.taskstoissues
 description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
 tools: ['github/github-mcp-server/issue_write']
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All 9 speckit command files in `.claude/commands/` are missing the `name` frontmatter field:

- `speckit.taskstoissues.md`
- `speckit.analyze.md`
- `speckit.checklist.md`
- `speckit.clarify.md`
- `speckit.constitution.md`
- `speckit.implement.md`
- `speckit.plan.md`
- `speckit.specify.md`
- `speckit.tasks.md`

## Why it matters

Claude Code uses the `name` frontmatter field for command registration and user-facing display in the command palette. Without it, Claude Code cannot correctly identify these commands — they may be silently dropped or misidentified, making the entire speckit workflow suite unavailable or unreliable for users.

The [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code/slash-commands) specifies that the `name` field is required for proper command registration.

## Fix

Added `name: speckit.<command>` to the frontmatter of each file, matching the filename convention (e.g. `speckit.plan.md` → `name: speckit.plan`). No other content was changed.

```diff
 ---
+name: speckit.plan
 description: Execute the implementation planning workflow...
```

This is a one-line fix per file with zero functional impact on command behaviour — it only enables correct registration.