### PR TITLE
fix(security): replace Invoke-Expression with argument array in run-act-test.ps1

### DIFF
--- a/commands/run-act-test.ps1
+++ b/commands/run-act-test.ps1
@@ -164,36 +164,36 @@ if ($missingSecrets.Count -gt 0) {
 }
 
 # ============================================================================
-# Build act command
+# Build act argument array (avoids Invoke-Expression injection surface)
 # ============================================================================
 
-# Base command
-$actCommand = "act workflow_dispatch -j $JobName -W $WorkflowFile"
+# Base arguments
+$actArgs = @('workflow_dispatch', '-j', $JobName, '-W', $WorkflowFile)
 
 # Add secrets
 foreach ($key in $secrets.Keys) {
-    $actCommand += " -s $key=`"$($secrets[$key])`""
+    $actArgs += @('-s', "${key}=$($secrets[$key])")
 }
 
 # Add debugging flags
 if ($Verbose) {
-    $actCommand += " --verbose"
+    $actArgs += '--verbose'
 }
 
 if ($DryRun) {
-    $actCommand += " --dryrun"
+    $actArgs += '--dryrun'
 }
 
 if ($StepDebug) {
-    $actCommand += " --env ACTIONS_STEP_DEBUG=true"
+    $actArgs += @('--env', 'ACTIONS_STEP_DEBUG=true')
 }
 
 # Add artifact support
 $artifactPath = "./.act-artifacts"
-$actCommand += " --artifact-server-path `"$artifactPath`""
+$actArgs += @('--artifact-server-path', $artifactPath)
 
 # Add container architecture for consistency
-$actCommand += " --container-architecture linux/amd64"
+$actArgs += @('--container-architecture', 'linux/amd64')
 
 # ============================================================================
 # Display execution info
@@ -223,12 +223,12 @@ $startTime = Get-Date
 
 if ($LogFile) {
     # Execute with log file
-    Invoke-Expression "$actCommand 2>&1 | Tee-Object -FilePath `"$LogFile`""
+    & act @actArgs 2>&1 | Tee-Object -FilePath $LogFile
     $exitCode = $LASTEXITCODE
 }
 else {
     # Execute normally
-    Invoke-Expression $actCommand
+    & act @actArgs
     $exitCode = $LASTEXITCODE
 }
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Issue (Medium)

`commands/run-act-test.ps1` builds an `$actCommand` string by concatenating `$JobName`, `$WorkflowFile`, secret values from the `.env` file, and flag strings, then executes it via `Invoke-Expression`. This is a command-injection surface: if any `.env` value contains PowerShell metacharacters (backticks, `$(...)`, semicolons, `&`), the expression can be widened beyond intent.

```powershell
# Before — injection surface
$actCommand = "act workflow_dispatch -j $JobName -W $WorkflowFile"
foreach ($key in $secrets.Keys) {
    $actCommand += " -s $key=`"$($secrets[$key])`""
}
# ...
Invoke-Expression $actCommand
```

## Fix

Replace the string-building approach with a typed argument array (`$actArgs`) and invoke `act` using the PowerShell call operator (`& act @actArgs`). Argument splatting never invokes PowerShell's expression parser — each array element is passed as a discrete argument to the process, making metacharacter injection impossible.

```powershell
# After — no expression parsing
$actArgs = @('workflow_dispatch', '-j', $JobName, '-W', $WorkflowFile)
foreach ($key in $secrets.Keys) {
    $actArgs += @('-s', "${key}=$($secrets[$key])")
}
# ...
& act @actArgs
```

The `LogFile` path (which previously used a pipeline inside `Invoke-Expression`) is now handled by a standard PowerShell pipeline outside the expression context.

## Impact

This is a developer-only local script (not CI-facing), so real-world exploitability is low. However, the `Invoke-Expression` pattern is categorically unsafe — this fix removes the risk entirely with a straightforward refactor.