### PR TITLE
fix(security): validate remote URL and escape commit messages in generate-release.ps1

### DIFF
--- a/commands/generate-release.ps1
+++ b/commands/generate-release.ps1
@@ -17,6 +17,13 @@ if ($repoUrl -match '^git@github\.com:(.+)') {
     $repoUrl = "https://github.com/$($matches[1])"
 }
 
+# Validate remote URL is a standard GitHub repo path (guard against tampered remotes)
+if ($repoUrl -notmatch '^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+    Write-Error "Unexpected remote URL '$repoUrl' — aborting to prevent unintended GitHub API calls."
+    Pop-Location
+    exit 1
+}
+
 $filename = "release_${VersionFrom}_to_${VersionTo}.md"
 
 # Clear existing release.md if it exists
@@ -68,8 +75,11 @@ foreach ($sha in $commits) {
     $message = git log -1 --pretty=format:'%s' $sha
     $shortSha = git log -1 --pretty=format:'%h' $sha | ForEach-Object { $_.Substring(0, 6) }
 
+    # Escape markdown special characters in commit message to prevent content injection
+    $safemessage = $message -replace '\[', '\[' -replace '\]', '\]' -replace '<', '&lt;' -replace '>', '&gt;'
+
     # Add commit line to release.md
-    Add-Content -Path $filename -Value "- [``$shortSha``]($repoUrl/commit/$sha) — $message by @$username"
+    Add-Content -Path $filename -Value "- [``$shortSha``]($repoUrl/commit/$sha) — $safemessage by @$username"
 }
 
 Write-Host "Release notes generated successfully in $filename"


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Issues (Medium)

`commands/generate-release.ps1` has two related content-injection risks:

### 1. Untrusted `origin` remote URL

The script calls `git remote get-url origin` and derives `$repoPath` from the result, which it then passes directly to `gh api "repos/$repoPath/commits/$sha"`. If an attacker can modify the `origin` remote (e.g. via `git remote set-url origin`), the script will make GitHub API calls for an attacker-controlled repo and embed that repo's data into the release notes.

### 2. Unsanitized commit message in markdown output

Commit subjects (`git log --pretty=format:'%s'`) are written verbatim into the release notes file:

```powershell
Add-Content -Path $filename -Value "- [``$shortSha``]($repoUrl/commit/$sha) — $message by @$username"
```

A commit subject like `[evil link](https://attacker.example)` or `<script>alert(1)</script>` would be rendered as-is if the markdown file is published or displayed in a web context.

## Fix

**Remote URL validation** — added a regex guard immediately after parsing `$repoUrl`. If the URL does not match the expected `https://github.com/owner/repo` pattern, the script aborts before making any API call:

```powershell
if ($repoUrl -notmatch '^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
    Write-Error "Unexpected remote URL '$repoUrl' — aborting to prevent unintended GitHub API calls."
    Pop-Location
    exit 1
}
```

**Commit message escaping** — markdown brackets and HTML angle brackets are escaped before writing to the output file:

```powershell
$safemessage = $message -replace '\[', '\[' -replace '\]', '\]' -replace '<', '&lt;' -replace '>', '&gt;'
Add-Content -Path $filename -Value "- [``$shortSha``]($repoUrl/commit/$sha) — $safemessage by @$username"
```

Both changes are additive — no existing functionality is affected.