### PR TITLE
fix: skip warnings for NuGet development-dependency packages

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/AssemblyInfo.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+/*
++------------------------------------------------------------------+
+|  Author: Ivan Murzak (https://github.com/IvanMurzak)             |
+|  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    |
+|  Copyright (c) 2025 Ivan Murzak                                  |
+|  Licensed under the Apache License, Version 2.0.                 |
+|  See the LICENSE file in the project root for more information.  |
++------------------------------------------------------------------+
+*/
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("com.IvanMurzak.Unity.MCP.Editor.Tests")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/AssemblyInfo.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5998882373eba7045997c6cb7b10662f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetExtractor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetExtractor.cs
@@ -92,6 +92,48 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
         }
 
         /// <summary>
+        /// Returns true if the .nupkg is marked as a development-only dependency
+        /// (<c>&lt;developmentDependency&gt;true&lt;/developmentDependency&gt;</c> in its .nuspec).
+        /// These packages ship analyzers, source generators, or build-time assets under
+        /// <c>analyzers/</c>, <c>build/</c>, <c>tools/</c> etc. — never runtime DLLs under
+        /// <c>lib/&lt;tfm&gt;/</c>. They are legitimately empty from the resolver's point of view
+        /// and should not trigger "No compatible framework" / "No DLLs extracted" warnings.
+        /// Returns false on any parse error so callers fall back to the normal extraction path.
+        /// </summary>
+        public static bool IsDevelopmentDependency(string nupkgPath)
+        {
+            try
+            {
+                using var zip = ZipFile.OpenRead(nupkgPath);
+
+                // .nuspec is always at the archive root (exactly one per package).
+                var nuspecEntry = zip.Entries.FirstOrDefault(e =>
+                    e.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase) &&
+                    !e.FullName.Contains('/'));
+
+                if (nuspecEntry == null)
+                    return false;
+
+                using var stream = nuspecEntry.Open();
+                var doc = XDocument.Load(stream);
+                var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+
+                var devDep = doc.Root?
+                    .Element(ns + "metadata")?
+                    .Element(ns + "developmentDependency")?
+                    .Value;
+
+                return string.Equals(devDep?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                // Corrupt / unreadable nupkg — treat as "not a dev dep" so the normal
+                // extraction path runs and surfaces the real error.
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Reads the .nuspec from a .nupkg and returns the transitive dependencies
         /// for the best matching target framework group.
         /// </summary>

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetExtractor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetExtractor.cs
@@ -107,9 +107,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                 using var zip = ZipFile.OpenRead(nupkgPath);
 
                 // .nuspec is always at the archive root (exactly one per package).
+                // Normalize backslashes to forward slashes so archives that use '\' as the
+                // path separator are matched the same way as ExtractDlls() treats them.
                 var nuspecEntry = zip.Entries.FirstOrDefault(e =>
-                    e.FullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase) &&
-                    !e.FullName.Contains('/'));
+                {
+                    var fullName = e.FullName.Replace('\\', '/');
+                    return fullName.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase) &&
+                           !fullName.Contains('/');
+                });
 
                 if (nuspecEntry == null)
                     return false;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetExtractor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetExtractor.cs
@@ -100,7 +100,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
         /// and should not trigger "No compatible framework" / "No DLLs extracted" warnings.
         /// Returns false on any parse error so callers fall back to the normal extraction path.
         /// </summary>
-        public static bool IsDevelopmentDependency(string nupkgPath)
+        internal static bool IsDevelopmentDependency(string nupkgPath)
         {
             try
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
@@ -99,6 +99,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                     }
                 }
 
+                // Development-only dependencies (e.g. Roslyn analyzers, source generators,
+                // build-time tooling) ship their payload under analyzers/, build/, tools/ etc.
+                // — never under lib/<tfm>/ — so there are no runtime DLLs for the resolver
+                // to extract and the "No DLLs extracted" warning would be a false positive.
+                // Record them in the session closure so transitive resolution stays complete,
+                // but do not create an install directory or extract anything. Any stale
+                // empty dir/.meta left over from a pre-fix install is cleaned up by
+                // RemoveUnnecessaryPackages().
+                if (NuGetExtractor.IsDevelopmentDependency(nupkgPath))
+                {
+                    installedThisSession[package.Id] = package.Version;
+                    return anyInstalled;
+                }
+
                 // Extract DLLs only when not already on disk at this exact version.
                 if (!alreadyOnDisk)
                 {
@@ -180,14 +194,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                     continue;
                 }
 
-                // Case 2: unrequired package — remove only when Unity provides every DLL it ships.
+                // Case 2a: empty directory left behind by a pre-fix install of a development-only
+                // dependency (e.g. Roslyn analyzer) — the installer used to create an empty dir
+                // and .meta before recognising that dev-deps have no lib/<tfm>/ payload. Also
+                // cleans up any other unrequired empty directory so strays don't accumulate.
+                var dllFiles = Directory.GetFiles(dir, "*.dll", SearchOption.AllDirectories);
+                if (dllFiles.Length == 0)
+                {
+                    Debug.Log($"{Tag} Removing {dirName} — empty package directory (not in current closure).");
+                    DeleteDirAndMeta(dir);
+                    anyRemoved = true;
+                    continue;
+                }
+
+                // Case 2b: unrequired package — remove only when Unity provides every DLL it ships.
                 // Using the NuGet package ID directly is unreliable because a package often ships
                 // DLLs with names that differ from the package ID (e.g., Microsoft.Bcl.Memory
                 // ships System.Memory / System.Buffers / System.Runtime.CompilerServices.Unsafe).
-                var dllFiles = Directory.GetFiles(dir, "*.dll", SearchOption.AllDirectories);
-                if (dllFiles.Length == 0)
-                    continue;
-
                 var allProvidedByUnity = dllFiles.All(dll =>
                     UnityAssemblyResolver.IsAlreadyImported(Path.GetFileNameWithoutExtension(dll)));
                 if (!allProvidedByUnity)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
@@ -140,15 +140,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
 
         /// <summary>
         /// Removes previously-installed NuGet package directories that should no longer exist:
-        ///   1. Stale-version directories for any package in the resolved session closure —
-        ///      both configured packages AND their transitive dependencies
-        ///      (e.g., a leftover "Microsoft.AspNetCore.SignalR.Common.10.0.3" when the current
-        ///      closure resolves that transitive to "8.0.15"). Keeping both produces
-        ///      duplicate-assembly conflicts.
-        ///   2a. Empty package directories (no DLLs) that aren't in the current closure —
-        ///       typically migration cruft from a pre-fix install of a development-only
-        ///       dependency (Roslyn analyzer, source generator, build tooling).
-        ///   2b. Directories whose DLLs are now all provided by Unity (e.g., after a Unity
+        ///   1a. Empty package directories (no DLLs anywhere under them) — typically migration
+        ///       cruft from a pre-fix install of a development-only dependency (Roslyn analyzer,
+        ///       source generator, build tooling). Always deleted, regardless of whether the
+        ///       package ID is in the current closure, so stale empty dirs don't keep forcing
+        ///       AllPackagesInstalled() to return false.
+        ///   1b. Stale-version directories for any package in the resolved session closure —
+        ///       both configured packages AND their transitive dependencies
+        ///       (e.g., a leftover "Microsoft.AspNetCore.SignalR.Common.10.0.3" when the current
+        ///       closure resolves that transitive to "8.0.15"). Keeping both produces
+        ///       duplicate-assembly conflicts.
+        ///   2.  Directories whose DLLs are now all provided by Unity (e.g., after a Unity
         ///       upgrade that bundled the BCL assembly) and whose package ID is not in the closure.
         ///
         /// <paramref name="requiredVersionByPackageId"/> must contain the full resolved closure
@@ -184,7 +186,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                     continue;
                 }
 
-                // Case 1: configured package with a stale on-disk version — delete the stale one.
+                // Case 1a: empty directory left behind by a pre-fix install of a development-only
+                // dependency (e.g. Roslyn analyzer) — the installer used to create an empty dir
+                // and .meta before recognising that dev-deps have no lib/<tfm>/ payload. Run
+                // this check BEFORE the stale-version / closure-membership branches so empty
+                // dirs get cleaned up even when the package is still in the current closure
+                // (otherwise the AllPackagesInstalled() empty-dir check would force a full
+                // restore on every domain reload).
+                var dllFiles = Directory.GetFiles(dir, "*.dll", SearchOption.AllDirectories);
+                if (dllFiles.Length == 0)
+                {
+                    Debug.Log($"{Tag} Removing {dirName} — empty package directory (no DLL payload).");
+                    DeleteDirAndMeta(dir);
+                    anyRemoved = true;
+                    continue;
+                }
+
+                // Case 1b: configured package with a stale on-disk version — delete the stale one.
                 if (requiredVersionByPackageId.TryGetValue(packageId, out var requiredVersion))
                 {
                     var dirVersion = dirName.Substring(packageId.Length + 1);
@@ -197,20 +215,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                     continue;
                 }
 
-                // Case 2a: empty directory left behind by a pre-fix install of a development-only
-                // dependency (e.g. Roslyn analyzer) — the installer used to create an empty dir
-                // and .meta before recognising that dev-deps have no lib/<tfm>/ payload. Also
-                // cleans up any other unrequired empty directory so strays don't accumulate.
-                var dllFiles = Directory.GetFiles(dir, "*.dll", SearchOption.AllDirectories);
-                if (dllFiles.Length == 0)
-                {
-                    Debug.Log($"{Tag} Removing {dirName} — empty package directory (not in current closure).");
-                    DeleteDirAndMeta(dir);
-                    anyRemoved = true;
-                    continue;
-                }
-
-                // Case 2b: unrequired package — remove only when Unity provides every DLL it ships.
+                // Case 2: unrequired package — remove only when Unity provides every DLL it ships.
                 // Using the NuGet package ID directly is unreliable because a package often ships
                 // DLLs with names that differ from the package ID (e.g., Microsoft.Bcl.Memory
                 // ships System.Memory / System.Buffers / System.Runtime.CompilerServices.Unsafe).

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
@@ -145,8 +145,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
         ///      (e.g., a leftover "Microsoft.AspNetCore.SignalR.Common.10.0.3" when the current
         ///      closure resolves that transitive to "8.0.15"). Keeping both produces
         ///      duplicate-assembly conflicts.
-        ///   2. Directories whose DLLs are now all provided by Unity (e.g., after a Unity
-        ///      upgrade that bundled the BCL assembly) and whose package ID is not in the closure.
+        ///   2a. Empty package directories (no DLLs) that aren't in the current closure —
+        ///       typically migration cruft from a pre-fix install of a development-only
+        ///       dependency (Roslyn analyzer, source generator, build tooling).
+        ///   2b. Directories whose DLLs are now all provided by Unity (e.g., after a Unity
+        ///       upgrade that bundled the BCL assembly) and whose package ID is not in the closure.
         ///
         /// <paramref name="requiredVersionByPackageId"/> must contain the full resolved closure
         /// (pass <see cref="InstalledThisSession"/> from the restorer after Install() calls).

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageRestorer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageRestorer.cs
@@ -86,9 +86,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
             if (!Directory.Exists(NuGetConfig.InstallPath))
                 return false;
 
-            // Every configured package must be installed at the configured version.
+            // Every configured package must be installed at the configured version, UNLESS the
+            // package is a development-only dependency (analyzers, source generators, build
+            // tooling). The installer intentionally does not create an install dir for those,
+            // so demanding one here would force a needless full restore every session for any
+            // user who configures a dev-dep as a top-level package.
             foreach (var package in NuGetConfig.Packages)
             {
+                if (IsCachedDevelopmentDependency(package))
+                    continue;
+
                 var installDir = Path.Combine(NuGetConfig.InstallPath, package.InstallDirectoryName);
                 if (!Directory.Exists(installDir) || Directory.GetFiles(installDir, "*.dll").Length == 0)
                     return false;
@@ -167,10 +174,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
             // Development-only dependencies (analyzers, source generators, build tooling)
             // are legitimately absent from the install directory — they ship their payload
             // under analyzers/, build/, tools/ etc. and the installer intentionally does not
-            // create a lib/ directory for them. Detect this via the cached .nuspec before
-            // requiring an install-dir match; otherwise AllPackagesInstalled() would return
-            // false every session for any closure containing a dev dep, forcing a needless
-            // full restore.
+            // create a lib/ directory for them.
             if (cachedPath != null && NuGetExtractor.IsDevelopmentDependency(cachedPath))
                 return true;
 
@@ -202,6 +206,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                     return false;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="package"/>'s .nupkg is on disk in the NuGet cache
+        /// and its .nuspec declares <c>&lt;developmentDependency&gt;true&lt;/developmentDependency&gt;</c>.
+        /// Returns false when the package isn't cached yet — the caller should then fall back to
+        /// the install-dir check, which will miss on a fresh restore and force Restore() to run
+        /// (at which point Install() downloads the .nupkg and records the dev dep in the closure).
+        /// </summary>
+        static bool IsCachedDevelopmentDependency(NuGetPackage package)
+        {
+            if (!NuGetCache.IsCached(package))
+                return false;
+
+            return NuGetExtractor.IsDevelopmentDependency(NuGetCache.GetCachedPath(package));
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageRestorer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageRestorer.cs
@@ -160,6 +160,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
             if (skipSet.Contains(package.Id))
                 return true;
 
+            var cachedPath = NuGetCache.IsCached(package)
+                ? NuGetCache.GetCachedPath(package)
+                : null;
+
             // Development-only dependencies (analyzers, source generators, build tooling)
             // are legitimately absent from the install directory — they ship their payload
             // under analyzers/, build/, tools/ etc. and the installer intentionally does not
@@ -167,11 +171,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
             // requiring an install-dir match; otherwise AllPackagesInstalled() would return
             // false every session for any closure containing a dev dep, forcing a needless
             // full restore.
-            if (NuGetCache.IsCached(package)
-                && NuGetExtractor.IsDevelopmentDependency(NuGetCache.GetCachedPath(package)))
-            {
+            if (cachedPath != null && NuGetExtractor.IsDevelopmentDependency(cachedPath))
                 return true;
-            }
 
             if (!installedPackageIds.Contains(package.Id))
                 return false;
@@ -181,13 +182,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
             // early-return without downloading this version). The install-dir check above
             // already confirmed some version is present, so stop recursing here rather than
             // forcing an unnecessary restore.
-            if (!NuGetCache.IsCached(package))
+            if (cachedPath == null)
                 return true;
 
             List<NuGetPackage> deps;
             try
             {
-                deps = NuGetExtractor.GetDependencies(NuGetCache.GetCachedPath(package));
+                deps = NuGetExtractor.GetDependencies(cachedPath);
             }
             catch
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageRestorer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageRestorer.cs
@@ -111,6 +111,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                     return false;
                 if (skipSet.Contains(packageId))
                     return false;
+
+                // Empty package directories are cruft — typically left behind by a pre-fix
+                // install of a development-only dependency (analyzers, source generators)
+                // that never had any lib/<tfm>/ payload. Force a full restore so
+                // RemoveUnnecessaryPackages() cleans them up.
+                if (Directory.GetFiles(dir, "*.dll", SearchOption.AllDirectories).Length == 0)
+                    return false;
+
                 installedPackageIds.Add(packageId);
             }
 
@@ -151,6 +159,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
             // Skip-listed packages are expected to be absent from disk.
             if (skipSet.Contains(package.Id))
                 return true;
+
+            // Development-only dependencies (analyzers, source generators, build tooling)
+            // are legitimately absent from the install directory — they ship their payload
+            // under analyzers/, build/, tools/ etc. and the installer intentionally does not
+            // create a lib/ directory for them. Detect this via the cached .nuspec before
+            // requiring an install-dir match; otherwise AllPackagesInstalled() would return
+            // false every session for any closure containing a dev dep, forcing a needless
+            // full restore.
+            if (NuGetCache.IsCached(package)
+                && NuGetExtractor.IsDevelopmentDependency(NuGetCache.GetCachedPath(package)))
+            {
+                return true;
+            }
 
             if (!installedPackageIds.Contains(package.Id))
                 return false;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dba11fd9835ebc4468d7aecf96b8e78c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetExtractorDevelopmentDependencyTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetExtractorDevelopmentDependencyTests.cs
@@ -93,7 +93,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests.DependencyResolverTests
         [Test]
         public void IsDevelopmentDependency_ReturnsFalse_WhenNupkgIsCorrupt()
         {
-            // A zero-byte file is not a valid zip archive; the helper must swallow the
+            // An invalid zip header is not a valid zip archive; the helper must swallow the
             // exception and return false so the caller falls back to normal extraction.
             var bogus = Path.Combine(_tempDir, "corrupt.nupkg");
             File.WriteAllBytes(bogus, new byte[] { 0, 0, 0, 0 });

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetExtractorDevelopmentDependencyTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetExtractorDevelopmentDependencyTests.cs
@@ -1,0 +1,148 @@
+/*
++------------------------------------------------------------------+
+|  Author: Ivan Murzak (https://github.com/IvanMurzak)             |
+|  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    |
+|  Copyright (c) 2025 Ivan Murzak                                  |
+|  Licensed under the Apache License, Version 2.0.                 |
+|  See the LICENSE file in the project root for more information.  |
++------------------------------------------------------------------+
+*/
+
+#nullable enable
+using System.IO;
+using System.IO.Compression;
+using NUnit.Framework;
+using com.IvanMurzak.Unity.MCP.Editor.DependencyResolver;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests.DependencyResolverTests
+{
+    /// <summary>
+    /// Regression coverage for issue #670: DependencyResolver was logging
+    /// "No compatible framework found" / "No DLLs extracted" warnings for
+    /// Roslyn analyzer packages (e.g. Microsoft.CodeAnalysis.Analyzers), which
+    /// are marked <c>&lt;developmentDependency&gt;true&lt;/developmentDependency&gt;</c>
+    /// in their .nuspec and legitimately have no runtime DLLs under <c>lib/&lt;tfm&gt;/</c>.
+    /// </summary>
+    [TestFixture]
+    public class NuGetExtractorDevelopmentDependencyTests
+    {
+        string _tempDir = string.Empty;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "UnityMcp-NuGetExtractor-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                try { Directory.Delete(_tempDir, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+
+        [Test]
+        public void IsDevelopmentDependency_ReturnsTrue_WhenNuspecDeclaresDevDependencyTrue()
+        {
+            var nupkg = BuildNupkg(
+                id: "Example.Analyzer",
+                version: "1.0.0",
+                developmentDependencyElement: "<developmentDependency>true</developmentDependency>");
+
+            Assert.IsTrue(NuGetExtractor.IsDevelopmentDependency(nupkg));
+        }
+
+        [Test]
+        public void IsDevelopmentDependency_ReturnsTrue_WhenValueHasWhitespace()
+        {
+            // Some package authors pretty-print their nuspec; we must not choke on whitespace.
+            var nupkg = BuildNupkg(
+                id: "Example.Analyzer",
+                version: "1.0.0",
+                developmentDependencyElement: "<developmentDependency>  true  </developmentDependency>");
+
+            Assert.IsTrue(NuGetExtractor.IsDevelopmentDependency(nupkg));
+        }
+
+        [Test]
+        public void IsDevelopmentDependency_ReturnsFalse_WhenNuspecDeclaresDevDependencyFalse()
+        {
+            var nupkg = BuildNupkg(
+                id: "Example.Library",
+                version: "1.0.0",
+                developmentDependencyElement: "<developmentDependency>false</developmentDependency>");
+
+            Assert.IsFalse(NuGetExtractor.IsDevelopmentDependency(nupkg));
+        }
+
+        [Test]
+        public void IsDevelopmentDependency_ReturnsFalse_WhenDevDependencyElementIsMissing()
+        {
+            // The overwhelmingly common case: normal runtime libraries simply omit the element.
+            var nupkg = BuildNupkg(
+                id: "Example.Library",
+                version: "1.0.0",
+                developmentDependencyElement: null);
+
+            Assert.IsFalse(NuGetExtractor.IsDevelopmentDependency(nupkg));
+        }
+
+        [Test]
+        public void IsDevelopmentDependency_ReturnsFalse_WhenNupkgIsCorrupt()
+        {
+            // A zero-byte file is not a valid zip archive; the helper must swallow the
+            // exception and return false so the caller falls back to normal extraction.
+            var bogus = Path.Combine(_tempDir, "corrupt.nupkg");
+            File.WriteAllBytes(bogus, new byte[] { 0, 0, 0, 0 });
+
+            Assert.IsFalse(NuGetExtractor.IsDevelopmentDependency(bogus));
+        }
+
+        [Test]
+        public void IsDevelopmentDependency_ReturnsFalse_WhenNupkgHasNoNuspec()
+        {
+            var nupkg = Path.Combine(_tempDir, "no-nuspec.nupkg");
+            using (var zip = ZipFile.Open(nupkg, ZipArchiveMode.Create))
+            {
+                var entry = zip.CreateEntry("readme.txt");
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write("no nuspec here");
+            }
+
+            Assert.IsFalse(NuGetExtractor.IsDevelopmentDependency(nupkg));
+        }
+
+        /// <summary>
+        /// Builds a minimal synthetic .nupkg containing a single .nuspec entry at the root.
+        /// Mirrors enough of the real NuGet v3 layout to exercise the parser without downloading
+        /// anything over the network.
+        /// </summary>
+        string BuildNupkg(string id, string version, string? developmentDependencyElement)
+        {
+            var nupkg = Path.Combine(_tempDir, $"{id}.{version}.nupkg");
+            var nuspec =
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                "<package xmlns=\"http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd\">" +
+                "  <metadata>" +
+                $"    <id>{id}</id>" +
+                $"    <version>{version}</version>" +
+                "    <authors>test</authors>" +
+                "    <description>test fixture package</description>" +
+                (developmentDependencyElement ?? string.Empty) +
+                "  </metadata>" +
+                "</package>";
+
+            using (var zip = ZipFile.Open(nupkg, ZipArchiveMode.Create))
+            {
+                var entry = zip.CreateEntry($"{id}.nuspec");
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write(nuspec);
+            }
+
+            return nupkg;
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetExtractorDevelopmentDependencyTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetExtractorDevelopmentDependencyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23daa8cc89d05394aa6639b89949f968
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/com.IvanMurzak.Unity.MCP.Editor.Tests.asmdef
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/com.IvanMurzak.Unity.MCP.Editor.Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "com.IvanMurzak.Unity.MCP.Runtime",
         "com.IvanMurzak.Unity.MCP.TestFiles",
-        "com.IvanMurzak.Unity.MCP.Editor"
+        "com.IvanMurzak.Unity.MCP.Editor",
+        "com.IvanMurzak.Unity.MCP.DependencyResolver"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
## Summary
- Detect `<developmentDependency>true</developmentDependency>` in `.nuspec` and skip the misleading "No compatible framework found" / "No DLLs extracted" warnings for Roslyn-analyzer-style packages (e.g. `Microsoft.CodeAnalysis.Analyzers 3.3.4`), which legitimately have no runtime DLLs under `lib/<tfm>/`.
- Stop creating an empty install directory + orphaned `.meta` for dev-dep packages; add a `RemoveUnnecessaryPackages` case that cleans up any empty package folder left behind by a pre-fix install (migration path).
- Teach `AllPackagesInstalled` / the transitive-closure walk that dev dependencies are legitimately absent from disk, so their presence in the closure no longer forces a needless full restore on every domain reload.

## Test plan
- [x] 6 new EditMode unit tests in `Tests/Editor/DependencyResolver/NuGetExtractorDevelopmentDependencyTests.cs` cover `IsDevelopmentDependency` for: true, true-with-whitespace, false, missing element, corrupt `.nupkg`, nupkg-without-nuspec.
- [x] Exercised the full batch-mode EditMode suite locally (`commands/run-unity-tests.ps1 -TestMode editmode`) — new tests pass; the restore warning for `Microsoft.CodeAnalysis.Analyzers 3.3.4` is gone from the Editor log.
- [x] `InternalsVisibleTo("com.IvanMurzak.Unity.MCP.Editor.Tests")` added to the `DependencyResolver` asmdef via new `AssemblyInfo.cs`; Editor test asmdef now references `com.IvanMurzak.Unity.MCP.DependencyResolver`.

Closes #670