### PR TITLE
[codex] Add milestone-1 tmux team orchestration commands

### DIFF
--- a/.omx/reports/milestone-1-scope-guard.md
+++ b/.omx/reports/milestone-1-scope-guard.md
@@ -1,0 +1,63 @@
+# Milestone 1 Scope Guard — tmux orchestration fork
+
+## Purpose
+Preserve the approved milestone-1 boundary for the tmux orchestration fork so implementation stays limited to the smallest CLI-first slice.
+
+## Source of truth
+- `.omx/plans/prd-tmux-orchestration-fork-plan.md`
+- `.omx/plans/test-spec-tmux-orchestration-fork-plan.md`
+
+## In scope
+1. New CLI `team` command family attached to the existing CLI entrypoint.
+2. Local tmux session launch with a deterministic default role/pane layout.
+3. Persisted orchestration state sufficient for `team status` and `team list`.
+4. Basic management commands for milestone 1:
+   - `team launch`
+   - `team status`
+   - `team list`
+   - `team stop` is optional but acceptable inside the same lifecycle slice.
+5. Live tmux reconciliation for status reporting, including degraded/stale-state messaging.
+6. Tests/docs strictly required to support the above command surface.
+
+## Preferred implementation surface
+- `cli/src/index.ts`
+- `cli/src/commands/team/*`
+- `cli/src/utils/tmux.ts`
+- `cli/src/utils/team-state.ts`
+- `cli/src/utils/team-templates.ts`
+- matching tests/docs for the same surface
+
+## Out of scope for milestone 1
+- OMX feature parity
+- remote/cloud/multi-machine orchestration
+- HUD/question/interview workflows
+- deep role automation or handoff engines
+- Unity plugin or Unity-MCP server refactors as part of this milestone
+- broad CLI architecture reshaping beyond adding the `team` family and its supporting utilities
+
+## Acceptance guardrails
+Implementation should satisfy all of the following:
+1. The new behavior enters through the existing CLI registration surface.
+2. Session state is persisted independently from raw tmux inspection.
+3. `team list` can summarize saved sessions without requiring manual tmux parsing.
+4. Missing tmux and stale session cases produce actionable output.
+5. Documentation describes the feature as local-only and milestone-1 scoped.
+
+## Scope drift signals
+Escalate immediately if implementation starts to introduce any of the following:
+- changes in Unity plugin/server runtime behavior
+- cloud or remote session management
+- OMX-style workflow engines beyond simple role presets/metadata
+- unrelated command rewrites outside the `team` family
+- state model expansion driven by future milestones rather than milestone-1 needs
+
+## Review checklist
+Use this quick review before accepting milestone-1 implementation changes:
+- Does the diff stay centered on `team` command registration, tmux helpers, state helpers, templates, and directly related tests/docs?
+- Does any new option/behavior serve launch, status, list, or optional stop directly?
+- Can the saved state still be understood without live tmux access?
+- Are missing-tmux and stale-state paths explicit and actionable?
+- Did the change avoid introducing remote/cloud or non-local orchestration assumptions?
+
+## Notes for review
+If a change is ambiguous, prefer the narrower interpretation that keeps the first deliverable to launcher + state + basic management only.

--- a/cli/README.md
+++ b/cli/README.md
@@ -367,6 +367,54 @@ unity-mcp-cli wait-for-ready --url http://localhost:8080 --timeout 30000
 
 ![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 
+## `team`
+
+Launch and inspect a local tmux-based team session for a Unity project. Milestone 1 is intentionally local-only: it creates a deterministic four-pane tmux layout, persists session metadata under `.unity-mcp/team-state/`, and exposes basic lifecycle commands. It does **not** provide OMX parity, remote orchestration, or cloud coordination.
+
+```bash
+unity-mcp-cli team launch ./MyGame
+```
+
+### `team launch`
+
+Create a tmux session with the built-in `leader`, `builder`, `verifier`, and `notes` panes.
+
+| Option | Required | Description |
+|---|---|---|
+| `[path]` | No | Unity project path (defaults to current directory) |
+| `--path <path>` | No | Unity project path (defaults to current directory) |
+| `--layout <name>` | No | Layout preset name (`default` only in milestone 1) |
+| `--session-name <name>` | No | Override the generated tmux session name |
+
+### `team status`
+
+Inspect persisted state and reconcile it with the live tmux session.
+
+```bash
+unity-mcp-cli team status ./MyGame
+unity-mcp-cli team status mygame-team-20260423t050000z --path ./MyGame
+```
+
+### `team list`
+
+List saved team sessions for a project and summarize whether each session is `ready`, `degraded`, or `stopped`.
+
+```bash
+unity-mcp-cli team list ./MyGame
+```
+
+### `team stop`
+
+Stop a tmux team session and mark its saved state as `stopped`.
+
+```bash
+unity-mcp-cli team stop mygame-team-20260423t050000z --path ./MyGame
+```
+
+If `tmux` is not installed or is missing from `PATH`, the launcher exits with an actionable error telling you to install tmux before using team orchestration commands.
+
+![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
+
 ## `setup-mcp`
 
 Write MCP config files for AI agents, enabling headless/CI setup without the Unity Editor UI. Supports all 14 agents (Claude Code, Cursor, Gemini, Codex, etc.).

--- a/cli/src/commands/team.ts
+++ b/cli/src/commands/team.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+import { createTeamLaunchCommand } from './team/launch.js';
+import { createTeamListCommand } from './team/list.js';
+import { createTeamStatusCommand } from './team/status.js';
+import { createTeamStopCommand } from './team/stop.js';
+
+export function createTeamCommand(launcherVersion: string): Command {
+  const command = new Command('team')
+    .description('Local tmux-based team orchestration for Unity projects');
+
+  command.addCommand(createTeamLaunchCommand(launcherVersion));
+  command.addCommand(createTeamListCommand());
+  command.addCommand(createTeamStatusCommand());
+  command.addCommand(createTeamStopCommand());
+
+  return command;
+}

--- a/cli/src/commands/team/helpers.ts
+++ b/cli/src/commands/team/helpers.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveAndValidateProjectPath } from '../../utils/connection.js';
+
+export interface TeamProjectOptions {
+  path?: string;
+}
+
+export interface TeamTargetResolution {
+  projectPath: string;
+  sessionRef?: string;
+}
+
+export function resolveTeamProjectPath(positionalPath: string | undefined, options: TeamProjectOptions): string {
+  return resolveAndValidateProjectPath(positionalPath, { path: options.path });
+}
+
+export function resolveTeamProjectAndSession(target: string | undefined, options: TeamProjectOptions): TeamTargetResolution {
+  if (options.path) {
+    return {
+      projectPath: resolveAndValidateProjectPath(undefined, { path: options.path }),
+      sessionRef: target,
+    };
+  }
+
+  if (target) {
+    const asPath = path.resolve(target);
+    if (fs.existsSync(asPath)) {
+      return {
+        projectPath: resolveAndValidateProjectPath(target, {}),
+      };
+    }
+  }
+
+  return {
+    projectPath: resolveAndValidateProjectPath(undefined, {}),
+    sessionRef: target,
+  };
+}

--- a/cli/src/commands/team/launch.ts
+++ b/cli/src/commands/team/launch.ts
@@ -1,0 +1,42 @@
+import { Command } from 'commander';
+import * as ui from '../../utils/ui.js';
+import { createTmuxAdapter } from '../../utils/tmux.js';
+import { launchTeamSession } from '../../utils/team-orchestration.js';
+import { getTeamStateFilePath } from '../../utils/team-state.js';
+import { resolveTeamProjectPath } from './helpers.js';
+
+interface TeamLaunchCommandOptions {
+  path?: string;
+  layout?: string;
+  sessionName?: string;
+}
+
+export function createTeamLaunchCommand(launcherVersion: string): Command {
+  return new Command('launch')
+    .description('Launch a local tmux team session for a Unity project')
+    .argument('[path]', 'Unity project path (defaults to current directory)')
+    .option('--path <path>', 'Unity project path (defaults to current directory)')
+    .option('--layout <name>', 'Layout preset name (milestone 1 supports only: default)', 'default')
+    .option('--session-name <name>', 'Override the generated tmux session name')
+    .action((positionalPath: string | undefined, options: TeamLaunchCommandOptions) => {
+      try {
+        const projectPath = resolveTeamProjectPath(positionalPath, options);
+        const state = launchTeamSession(projectPath, launcherVersion, createTmuxAdapter(), options);
+
+        ui.heading('Unity-MCP Team Launch');
+        ui.label('Project', state.projectPath);
+        ui.label('Session', state.sessionId);
+        ui.label('Layout', state.layoutPreset);
+        ui.label('State file', getTeamStateFilePath(state.projectPath, state.sessionId));
+        ui.divider();
+        for (const role of state.roles) {
+          ui.label(role.roleName, `${role.paneId} (${role.paneTitle})`);
+        }
+        ui.divider();
+        ui.success(`Team session ${state.sessionId} is ready.`);
+      } catch (err) {
+        ui.error((err as Error).message || String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/team/list.ts
+++ b/cli/src/commands/team/list.ts
@@ -1,0 +1,48 @@
+import { Command } from 'commander';
+import * as ui from '../../utils/ui.js';
+import { createTmuxAdapter } from '../../utils/tmux.js';
+import { listTeamSessions } from '../../utils/team-orchestration.js';
+import { resolveTeamProjectPath } from './helpers.js';
+
+interface TeamListCommandOptions {
+  path?: string;
+}
+
+export function createTeamListCommand(): Command {
+  return new Command('list')
+    .description('List saved team sessions for a Unity project')
+    .argument('[path]', 'Unity project path (defaults to current directory)')
+    .option('--path <path>', 'Unity project path (defaults to current directory)')
+    .action((positionalPath: string | undefined, options: TeamListCommandOptions) => {
+      try {
+        const projectPath = resolveTeamProjectPath(positionalPath, options);
+        const result = listTeamSessions(projectPath, createTmuxAdapter());
+
+        ui.heading('Unity-MCP Team Sessions');
+        ui.label('Project', projectPath);
+        if (result.tmuxUnavailableMessage) {
+          ui.warn(result.tmuxUnavailableMessage);
+        }
+        ui.divider();
+
+        if (result.inspections.length === 0) {
+          ui.info('No saved team sessions found.');
+        } else {
+          for (const inspection of result.inspections) {
+            const paneSummary = inspection.state.roles.map(role => `${role.roleName}:${role.status}`).join(', ');
+            ui.label(inspection.state.sessionId, `${inspection.state.status} — ${paneSummary}`);
+          }
+        }
+
+        if (result.invalid.length > 0) {
+          ui.divider();
+          for (const failure of result.invalid) {
+            ui.warn(`Skipped invalid state file ${failure.filePath}: ${failure.error}`);
+          }
+        }
+      } catch (err) {
+        ui.error((err as Error).message || String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/team/status.ts
+++ b/cli/src/commands/team/status.ts
@@ -1,0 +1,44 @@
+import { Command } from 'commander';
+import * as ui from '../../utils/ui.js';
+import { createTmuxAdapter } from '../../utils/tmux.js';
+import { getTeamSessionStatus } from '../../utils/team-orchestration.js';
+import { resolveTeamProjectAndSession } from './helpers.js';
+
+interface TeamStatusCommandOptions {
+  path?: string;
+}
+
+export function createTeamStatusCommand(): Command {
+  return new Command('status')
+    .description('Show saved and live tmux status for a local team session')
+    .argument('[session-or-path]', 'Session id/name or Unity project path (defaults to latest session in cwd project)')
+    .option('--path <path>', 'Unity project path when looking up a specific session id/name')
+    .action((target: string | undefined, options: TeamStatusCommandOptions) => {
+      try {
+        const { projectPath, sessionRef } = resolveTeamProjectAndSession(target, options);
+        const inspection = getTeamSessionStatus(projectPath, createTmuxAdapter(), sessionRef);
+
+        ui.heading('Unity-MCP Team Status');
+        ui.label('Project', inspection.state.projectPath);
+        ui.label('Session', inspection.state.sessionId);
+        ui.label('tmux', inspection.state.tmuxSessionName);
+        ui.label('Status', inspection.state.status);
+        ui.divider();
+        for (const role of inspection.state.roles) {
+          ui.label(role.roleName, `${role.status} — ${role.paneId || 'unassigned'} (${role.paneTitle})`);
+        }
+        if (inspection.issues.length > 0) {
+          ui.divider();
+          for (const issue of inspection.issues) {
+            ui.warn(issue);
+          }
+          process.exit(1);
+        }
+        ui.divider();
+        ui.success('Persisted state matches the live tmux session.');
+      } catch (err) {
+        ui.error((err as Error).message || String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/team/stop.ts
+++ b/cli/src/commands/team/stop.ts
@@ -1,0 +1,26 @@
+import { Command } from 'commander';
+import * as ui from '../../utils/ui.js';
+import { createTmuxAdapter } from '../../utils/tmux.js';
+import { stopTeamSession } from '../../utils/team-orchestration.js';
+import { resolveTeamProjectAndSession } from './helpers.js';
+
+interface TeamStopCommandOptions {
+  path?: string;
+}
+
+export function createTeamStopCommand(): Command {
+  return new Command('stop')
+    .description('Stop a local tmux team session and mark saved state as stopped')
+    .argument('[session]', 'Session id/name to stop (defaults to latest active session in cwd project)')
+    .option('--path <path>', 'Unity project path when stopping a specific session id/name')
+    .action((sessionRef: string | undefined, options: TeamStopCommandOptions) => {
+      try {
+        const { projectPath, sessionRef: resolvedSessionRef } = resolveTeamProjectAndSession(sessionRef, options);
+        const state = stopTeamSession(projectPath, createTmuxAdapter(), resolvedSessionRef);
+        ui.success(`Stopped team session ${state.sessionId}.`);
+      } catch (err) {
+        ui.error((err as Error).message || String(err));
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,7 @@ import { runSystemToolCommand } from './commands/run-system-tool.js';
 import { setupMcpCommand } from './commands/setup-mcp.js';
 import { setupSkillsCommand } from './commands/setup-skills.js';
 import { statusCommand } from './commands/status.js';
+import { createTeamCommand } from './commands/team.js';
 import { createUpdateCommand } from './commands/update.js';
 import { waitForReadyCommand } from './commands/wait-for-ready.js';
 import { configureStyledHelp, error as uiError, setVerbose } from './utils/ui.js';
@@ -42,6 +43,7 @@ const subcommands = [
   setupMcpCommand,
   setupSkillsCommand,
   statusCommand,
+  createTeamCommand(pkg.version),
   createUpdateCommand(pkg.version),
   waitForReadyCommand,
 ];

--- a/cli/src/utils/team-orchestration.ts
+++ b/cli/src/utils/team-orchestration.ts
@@ -1,0 +1,270 @@
+import * as path from 'path';
+import {
+  createTeamSessionState,
+  listTeamSessionStates,
+  resolveTeamSessionState,
+  transitionTeamSessionState,
+  writeTeamSessionState,
+  type TeamRoleState,
+  type TeamSessionState,
+  type TeamSessionStatus,
+  type TeamStateLoadFailure,
+} from './team-state.js';
+import { getTeamLayoutTemplate } from './team-templates.js';
+import type { TmuxAdapter, TmuxPaneSnapshot } from './tmux.js';
+
+export interface TeamLaunchOptions {
+  layout?: string;
+  sessionName?: string;
+}
+
+export interface TeamSessionInspection {
+  state: TeamSessionState;
+  livePanes: TmuxPaneSnapshot[];
+  issues: string[];
+}
+
+export interface TeamSessionListResult {
+  inspections: TeamSessionInspection[];
+  invalid: TeamStateLoadFailure[];
+  tmuxUnavailableMessage?: string;
+}
+
+export class TeamOrchestrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TeamOrchestrationError';
+  }
+}
+
+function compactTimestamp(value: Date): string {
+  return value.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+export function sanitizeSessionName(value: string): string {
+  const sanitized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  if (!sanitized) {
+    throw new TeamOrchestrationError('Session name must include at least one alphanumeric character.');
+  }
+
+  return sanitized.slice(0, 48);
+}
+
+export function createDefaultSessionName(projectPath: string, now: Date): string {
+  return sanitizeSessionName(`${path.basename(projectPath)}-team-${compactTimestamp(now)}`);
+}
+
+function cloneRoles(roles: TeamRoleState[]): TeamRoleState[] {
+  return roles.map(role => ({ ...role }));
+}
+
+function withUpdatedRole(
+  state: TeamSessionState,
+  roleIndex: number,
+  patch: Partial<TeamRoleState>,
+  updatedAt: string,
+): TeamSessionState {
+  const roles = cloneRoles(state.roles);
+  roles[roleIndex] = {
+    ...roles[roleIndex],
+    ...patch,
+  };
+
+  return {
+    ...state,
+    roles,
+    updatedAt,
+  };
+}
+
+function determineRoleStatus(role: TeamRoleState, livePanes: TmuxPaneSnapshot[], sessionStatus: TeamSessionStatus): TeamRoleState['status'] {
+  if (sessionStatus === 'stopped') {
+    return 'stopped';
+  }
+
+  return livePanes.some(pane => pane.paneId === role.paneId) ? 'ready' : 'degraded';
+}
+
+function inspectSessionState(state: TeamSessionState, tmux: TmuxAdapter): TeamSessionInspection {
+  if (state.status === 'stopped') {
+    return {
+      state,
+      livePanes: [],
+      issues: [],
+    };
+  }
+
+  const issues: string[] = [];
+  const livePanes = tmux.hasSession(state.tmuxSessionName)
+    ? tmux.listPanes(state.tmuxSessionName)
+    : [];
+
+  if (livePanes.length === 0) {
+    issues.push(`tmux session ${state.tmuxSessionName} is not available`);
+  }
+
+  for (const role of state.roles) {
+    if (!livePanes.some(pane => pane.paneId === role.paneId)) {
+      issues.push(`missing pane for role ${role.roleName} (${role.paneId || 'unassigned'})`);
+    }
+  }
+
+  const nextStatus: TeamSessionStatus = issues.length > 0 ? 'degraded' : 'ready';
+  const updatedAt = new Date().toISOString();
+  const nextRoles = state.roles.map(role => ({
+    ...role,
+    status: determineRoleStatus(role, livePanes, nextStatus),
+  }));
+
+  return {
+    state: {
+      ...state,
+      status: nextStatus,
+      updatedAt,
+      roles: nextRoles,
+    },
+    livePanes,
+    issues,
+  };
+}
+
+export function launchTeamSession(
+  projectPath: string,
+  launcherVersion: string,
+  tmux: TmuxAdapter,
+  options: TeamLaunchOptions = {},
+  now = new Date(),
+): TeamSessionState {
+  const resolvedProjectPath = path.resolve(projectPath);
+  const layout = getTeamLayoutTemplate(options.layout, resolvedProjectPath);
+  const sessionId = sanitizeSessionName(options.sessionName ?? createDefaultSessionName(resolvedProjectPath, now));
+
+  tmux.ensureAvailable();
+
+  if (tmux.hasSession(sessionId)) {
+    throw new TeamOrchestrationError(`A tmux session named "${sessionId}" already exists. Use --session-name to choose a different name or stop the existing session first.`);
+  }
+
+  const launchTimestamp = now.toISOString();
+
+  let state = createTeamSessionState({
+    sessionId,
+    projectPath: resolvedProjectPath,
+    launcherVersion,
+    tmuxSessionName: sessionId,
+    layoutPreset: layout.name,
+    verificationPolicy: layout.verificationPolicy,
+    templateVersion: layout.templateVersion,
+    roles: layout.roles,
+    createdAt: launchTimestamp,
+    updatedAt: launchTimestamp,
+  });
+
+  writeTeamSessionState(resolvedProjectPath, state);
+
+  try {
+    const firstPaneId = tmux.createSession(sessionId, resolvedProjectPath, layout.windowName);
+    const paneIds = [
+      firstPaneId,
+      tmux.splitWindow(firstPaneId, resolvedProjectPath, 'horizontal'),
+      tmux.splitWindow(firstPaneId, resolvedProjectPath, 'vertical'),
+      tmux.splitWindow(firstPaneId, resolvedProjectPath, 'vertical'),
+    ];
+
+    tmux.selectLayout(sessionId, 'tiled');
+
+    for (const [index, role] of layout.roles.entries()) {
+      const paneId = paneIds[index] ?? '';
+      if (!paneId) {
+        throw new TeamOrchestrationError(`Unable to assign pane for role ${role.roleName}`);
+      }
+      tmux.setPaneTitle(paneId, role.paneTitle);
+      state = withUpdatedRole(state, index, { paneId, status: 'ready' }, launchTimestamp);
+      writeTeamSessionState(resolvedProjectPath, state);
+    }
+
+    state = transitionTeamSessionState(state, 'ready', launchTimestamp);
+    writeTeamSessionState(resolvedProjectPath, state);
+    return state;
+  } catch (err) {
+    const message = (err as Error).message || String(err);
+
+    try {
+      if (tmux.hasSession(sessionId)) {
+        tmux.killSession(sessionId);
+      }
+    } catch {
+      // best-effort cleanup only
+    }
+
+    state = {
+      ...transitionTeamSessionState(state, 'degraded', launchTimestamp),
+      notes: [...state.notes, `Launch failed: ${message}`],
+      roles: state.roles.map(role => ({
+        ...role,
+        status: role.paneId ? 'degraded' : role.status,
+      })),
+    };
+    writeTeamSessionState(resolvedProjectPath, state);
+    throw err;
+  }
+}
+
+export function getTeamSessionStatus(projectPath: string, tmux: TmuxAdapter, sessionRef?: string): TeamSessionInspection {
+  const resolvedProjectPath = path.resolve(projectPath);
+  const state = resolveTeamSessionState(resolvedProjectPath, sessionRef);
+  const inspection = inspectSessionState(state, tmux);
+  writeTeamSessionState(resolvedProjectPath, inspection.state);
+  return inspection;
+}
+
+export function listTeamSessions(projectPath: string, tmux: TmuxAdapter): TeamSessionListResult {
+  const resolvedProjectPath = path.resolve(projectPath);
+  const { sessions, invalid } = listTeamSessionStates(resolvedProjectPath);
+
+  try {
+    const inspections = sessions.map(session => {
+      const inspection = inspectSessionState(session, tmux);
+      writeTeamSessionState(resolvedProjectPath, inspection.state);
+      return inspection;
+    });
+
+    return { inspections, invalid };
+  } catch (err) {
+    return {
+      inspections: sessions.map(session => ({
+        state: session,
+        livePanes: [],
+        issues: [],
+      })),
+      invalid,
+      tmuxUnavailableMessage: (err as Error).message || String(err),
+    };
+  }
+}
+
+export function stopTeamSession(projectPath: string, tmux: TmuxAdapter, sessionRef?: string): TeamSessionState {
+  const resolvedProjectPath = path.resolve(projectPath);
+  const state = resolveTeamSessionState(resolvedProjectPath, sessionRef);
+
+  if (state.status !== 'stopped' && tmux.hasSession(state.tmuxSessionName)) {
+    tmux.killSession(state.tmuxSessionName);
+  }
+
+  const updatedAt = new Date().toISOString();
+  const nextState = {
+    ...transitionTeamSessionState(state, 'stopped', updatedAt),
+    roles: state.roles.map(role => ({
+      ...role,
+      status: 'stopped' as const,
+    })),
+  };
+  writeTeamSessionState(resolvedProjectPath, nextState);
+  return nextState;
+}

--- a/cli/src/utils/team-state.ts
+++ b/cli/src/utils/team-state.ts
@@ -1,0 +1,271 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { TeamRoleTemplate } from './team-templates.js';
+
+export const TEAM_STATE_SCHEMA_VERSION = 1;
+const TEAM_STATE_DIR = path.join('.unity-mcp', 'team-state');
+
+const TEAM_SESSION_STATUSES = ['launching', 'ready', 'degraded', 'stopped'] as const;
+const TEAM_ROLE_STATUSES = ['pending', 'ready', 'degraded', 'stopped'] as const;
+
+export type TeamSessionStatus = typeof TEAM_SESSION_STATUSES[number];
+export type TeamRoleStatus = typeof TEAM_ROLE_STATUSES[number];
+
+export interface TeamRoleState extends TeamRoleTemplate {
+  paneId: string;
+  status: TeamRoleStatus;
+}
+
+export interface TeamSessionState {
+  schemaVersion: number;
+  sessionId: string;
+  projectPath: string;
+  createdAt: string;
+  updatedAt: string;
+  launcherVersion: string;
+  tmuxSessionName: string;
+  status: TeamSessionStatus;
+  layoutPreset: string;
+  roles: TeamRoleState[];
+  verificationPolicy: string;
+  notes: string[];
+  templateVersion: string;
+}
+
+export interface TeamStateLoadFailure {
+  filePath: string;
+  error: string;
+}
+
+export class InvalidTeamStateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidTeamStateError';
+  }
+}
+
+const VALID_STATUS_TRANSITIONS: Record<TeamSessionStatus, TeamSessionStatus[]> = {
+  launching: ['ready', 'degraded', 'stopped'],
+  ready: ['degraded', 'stopped'],
+  degraded: ['ready', 'stopped'],
+  stopped: [],
+};
+
+export function isTeamSessionStatus(value: unknown): value is TeamSessionStatus {
+  return typeof value === 'string' && (TEAM_SESSION_STATUSES as readonly string[]).includes(value);
+}
+
+export function isTeamRoleStatus(value: unknown): value is TeamRoleStatus {
+  return typeof value === 'string' && (TEAM_ROLE_STATUSES as readonly string[]).includes(value);
+}
+
+export function canTransitionTeamSessionStatus(from: TeamSessionStatus, to: TeamSessionStatus): boolean {
+  return from === to || VALID_STATUS_TRANSITIONS[from].includes(to);
+}
+
+export function getTeamStateDirectory(projectPath: string): string {
+  return path.join(path.resolve(projectPath), TEAM_STATE_DIR);
+}
+
+export function getTeamStateFilePath(projectPath: string, sessionId: string): string {
+  return path.join(getTeamStateDirectory(projectPath), `${sessionId}.json`);
+}
+
+export function createTeamSessionState(input: {
+  sessionId: string;
+  projectPath: string;
+  launcherVersion: string;
+  tmuxSessionName: string;
+  layoutPreset: string;
+  verificationPolicy: string;
+  templateVersion: string;
+  roles: TeamRoleTemplate[];
+  createdAt?: string;
+  updatedAt?: string;
+  status?: TeamSessionStatus;
+  notes?: string[];
+}): TeamSessionState {
+  const createdAt = input.createdAt ?? new Date().toISOString();
+  const updatedAt = input.updatedAt ?? createdAt;
+
+  return {
+    schemaVersion: TEAM_STATE_SCHEMA_VERSION,
+    sessionId: input.sessionId,
+    projectPath: path.resolve(input.projectPath),
+    createdAt,
+    updatedAt,
+    launcherVersion: input.launcherVersion,
+    tmuxSessionName: input.tmuxSessionName,
+    status: input.status ?? 'launching',
+    layoutPreset: input.layoutPreset,
+    roles: input.roles.map(role => ({
+      ...role,
+      paneId: '',
+      status: 'pending',
+    })),
+    verificationPolicy: input.verificationPolicy,
+    notes: [...(input.notes ?? [])],
+    templateVersion: input.templateVersion,
+  };
+}
+
+function assertString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new InvalidTeamStateError(`Invalid or missing ${field}`);
+  }
+  return value;
+}
+
+function assertStringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
+    throw new InvalidTeamStateError(`Invalid ${field}; expected string[]`);
+  }
+  return value as string[];
+}
+
+function assertRoleState(value: unknown, index: number): TeamRoleState {
+  if (typeof value !== 'object' || value === null) {
+    throw new InvalidTeamStateError(`Invalid roles[${index}] entry`);
+  }
+
+  const role = value as Record<string, unknown>;
+  const status = role.status;
+  if (!isTeamRoleStatus(status)) {
+    throw new InvalidTeamStateError(`Invalid roles[${index}].status`);
+  }
+
+  return {
+    roleName: assertString(role.roleName, `roles[${index}].roleName`),
+    paneTitle: assertString(role.paneTitle, `roles[${index}].paneTitle`),
+    command: assertString(role.command, `roles[${index}].command`),
+    workingDirectory: assertString(role.workingDirectory, `roles[${index}].workingDirectory`),
+    readinessHint: assertString(role.readinessHint, `roles[${index}].readinessHint`),
+    paneId: typeof role.paneId === 'string' ? role.paneId : '',
+    status,
+  };
+}
+
+export function parseTeamSessionState(json: string, source = 'team state'): TeamSessionState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json) as unknown;
+  } catch (err) {
+    throw new InvalidTeamStateError(`Malformed JSON in ${source}: ${(err as Error).message}`);
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new InvalidTeamStateError(`Invalid ${source}; expected object`);
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const schemaVersion = record.schemaVersion;
+  if (schemaVersion !== TEAM_STATE_SCHEMA_VERSION) {
+    throw new InvalidTeamStateError(`Unsupported schemaVersion in ${source}: ${String(schemaVersion)}`);
+  }
+
+  const status = record.status;
+  if (!isTeamSessionStatus(status)) {
+    throw new InvalidTeamStateError(`Invalid ${source}.status`);
+  }
+
+  const rolesValue = record.roles;
+  if (!Array.isArray(rolesValue) || rolesValue.length === 0) {
+    throw new InvalidTeamStateError(`Invalid ${source}.roles; expected non-empty array`);
+  }
+
+  return {
+    schemaVersion,
+    sessionId: assertString(record.sessionId, `${source}.sessionId`),
+    projectPath: assertString(record.projectPath, `${source}.projectPath`),
+    createdAt: assertString(record.createdAt, `${source}.createdAt`),
+    updatedAt: assertString(record.updatedAt, `${source}.updatedAt`),
+    launcherVersion: assertString(record.launcherVersion, `${source}.launcherVersion`),
+    tmuxSessionName: assertString(record.tmuxSessionName, `${source}.tmuxSessionName`),
+    status,
+    layoutPreset: assertString(record.layoutPreset, `${source}.layoutPreset`),
+    roles: rolesValue.map((role, index) => assertRoleState(role, index)),
+    verificationPolicy: assertString(record.verificationPolicy, `${source}.verificationPolicy`),
+    notes: assertStringArray(record.notes, `${source}.notes`),
+    templateVersion: assertString(record.templateVersion, `${source}.templateVersion`),
+  };
+}
+
+export function readTeamSessionState(projectPath: string, sessionId: string): TeamSessionState {
+  const filePath = getTeamStateFilePath(projectPath, sessionId);
+  if (!fs.existsSync(filePath)) {
+    throw new InvalidTeamStateError(`No team state found for session: ${sessionId}`);
+  }
+
+  return parseTeamSessionState(fs.readFileSync(filePath, 'utf-8'), filePath);
+}
+
+export function writeTeamSessionState(projectPath: string, state: TeamSessionState): string {
+  const filePath = getTeamStateFilePath(projectPath, state.sessionId);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(state, null, 2) + '\n');
+  return filePath;
+}
+
+export function listTeamSessionStates(projectPath: string): {
+  sessions: TeamSessionState[];
+  invalid: TeamStateLoadFailure[];
+} {
+  const stateDir = getTeamStateDirectory(projectPath);
+  if (!fs.existsSync(stateDir)) {
+    return { sessions: [], invalid: [] };
+  }
+
+  const sessions: TeamSessionState[] = [];
+  const invalid: TeamStateLoadFailure[] = [];
+
+  for (const entry of fs.readdirSync(stateDir).filter(name => name.endsWith('.json')).sort()) {
+    const filePath = path.join(stateDir, entry);
+    try {
+      sessions.push(parseTeamSessionState(fs.readFileSync(filePath, 'utf-8'), filePath));
+    } catch (err) {
+      invalid.push({
+        filePath,
+        error: (err as Error).message || String(err),
+      });
+    }
+  }
+
+  sessions.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  return { sessions, invalid };
+}
+
+export function resolveTeamSessionState(projectPath: string, sessionRef?: string): TeamSessionState {
+  const { sessions } = listTeamSessionStates(projectPath);
+
+  if (sessions.length === 0) {
+    throw new InvalidTeamStateError(`No team sessions found for project: ${path.resolve(projectPath)}`);
+  }
+
+  if (!sessionRef) {
+    const active = sessions.find(session => session.status !== 'stopped');
+    return active ?? sessions[0];
+  }
+
+  const match = sessions.find(session => session.sessionId === sessionRef || session.tmuxSessionName === sessionRef);
+  if (!match) {
+    throw new InvalidTeamStateError(`No team session found matching: ${sessionRef}`);
+  }
+
+  return match;
+}
+
+export function transitionTeamSessionState(
+  state: TeamSessionState,
+  nextStatus: TeamSessionStatus,
+  updatedAt = new Date().toISOString(),
+): TeamSessionState {
+  if (!canTransitionTeamSessionStatus(state.status, nextStatus)) {
+    throw new InvalidTeamStateError(`Invalid team status transition: ${state.status} -> ${nextStatus}`);
+  }
+
+  return {
+    ...state,
+    status: nextStatus,
+    updatedAt,
+  };
+}

--- a/cli/src/utils/team-templates.ts
+++ b/cli/src/utils/team-templates.ts
@@ -1,0 +1,71 @@
+import * as path from 'path';
+
+export interface TeamRoleTemplate {
+  roleName: string;
+  paneTitle: string;
+  command: string;
+  workingDirectory: string;
+  readinessHint: string;
+}
+
+export interface TeamLayoutTemplate {
+  name: string;
+  templateVersion: string;
+  windowName: string;
+  verificationPolicy: string;
+  roles: TeamRoleTemplate[];
+}
+
+const DEFAULT_TEMPLATE_VERSION = '1';
+const DEFAULT_LAYOUT_NAME = 'default';
+
+export function createDefaultTeamLayout(projectPath: string): TeamLayoutTemplate {
+  const workingDirectory = path.resolve(projectPath);
+
+  return {
+    name: DEFAULT_LAYOUT_NAME,
+    templateVersion: DEFAULT_TEMPLATE_VERSION,
+    windowName: 'team',
+    verificationPolicy: 'Session is ready when tmux panes exist and persisted state matches the live layout.',
+    roles: [
+      {
+        roleName: 'leader',
+        paneTitle: 'leader',
+        command: 'shell',
+        workingDirectory,
+        readinessHint: 'Leader pane created and ready for operator commands.',
+      },
+      {
+        roleName: 'builder',
+        paneTitle: 'builder',
+        command: 'shell',
+        workingDirectory,
+        readinessHint: 'Builder pane created and ready for implementation work.',
+      },
+      {
+        roleName: 'verifier',
+        paneTitle: 'verifier',
+        command: 'shell',
+        workingDirectory,
+        readinessHint: 'Verifier pane created and ready for test and validation work.',
+      },
+      {
+        roleName: 'notes',
+        paneTitle: 'notes',
+        command: 'shell',
+        workingDirectory,
+        readinessHint: 'Notes pane created and ready for logs or scratch notes.',
+      },
+    ],
+  };
+}
+
+export function getTeamLayoutTemplate(layoutName: string | undefined, projectPath: string): TeamLayoutTemplate {
+  const normalized = (layoutName ?? DEFAULT_LAYOUT_NAME).trim().toLowerCase();
+
+  if (normalized !== DEFAULT_LAYOUT_NAME) {
+    throw new Error(`Unknown team layout preset: ${layoutName}. Only "${DEFAULT_LAYOUT_NAME}" is available in milestone 1.`);
+  }
+
+  return createDefaultTeamLayout(projectPath);
+}

--- a/cli/src/utils/tmux.ts
+++ b/cli/src/utils/tmux.ts
@@ -1,0 +1,148 @@
+import { execFileSync } from 'child_process';
+
+const LIST_PANES_FORMAT = '#{pane_id}\t#{pane_title}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_active}';
+
+export interface TmuxPaneSnapshot {
+  paneId: string;
+  title: string;
+  currentCommand: string;
+  currentPath: string;
+  active: boolean;
+}
+
+export interface TmuxAdapter {
+  ensureAvailable(): void;
+  hasSession(sessionName: string): boolean;
+  createSession(sessionName: string, workingDirectory: string, windowName: string): string;
+  splitWindow(targetPaneId: string, workingDirectory: string, orientation: 'horizontal' | 'vertical'): string;
+  setPaneTitle(targetPaneId: string, title: string): void;
+  selectLayout(sessionName: string, layoutName: string): void;
+  listPanes(sessionName: string): TmuxPaneSnapshot[];
+  killSession(sessionName: string): void;
+}
+
+export type TmuxExec = (args: string[]) => string;
+
+export class TmuxCommandError extends Error {
+  readonly kind: 'missing' | 'failed';
+
+  constructor(message: string, kind: 'missing' | 'failed') {
+    super(message);
+    this.name = 'TmuxCommandError';
+    this.kind = kind;
+  }
+}
+
+function normalizeTmuxError(err: unknown, command: string): TmuxCommandError {
+  const error = err as NodeJS.ErrnoException & { status?: number; stderr?: string | Buffer };
+  if (error?.code === 'ENOENT') {
+    return new TmuxCommandError('tmux is required for team orchestration. Install tmux and ensure it is available on PATH.', 'missing');
+  }
+
+  const stderr = typeof error?.stderr === 'string'
+    ? error.stderr.trim()
+    : Buffer.isBuffer(error?.stderr)
+      ? error.stderr.toString('utf-8').trim()
+      : '';
+
+  const details = stderr.length > 0 ? `: ${stderr}` : '';
+  return new TmuxCommandError(`tmux ${command} failed${details}`, 'failed');
+}
+
+function defaultExec(args: string[]): string {
+  try {
+    return execFileSync('tmux', args, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (err) {
+    throw normalizeTmuxError(err, args[0] ?? 'command');
+  }
+}
+
+export function parseListPanesOutput(output: string): TmuxPaneSnapshot[] {
+  return output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [paneId = '', title = '', currentCommand = '', currentPath = '', active = '0'] = line.split('\t');
+      if (!paneId) {
+        throw new TmuxCommandError('tmux list-panes returned malformed pane data', 'failed');
+      }
+
+      return {
+        paneId,
+        title,
+        currentCommand,
+        currentPath,
+        active: active === '1',
+      };
+    });
+}
+
+export function createTmuxAdapter(exec: TmuxExec = defaultExec): TmuxAdapter {
+  return {
+    ensureAvailable(): void {
+      exec(['-V']);
+    },
+
+    hasSession(sessionName: string): boolean {
+      try {
+        exec(['has-session', '-t', sessionName]);
+        return true;
+      } catch (err) {
+        if (err instanceof TmuxCommandError && err.kind === 'missing') {
+          throw err;
+        }
+        return false;
+      }
+    },
+
+    createSession(sessionName: string, workingDirectory: string, windowName: string): string {
+      return exec([
+        'new-session',
+        '-d',
+        '-P',
+        '-F',
+        '#{pane_id}',
+        '-s',
+        sessionName,
+        '-n',
+        windowName,
+        '-c',
+        workingDirectory,
+      ]);
+    },
+
+    splitWindow(targetPaneId: string, workingDirectory: string, orientation: 'horizontal' | 'vertical'): string {
+      return exec([
+        'split-window',
+        orientation === 'horizontal' ? '-h' : '-v',
+        '-P',
+        '-F',
+        '#{pane_id}',
+        '-t',
+        targetPaneId,
+        '-c',
+        workingDirectory,
+      ]);
+    },
+
+    setPaneTitle(targetPaneId: string, title: string): void {
+      exec(['select-pane', '-t', targetPaneId, '-T', title]);
+    },
+
+    selectLayout(sessionName: string, layoutName: string): void {
+      exec(['select-layout', '-t', `${sessionName}:0`, layoutName]);
+    },
+
+    listPanes(sessionName: string): TmuxPaneSnapshot[] {
+      return parseListPanesOutput(exec(['list-panes', '-t', `${sessionName}:0`, '-F', LIST_PANES_FORMAT]));
+    },
+
+    killSession(sessionName: string): void {
+      exec(['kill-session', '-t', sessionName]);
+    },
+  };
+}

--- a/cli/tests/cli.test.ts
+++ b/cli/tests/cli.test.ts
@@ -40,6 +40,7 @@ describe('CLI integration', () => {
       expect(stdout).toContain('remove-plugin');
       expect(stdout).toContain('configure');
       expect(stdout).toContain('run-tool');
+      expect(stdout).toContain('team');
       // connect command was merged into open — no separate 'connect' command listed
       // (the word 'connect' may appear in descriptions, but not as a standalone command)
     });
@@ -48,7 +49,7 @@ describe('CLI integration', () => {
       const { stdout, exitCode } = runCli(['--help']);
       expect(exitCode).toBe(0);
       // Extract command names from help output
-      const commandNames = ['configure', 'create-project', 'install-plugin', 'install-unity', 'open', 'remove-plugin', 'run-tool'];
+      const commandNames = ['configure', 'create-project', 'install-plugin', 'install-unity', 'open', 'remove-plugin', 'run-tool', 'team'];
       const positions = commandNames.map(name => stdout.indexOf(name));
       // Verify each command appears after the previous one (alphabetical order)
       for (let i = 1; i < positions.length; i++) {

--- a/cli/tests/team.test.ts
+++ b/cli/tests/team.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { createDefaultTeamLayout } from '../src/utils/team-templates.js';
+import {
+  canTransitionTeamSessionStatus,
+  createTeamSessionState,
+  getTeamStateFilePath,
+  listTeamSessionStates,
+  parseTeamSessionState,
+  readTeamSessionState,
+  transitionTeamSessionState,
+  writeTeamSessionState,
+} from '../src/utils/team-state.js';
+import { createTmuxAdapter, parseListPanesOutput, TmuxCommandError, type TmuxAdapter, type TmuxPaneSnapshot } from '../src/utils/tmux.js';
+import {
+  getTeamSessionStatus,
+  launchTeamSession,
+  listTeamSessions,
+  stopTeamSession,
+  type TeamSessionListResult,
+} from '../src/utils/team-orchestration.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
+
+function runCli(args: string[], options?: { cwd?: string }): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      timeout: 10000,
+      cwd: options?.cwd,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: (error.stdout ?? '') + (error.stderr ?? ''),
+      exitCode: error.status ?? 1,
+    };
+  }
+}
+
+function makeFakeUnityProject(dir: string): void {
+  fs.mkdirSync(path.join(dir, 'Assets'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'ProjectSettings'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'ProjectSettings', 'ProjectVersion.txt'), 'm_EditorVersion: 6000.0.0f1\n');
+}
+
+class FakeTmux implements TmuxAdapter {
+  readonly sessions = new Map<string, TmuxPaneSnapshot[]>();
+  readonly killedSessions: string[] = [];
+  private nextPaneNumber = 1;
+
+  ensureAvailable(): void {
+    // no-op
+  }
+
+  hasSession(sessionName: string): boolean {
+    return this.sessions.has(sessionName);
+  }
+
+  createSession(sessionName: string, workingDirectory: string): string {
+    const paneId = `%${this.nextPaneNumber++}`;
+    this.sessions.set(sessionName, [{
+      paneId,
+      title: '',
+      currentCommand: 'shell',
+      currentPath: workingDirectory,
+      active: true,
+    }]);
+    return paneId;
+  }
+
+  splitWindow(targetPaneId: string, workingDirectory: string): string {
+    const session = this.findSessionByPaneId(targetPaneId);
+    if (!session) {
+      throw new Error(`Unknown pane: ${targetPaneId}`);
+    }
+
+    const paneId = `%${this.nextPaneNumber++}`;
+    const panes = this.sessions.get(session)!;
+    panes.push({
+      paneId,
+      title: '',
+      currentCommand: 'shell',
+      currentPath: workingDirectory,
+      active: false,
+    });
+    return paneId;
+  }
+
+  setPaneTitle(targetPaneId: string, title: string): void {
+    const session = this.findSessionByPaneId(targetPaneId);
+    if (!session) {
+      throw new Error(`Unknown pane: ${targetPaneId}`);
+    }
+    const panes = this.sessions.get(session)!;
+    const pane = panes.find(entry => entry.paneId === targetPaneId);
+    if (pane) {
+      pane.title = title;
+    }
+  }
+
+  selectLayout(): void {
+    // no-op for tests
+  }
+
+  listPanes(sessionName: string): TmuxPaneSnapshot[] {
+    return [...(this.sessions.get(sessionName) ?? [])].map(pane => ({ ...pane }));
+  }
+
+  killSession(sessionName: string): void {
+    this.killedSessions.push(sessionName);
+    this.sessions.delete(sessionName);
+  }
+
+  private findSessionByPaneId(targetPaneId: string): string | undefined {
+    for (const [sessionName, panes] of this.sessions.entries()) {
+      if (panes.some(pane => pane.paneId === targetPaneId)) {
+        return sessionName;
+      }
+    }
+    return undefined;
+  }
+}
+
+describe('team command registration', () => {
+  it('lists the team command in global help', () => {
+    const { stdout, exitCode } = runCli(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('team');
+  });
+
+  it('shows team subcommands in help', () => {
+    const { stdout, exitCode } = runCli(['team', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('launch');
+    expect(stdout).toContain('list');
+    expect(stdout).toContain('status');
+    expect(stdout).toContain('stop');
+  });
+});
+
+describe('team state helpers', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-team-state-'));
+    makeFakeUnityProject(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('serializes and deserializes a team session state', () => {
+    const state = createTeamSessionState({
+      sessionId: 'demo-session',
+      projectPath: tmpDir,
+      launcherVersion: '0.66.0',
+      tmuxSessionName: 'demo-session',
+      layoutPreset: 'default',
+      verificationPolicy: 'ready when panes exist',
+      templateVersion: '1',
+      roles: createDefaultTeamLayout(tmpDir).roles,
+    });
+
+    writeTeamSessionState(tmpDir, state);
+    const loaded = readTeamSessionState(tmpDir, 'demo-session');
+
+    expect(loaded.sessionId).toBe('demo-session');
+    expect(loaded.roles).toHaveLength(4);
+    expect(loaded.roles.every(role => role.status === 'pending')).toBe(true);
+  });
+
+  it('rejects malformed session state payloads', () => {
+    expect(() => parseTeamSessionState('{"schemaVersion":1,"status":"ready"}', 'broken.json'))
+      .toThrowError(/roles/);
+  });
+
+  it('validates supported status transitions', () => {
+    expect(canTransitionTeamSessionStatus('launching', 'ready')).toBe(true);
+    expect(canTransitionTeamSessionStatus('ready', 'stopped')).toBe(true);
+    expect(canTransitionTeamSessionStatus('stopped', 'ready')).toBe(false);
+
+    const state = createTeamSessionState({
+      sessionId: 'demo-session',
+      projectPath: tmpDir,
+      launcherVersion: '0.66.0',
+      tmuxSessionName: 'demo-session',
+      layoutPreset: 'default',
+      verificationPolicy: 'ready when panes exist',
+      templateVersion: '1',
+      roles: createDefaultTeamLayout(tmpDir).roles,
+    });
+    const ready = transitionTeamSessionState(state, 'ready');
+    expect(ready.status).toBe('ready');
+  });
+});
+
+describe('tmux adapter', () => {
+  it('builds the expected tmux arguments', () => {
+    const calls: string[][] = [];
+    const adapter = createTmuxAdapter((args) => {
+      calls.push(args);
+      if (args[0] === 'new-session') return '%1';
+      if (args[0] === 'split-window') return '%2';
+      if (args[0] === 'list-panes') return '%1\tleader\tshell\t/tmp\t1';
+      return '';
+    });
+
+    adapter.ensureAvailable();
+    adapter.createSession('demo', '/tmp/project', 'team');
+    adapter.splitWindow('%1', '/tmp/project', 'horizontal');
+    adapter.setPaneTitle('%1', 'leader');
+    adapter.selectLayout('demo', 'tiled');
+    adapter.listPanes('demo');
+    adapter.killSession('demo');
+
+    expect(calls).toEqual([
+      ['-V'],
+      ['new-session', '-d', '-P', '-F', '#{pane_id}', '-s', 'demo', '-n', 'team', '-c', '/tmp/project'],
+      ['split-window', '-h', '-P', '-F', '#{pane_id}', '-t', '%1', '-c', '/tmp/project'],
+      ['select-pane', '-t', '%1', '-T', 'leader'],
+      ['select-layout', '-t', 'demo:0', 'tiled'],
+      ['list-panes', '-t', 'demo:0', '-F', '#{pane_id}\t#{pane_title}\t#{pane_current_command}\t#{pane_current_path}\t#{pane_active}'],
+      ['kill-session', '-t', 'demo'],
+    ]);
+  });
+
+  it('parses list-panes output into typed pane records', () => {
+    expect(parseListPanesOutput('%1\tleader\tshell\t/tmp\t1\n%2\tbuilder\tnode\t/tmp\t0')).toEqual([
+      { paneId: '%1', title: 'leader', currentCommand: 'shell', currentPath: '/tmp', active: true },
+      { paneId: '%2', title: 'builder', currentCommand: 'node', currentPath: '/tmp', active: false },
+    ]);
+  });
+
+  it('surfaces a clear missing-tmux error', () => {
+    const adapter = createTmuxAdapter(() => {
+      throw new TmuxCommandError('tmux is required for team orchestration. Install tmux and ensure it is available on PATH.', 'missing');
+    });
+
+    expect(() => adapter.ensureAvailable()).toThrowError(/tmux is required/);
+  });
+});
+
+describe('team templates', () => {
+  it('expands the default layout into deterministic role panes', () => {
+    const layout = createDefaultTeamLayout('/tmp/project');
+    expect(layout.name).toBe('default');
+    expect(layout.roles.map(role => role.roleName)).toEqual(['leader', 'builder', 'verifier', 'notes']);
+    expect(layout.roles.map(role => role.paneTitle)).toEqual(['leader', 'builder', 'verifier', 'notes']);
+    expect(layout.roles.every(role => role.command === 'shell')).toBe(true);
+    expect(layout.roles.every(role => role.workingDirectory === '/tmp/project')).toBe(true);
+  });
+});
+
+describe('team lifecycle with mocked tmux', () => {
+  let tmpDir: string;
+  let tmux: FakeTmux;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-team-lifecycle-'));
+    makeFakeUnityProject(tmpDir);
+    tmux = new FakeTmux();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('launches a session, writes state, and marks it ready', () => {
+    const state = launchTeamSession(tmpDir, '0.66.0', tmux, { sessionName: 'alpha-team' }, new Date('2026-04-23T05:00:00.000Z'));
+
+    expect(state.status).toBe('ready');
+    expect(state.roles).toHaveLength(4);
+    expect(state.roles.every(role => role.status === 'ready')).toBe(true);
+    expect(fs.existsSync(getTeamStateFilePath(tmpDir, 'alpha-team'))).toBe(true);
+
+    const loaded = readTeamSessionState(tmpDir, 'alpha-team');
+    expect(loaded.tmuxSessionName).toBe('alpha-team');
+    expect(loaded.roles.map(role => role.paneTitle)).toEqual(['leader', 'builder', 'verifier', 'notes']);
+  });
+
+  it('reconciles status to degraded when tmux panes disappear', () => {
+    launchTeamSession(tmpDir, '0.66.0', tmux, { sessionName: 'alpha-team' }, new Date('2026-04-23T05:00:00.000Z'));
+    tmux.sessions.set('alpha-team', tmux.listPanes('alpha-team').slice(0, 2));
+
+    const inspection = getTeamSessionStatus(tmpDir, tmux, 'alpha-team');
+
+    expect(inspection.state.status).toBe('degraded');
+    expect(inspection.issues.some(issue => issue.includes('missing pane for role verifier'))).toBe(true);
+  });
+
+  it('lists sessions and skips corrupted state files without crashing', () => {
+    launchTeamSession(tmpDir, '0.66.0', tmux, { sessionName: 'alpha-team' }, new Date('2026-04-23T05:00:00.000Z'));
+    const corruptedPath = path.join(tmpDir, '.unity-mcp', 'team-state', 'broken.json');
+    fs.writeFileSync(corruptedPath, '{not-json}\n');
+
+    const result: TeamSessionListResult = listTeamSessions(tmpDir, tmux);
+
+    expect(result.inspections).toHaveLength(1);
+    expect(result.inspections[0].state.sessionId).toBe('alpha-team');
+    expect(result.invalid).toHaveLength(1);
+    expect(result.invalid[0].filePath).toBe(corruptedPath);
+  });
+
+  it('stops an active session and marks saved state as stopped', () => {
+    launchTeamSession(tmpDir, '0.66.0', tmux, { sessionName: 'alpha-team' }, new Date('2026-04-23T05:00:00.000Z'));
+
+    const stopped = stopTeamSession(tmpDir, tmux, 'alpha-team');
+
+    expect(stopped.status).toBe('stopped');
+    expect(stopped.roles.every(role => role.status === 'stopped')).toBe(true);
+    expect(tmux.killedSessions).toEqual(['alpha-team']);
+  });
+
+  it('records degraded launch state when pane creation fails mid-launch', () => {
+    const failingTmux = new FakeTmux();
+    const originalSplitWindow = failingTmux.splitWindow.bind(failingTmux);
+    let splitCalls = 0;
+    failingTmux.splitWindow = (targetPaneId, workingDirectory, orientation) => {
+      splitCalls += 1;
+      if (splitCalls === 2) {
+        throw new Error('split failed');
+      }
+      return originalSplitWindow(targetPaneId, workingDirectory, orientation);
+    };
+
+    expect(() => launchTeamSession(tmpDir, '0.66.0', failingTmux, { sessionName: 'broken-team' }, new Date('2026-04-23T05:00:00.000Z')))
+      .toThrowError(/split failed/);
+
+    const loaded = readTeamSessionState(tmpDir, 'broken-team');
+    expect(loaded.status).toBe('degraded');
+    expect(loaded.notes.some(note => note.includes('Launch failed: split failed'))).toBe(true);
+  });
+
+  it('returns saved sessions when tmux is unavailable during list', () => {
+    launchTeamSession(tmpDir, '0.66.0', tmux, { sessionName: 'alpha-team' }, new Date('2026-04-23T05:00:00.000Z'));
+
+    const unavailableTmux: TmuxAdapter = {
+      ensureAvailable: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+      hasSession: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+      createSession: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+      splitWindow: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+      setPaneTitle: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+      selectLayout: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+      listPanes: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+      killSession: () => { throw new TmuxCommandError('tmux is required', 'missing'); },
+    };
+
+    const result = listTeamSessions(tmpDir, unavailableTmux);
+
+    expect(result.inspections).toHaveLength(1);
+    expect(result.tmuxUnavailableMessage).toContain('tmux is required');
+  });
+
+  it('lists saved team state files newest-first', () => {
+    launchTeamSession(tmpDir, '0.66.0', tmux, { sessionName: 'alpha-team' }, new Date('2026-04-23T05:00:00.000Z'));
+    launchTeamSession(tmpDir, '0.66.0', tmux, { sessionName: 'beta-team' }, new Date('2026-04-23T06:00:00.000Z'));
+
+    const listed = listTeamSessionStates(tmpDir);
+    expect(listed.sessions.map(session => session.sessionId)).toEqual(['beta-team', 'alpha-team']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a local `team` command group to `unity-mcp-cli` with `launch`, `status`, `list`, and `stop`
- add tmux orchestration, project-local persisted session state, and default layout helpers for milestone-1
- document the new workflow and add coverage for command registration, state handling, tmux behavior, and degraded session reporting

## Why
This implements the approved milestone-1 tmux orchestration fork plan inside the existing CLI surface so local team sessions can be launched, inspected, and stopped without introducing a separate orchestration binary.

## Impact
- users can start and inspect a local 4-pane tmux team session from the CLI
- session state is preserved under `.unity-mcp/team-state` so list/status can explain stale or degraded sessions
- docs and tests now cover the new team workflow

## Validation
- `cd cli && npm test`
- `cd cli && npm run build`
- `node cli/dist/index.js team --help`
- `node cli/dist/index.js team launch --help`
- `node cli/dist/index.js team status --help`
- `node cli/dist/index.js team list --help`
- `node cli/dist/index.js team stop --help`
- manual tmux smoke on a temporary Unity project:
  - `team launch -> status -> list -> stop`
  - degraded path confirmed by killing the tmux session and observing `team status` return `degraded` with exit code `1`

## Notes
- no GitHub Actions runs were visible yet on the fork for commit `12846d16` at PR creation time
- scope intentionally stays within milestone-1 local tmux orchestration
