### PR TITLE
revert(cli): roll back version bump 0.67.0 to 0.66.0

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unity-mcp-cli",
-  "version": "0.67.0",
+  "version": "0.66.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unity-mcp-cli",
-      "version": "0.67.0",
+      "version": "0.66.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-mcp-cli",
-  "version": "0.67.0",
+  "version": "0.66.0",
   "description": "Cross-platform CLI tool for AI Game Developer (Skills & MCP). Full AI develop and test loop. Efficient token usage, advanced tools. Creates Unity project, installs plugins, configures tools, and manages HTTP connection with Unity Editor and a game made with Unity. Works with Claude Code, Gemini, Copilot, Cursor and any other absolutely for free.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
## Why

The library API work from #679 landed on main, but publishing `unity-mcp-cli@0.67.0` to npm was deferred (per decision on 2026-04-23). The Unity plugin and cli release together; bumping the cli version alone wouldn't trigger a publish anyway. Reverting the cli `package.json` version lets the new library API ship naturally with the next Unity plugin release (whenever that happens).

## Scope

- **Revert only** `cli/package.json` version field `0.67.0` -> `0.66.0`
- (And `cli/package-lock.json` if applicable)
- **Keep** all other changes from #679: library API (`src/lib.ts` + `src/lib/*.ts`), new CLI wrappers, tests, CHANGELOG entry

## Consumers

Anyone who needs the library API before the next Unity plugin release must reference unity-mcp-cli via git dep (`github:IvanMurzak/Unity-MCP#<sha>`) or `file:` path — npm will continue serving `0.66.0` without the library API until the next full release.

Refs #679.