### PR TITLE
fix: pin Microsoft.Extensions.Logging.Abstractions to 8.0.3 (#677)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetConfig.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetConfig.cs
@@ -59,7 +59,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
             new NuGetPackage("Microsoft.AspNetCore.SignalR.Client",                   "8.0.15", includeInBuild: true),
             new NuGetPackage("Microsoft.AspNetCore.SignalR.Protocols.Json",           "8.0.15", includeInBuild: true),
             new NuGetPackage("Microsoft.Extensions.Logging",                          "8.0.1",  includeInBuild: true),
-            new NuGetPackage("Microsoft.Extensions.Logging.Abstractions",             "8.0.2",  includeInBuild: true),
+            // Pinned to 8.0.3 to match the transitive requirement from
+            // Microsoft.AspNetCore.Http.Connections.Client 8.0.15 (pulled in via
+            // SignalR.Client 8.0.15 → SignalR.Client.Core 8.0.15). Any lower pin
+            // (e.g. 8.0.2) produces an infinite restore loop on every domain reload:
+            // higher-version-wins extracts 8.0.3 to disk while AllPackagesInstalled()
+            // keeps checking for the pinned dir, never finds it, and triggers Restore()
+            // again on the next reload. See Unity-MCP#677.
+            new NuGetPackage("Microsoft.Extensions.Logging.Abstractions",             "8.0.3",  includeInBuild: true),
             new NuGetPackage("Microsoft.Extensions.DependencyInjection",              "8.0.1",  includeInBuild: true),
             new NuGetPackage("Microsoft.Extensions.DependencyInjection.Abstractions", "8.0.2",  includeInBuild: true),
             new NuGetPackage("Microsoft.Extensions.Options",                          "8.0.2",  includeInBuild: true),


### PR DESCRIPTION
## Summary

- Bumps the `Microsoft.Extensions.Logging.Abstractions` pin in `NuGetConfig.Packages` from `8.0.2` to `8.0.3`.
- Resolves the infinite NuGet restore loop described in #677 that triggers on every domain reload when the Unity-MCP package is installed fresh at v0.66.0.

## Root cause

`NuGetDependencyResolver` trusts `NuGetConfig.Packages` as the source of truth for what should be on disk. The pin was `8.0.2`, but `Microsoft.AspNetCore.SignalR.Client 8.0.15` pulls in `Microsoft.AspNetCore.Http.Connections.Client 8.0.15`, which requires `Microsoft.Extensions.Logging.Abstractions >= 8.0.3`. NuGet's higher-version-wins extracts `8.0.3` to disk; `AllPackagesInstalled()` then keeps checking for the `8.0.2` directory, never finds it, and re-triggers `Restore()` on the next domain reload. Alongside Hot Reload it's very noisy, but the root cause is the pin/transitive mismatch — Hot Reload just surfaces it faster.

Transitive chain verified via nuspecs:
`SignalR.Client 8.0.15` → `SignalR.Client.Core 8.0.15` → `Http.Connections.Client 8.0.15` → `Microsoft.Extensions.Logging.Abstractions 8.0.3`.

## Fix

Single-line change in `Editor/DependencyResolver/NuGetConfig.cs` — update the pin, plus an inline comment explaining why the pin must match the transitive requirement.

## Test plan

- [ ] Fresh checkout at this branch, open Unity on the plugin project — confirm `Editor.log` shows no `[NuGet] Restoring` / `[NuGet] Downloading` output on the second (cache-populated) startup.
- [ ] Confirm `AllPackagesInstalled()` returns `true` on first check post-fix.
- [ ] Confirm the reporter's environment (Unity 6.x + Singularity Group Hot Reload at v0.66.0) no longer loops.
- [ ] GitHub CI runs a fresh install on a clean runner — that matches the end-user scenario in #677 exactly, so a green CI is strong evidence.

Closes #677