### PR TITLE
feat(cli): add bootstrap-local for fresh-worktree MCP config pinning

### DIFF
--- a/cli/src/commands/bootstrap-local.ts
+++ b/cli/src/commands/bootstrap-local.ts
@@ -71,17 +71,9 @@ export const bootstrapLocalCommand = new Command('bootstrap-local')
   .action(async (positionalPath: string | undefined, options: BootstrapLocalOptions) => {
     const projectPath = resolveAndValidateProjectPath(positionalPath, options);
 
-    const url = options.url?.replace(/\/$/, '');
-    const token = options.token;
-
-    if (!url) {
-      ui.error('--url is required');
-      process.exit(1);
-    }
-    if (!token) {
-      ui.error('--token is required');
-      process.exit(1);
-    }
+    // commander's requiredOption guarantees url/token are defined before the action runs.
+    const url = options.url!.replace(/\/$/, '');
+    const token = options.token!;
 
     verbose(`Project path: ${projectPath}`);
     verbose(`Target URL: ${url}`);

--- a/cli/src/commands/bootstrap-local.ts
+++ b/cli/src/commands/bootstrap-local.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { Command } from 'commander';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { resolveAndValidateProjectPath } from '../utils/connection.js';
+import {
+  readConfig,
+  writeConfig,
+  isCloudMode,
+  type UnityConnectionConfig,
+} from '../utils/config.js';
+
+interface BootstrapLocalOptions {
+  path?: string;
+  url?: string;
+  token?: string;
+  dryRun?: boolean;
+}
+
+/**
+ * Produce a new config object with local-mode fields pinned to `url` / `token`.
+ * Preserves all other keys from `current` (immutable update — does not mutate `current`).
+ *
+ * The plugin-side ConnectionMode enum only accepts "Custom" (local) or "Cloud".
+ * We intentionally normalize any integer (0 → Custom, 1 → Cloud) representation
+ * to the canonical string "Custom" so the on-disk file is explicit.
+ */
+export function pinLocalModeConfig(
+  current: Readonly<UnityConnectionConfig>,
+  url: string,
+  token: string,
+): UnityConnectionConfig {
+  return {
+    ...current,
+    connectionMode: 'Custom',
+    host: url,
+    token,
+  };
+}
+
+/**
+ * Returns true iff `current` already reflects local mode with matching url + token.
+ * Used to make bootstrap-local a no-op when nothing would change on disk.
+ */
+export function isAlreadyPinned(
+  current: Readonly<UnityConnectionConfig>,
+  url: string,
+  token: string,
+): boolean {
+  if (isCloudMode(current)) return false;
+  // Accept both "Custom" (string) and 0 (legacy int) as already-local.
+  const mode = current.connectionMode;
+  const isLocalMode = mode === 'Custom' || mode === 0;
+  if (!isLocalMode) return false;
+  return current.host === url && current.token === token;
+}
+
+export const bootstrapLocalCommand = new Command('bootstrap-local')
+  .description(
+    'Pin a Unity project\'s MCP config to local mode with the given URL/token. Idempotent.',
+  )
+  .argument('[path]', 'Unity project path (defaults to cwd)')
+  .option('--path <path>', 'Unity project path (defaults to cwd)')
+  .requiredOption('--url <url>', 'Local MCP server URL to pin (e.g. http://localhost:5140/)')
+  .requiredOption('--token <token>', 'Local MCP bearer token to pin')
+  .option('--dry-run', 'Report what would change without writing to disk')
+  .action(async (positionalPath: string | undefined, options: BootstrapLocalOptions) => {
+    const projectPath = resolveAndValidateProjectPath(positionalPath, options);
+
+    const url = options.url?.replace(/\/$/, '');
+    const token = options.token;
+
+    if (!url) {
+      ui.error('--url is required');
+      process.exit(1);
+    }
+    if (!token) {
+      ui.error('--token is required');
+      process.exit(1);
+    }
+
+    verbose(`Project path: ${projectPath}`);
+    verbose(`Target URL: ${url}`);
+    verbose(`Target token: ${'*'.repeat(Math.min(token.length, 8))}... (length ${token.length})`);
+
+    const configPath = path.join(projectPath, 'UserSettings', 'AI-Game-Developer-Config.json');
+    const existedBefore = fs.existsSync(configPath);
+
+    // Use readConfig (not getOrCreateConfig) so --dry-run truly has no side effects.
+    // When the file doesn't exist we pin onto an empty base; this mirrors a fresh
+    // worktree where the plugin has not yet written its default Cloud config.
+    const current: UnityConnectionConfig = readConfig(projectPath) ?? {};
+
+    if (isAlreadyPinned(current, url, token)) {
+      ui.success(
+        `MCP config already pinned to local mode (${url}). No changes written.`,
+      );
+      return;
+    }
+
+    const next = pinLocalModeConfig(current, url, token);
+
+    if (options.dryRun) {
+      ui.heading('bootstrap-local (dry run)');
+      ui.label('Config file', configPath);
+      ui.label('connectionMode', `${String(current.connectionMode ?? 'unset')} → Custom`);
+      ui.label('host', `${String(current.host ?? 'unset')} → ${url}`);
+      ui.label('token', `${current.token ? '<previous>' : '<unset>'} → <supplied>`);
+      ui.info('No changes written (--dry-run).');
+      return;
+    }
+
+    writeConfig(projectPath, next);
+
+    ui.heading('bootstrap-local');
+    ui.label('Config file', configPath);
+    ui.label('connectionMode', 'Custom');
+    ui.label('host', url);
+    ui.label('token', '<supplied>');
+    ui.success(
+      existedBefore
+        ? 'Config updated to pin local mode.'
+        : 'Config created and pinned to local mode.',
+    );
+  });

--- a/cli/src/commands/bootstrap-local.ts
+++ b/cli/src/commands/bootstrap-local.ts
@@ -10,7 +10,6 @@ import { resolveAndValidateProjectPath } from '../utils/connection.js';
 import {
   readConfig,
   writeConfig,
-  isCloudMode,
   type UnityConnectionConfig,
 } from '../utils/config.js';
 
@@ -51,11 +50,10 @@ export function isAlreadyPinned(
   url: string,
   token: string,
 ): boolean {
-  if (isCloudMode(current)) return false;
   // Accept both "Custom" (string) and 0 (legacy int) as already-local.
+  // Anything else (including "Cloud", 1, or unset) means we still need to pin.
   const mode = current.connectionMode;
-  const isLocalMode = mode === 'Custom' || mode === 0;
-  if (!isLocalMode) return false;
+  if (mode !== 'Custom' && mode !== 0) return false;
   return current.host === url && current.token === token;
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { createRequire } from 'module';
+import { bootstrapLocalCommand } from './commands/bootstrap-local.js';
 import { createProjectCommand } from './commands/create-project.js';
 import { installUnityCommand } from './commands/install-unity.js';
 import { openCommand } from './commands/open.js';
@@ -30,6 +31,7 @@ program
 
 // Register all subcommands
 const subcommands = [
+  bootstrapLocalCommand,
   configureCommand,
   createProjectCommand,
   installPluginCommand,

--- a/cli/tests/bootstrap-local.test.ts
+++ b/cli/tests/bootstrap-local.test.ts
@@ -1,0 +1,335 @@
+// Copyright (c) 2025 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+import {
+  pinLocalModeConfig,
+  isAlreadyPinned,
+} from '../src/commands/bootstrap-local.js';
+import {
+  readConfig,
+  type UnityConnectionConfig,
+} from '../src/utils/config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
+
+function runCli(args: string[]): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: (error.stdout ?? '') + (error.stderr ?? ''),
+      exitCode: error.status ?? 1,
+    };
+  }
+}
+
+describe('bootstrap-local pure helpers', () => {
+  describe('pinLocalModeConfig', () => {
+    it('produces a new object (does not mutate input)', () => {
+      const original: UnityConnectionConfig = {
+        connectionMode: 'Cloud',
+        cloudToken: 'cloud-secret',
+        host: 'http://old.example.com',
+      };
+      const frozen = Object.freeze({ ...original });
+
+      const next = pinLocalModeConfig(frozen, 'http://localhost:5140', 'local-token');
+
+      expect(next).not.toBe(frozen);
+      expect(next.connectionMode).toBe('Custom');
+      expect(next.host).toBe('http://localhost:5140');
+      expect(next.token).toBe('local-token');
+      // Original untouched
+      expect(frozen.connectionMode).toBe('Cloud');
+      expect(frozen.host).toBe('http://old.example.com');
+    });
+
+    it('preserves unrelated keys (tools, cloudToken, logLevel, ...)', () => {
+      const original: UnityConnectionConfig = {
+        connectionMode: 'Cloud',
+        cloudToken: 'keep-me',
+        logLevel: 2,
+        timeoutMs: 5000,
+        tools: [{ name: 'tool-a', enabled: true }],
+        prompts: [{ name: 'prompt-a', enabled: false }],
+        resources: [],
+        someCustomKey: 42,
+      };
+
+      const next = pinLocalModeConfig(original, 'http://localhost:5140', 'local-token');
+
+      expect(next.cloudToken).toBe('keep-me');
+      expect(next.logLevel).toBe(2);
+      expect(next.timeoutMs).toBe(5000);
+      expect(next.tools).toEqual([{ name: 'tool-a', enabled: true }]);
+      expect(next.prompts).toEqual([{ name: 'prompt-a', enabled: false }]);
+      expect(next.resources).toEqual([]);
+      expect(next.someCustomKey).toBe(42);
+    });
+
+    it('normalizes connectionMode to the string "Custom" (not 0)', () => {
+      const original: UnityConnectionConfig = { connectionMode: 0 };
+      const next = pinLocalModeConfig(original, 'http://localhost:5140', 'tok');
+      expect(next.connectionMode).toBe('Custom');
+    });
+  });
+
+  describe('isAlreadyPinned', () => {
+    it('returns true when mode=Custom, host=url, token=token', () => {
+      const cfg: UnityConnectionConfig = {
+        connectionMode: 'Custom',
+        host: 'http://localhost:5140',
+        token: 'tok',
+      };
+      expect(isAlreadyPinned(cfg, 'http://localhost:5140', 'tok')).toBe(true);
+    });
+
+    it('accepts legacy integer 0 (Custom) as already-local', () => {
+      const cfg: UnityConnectionConfig = {
+        connectionMode: 0,
+        host: 'http://localhost:5140',
+        token: 'tok',
+      };
+      expect(isAlreadyPinned(cfg, 'http://localhost:5140', 'tok')).toBe(true);
+    });
+
+    it('returns false when mode=Cloud', () => {
+      const cfg: UnityConnectionConfig = {
+        connectionMode: 'Cloud',
+        host: 'http://localhost:5140',
+        token: 'tok',
+      };
+      expect(isAlreadyPinned(cfg, 'http://localhost:5140', 'tok')).toBe(false);
+    });
+
+    it('returns false when mode=integer 1 (Cloud)', () => {
+      const cfg: UnityConnectionConfig = {
+        connectionMode: 1,
+        host: 'http://localhost:5140',
+        token: 'tok',
+      };
+      expect(isAlreadyPinned(cfg, 'http://localhost:5140', 'tok')).toBe(false);
+    });
+
+    it('returns false when host differs', () => {
+      const cfg: UnityConnectionConfig = {
+        connectionMode: 'Custom',
+        host: 'http://localhost:9999',
+        token: 'tok',
+      };
+      expect(isAlreadyPinned(cfg, 'http://localhost:5140', 'tok')).toBe(false);
+    });
+
+    it('returns false when token differs', () => {
+      const cfg: UnityConnectionConfig = {
+        connectionMode: 'Custom',
+        host: 'http://localhost:5140',
+        token: 'wrong',
+      };
+      expect(isAlreadyPinned(cfg, 'http://localhost:5140', 'tok')).toBe(false);
+    });
+
+    it('returns false when connectionMode is unset', () => {
+      const cfg: UnityConnectionConfig = {
+        host: 'http://localhost:5140',
+        token: 'tok',
+      };
+      expect(isAlreadyPinned(cfg, 'http://localhost:5140', 'tok')).toBe(false);
+    });
+  });
+});
+
+describe('bootstrap-local CLI integration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-bootstrap-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('shows help with --help', () => {
+    const { stdout, exitCode } = runCli(['bootstrap-local', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--url');
+    expect(stdout).toContain('--token');
+    expect(stdout).toContain('--path');
+    expect(stdout).toContain('--dry-run');
+  });
+
+  it('fails when --url is missing', () => {
+    const { stdout, exitCode } = runCli([
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--token', 'tok',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toMatch(/required option|--url/i);
+  });
+
+  it('fails when --token is missing', () => {
+    const { stdout, exitCode } = runCli([
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--url', 'http://localhost:5140',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toMatch(/required option|--token/i);
+  });
+
+  it('creates a new config file pinned to local mode when none exists', () => {
+    const { exitCode } = runCli([
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--url', 'http://localhost:5140',
+      '--token', 'tok-abc',
+    ]);
+    expect(exitCode).toBe(0);
+
+    const cfg = readConfig(tmpDir);
+    expect(cfg).not.toBeNull();
+    expect(cfg!.connectionMode).toBe('Custom');
+    expect(cfg!.host).toBe('http://localhost:5140');
+    expect(cfg!.token).toBe('tok-abc');
+  });
+
+  it('strips trailing slash from --url', () => {
+    const { exitCode } = runCli([
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--url', 'http://localhost:5140/',
+      '--token', 'tok',
+    ]);
+    expect(exitCode).toBe(0);
+    const cfg = readConfig(tmpDir);
+    expect(cfg!.host).toBe('http://localhost:5140');
+  });
+
+  it('flips a pre-existing Cloud config to Custom, preserving other keys', () => {
+    // Pre-seed a Cloud-mode config with extra keys
+    const preSeed: UnityConnectionConfig = {
+      connectionMode: 'Cloud',
+      cloudToken: 'cloud-secret',
+      host: 'http://localhost:9999',
+      logLevel: 2,
+      tools: [{ name: 'gameobject-create', enabled: false }],
+    };
+    fs.mkdirSync(path.join(tmpDir, 'UserSettings'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'UserSettings', 'AI-Game-Developer-Config.json'),
+      JSON.stringify(preSeed, null, 2) + '\n',
+    );
+
+    const { exitCode } = runCli([
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--url', 'http://localhost:5140',
+      '--token', 'new-tok',
+    ]);
+    expect(exitCode).toBe(0);
+
+    const cfg = readConfig(tmpDir);
+    expect(cfg!.connectionMode).toBe('Custom');
+    expect(cfg!.host).toBe('http://localhost:5140');
+    expect(cfg!.token).toBe('new-tok');
+    // Preserved:
+    expect(cfg!.cloudToken).toBe('cloud-secret');
+    expect(cfg!.logLevel).toBe(2);
+    expect(cfg!.tools).toEqual([{ name: 'gameobject-create', enabled: false }]);
+  });
+
+  it('is idempotent — second run with matching url/token reports no-op', () => {
+    const args = [
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--url', 'http://localhost:5140',
+      '--token', 'tok',
+    ];
+    const first = runCli(args);
+    expect(first.exitCode).toBe(0);
+    expect(first.stdout).toMatch(/created|updated/i);
+
+    // Capture mtime after first run
+    const configPath = path.join(tmpDir, 'UserSettings', 'AI-Game-Developer-Config.json');
+    const mtime1 = fs.statSync(configPath).mtimeMs;
+
+    // Wait a tick so any rewrite would show a different mtime
+    const second = runCli(args);
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toMatch(/already pinned|no changes/i);
+
+    const mtime2 = fs.statSync(configPath).mtimeMs;
+    expect(mtime2).toBe(mtime1); // file was NOT rewritten
+  });
+
+  it('--dry-run does not create the file when none exists', () => {
+    const { exitCode, stdout } = runCli([
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--url', 'http://localhost:5140',
+      '--token', 'tok',
+      '--dry-run',
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/dry run|no changes written/i);
+
+    const configPath = path.join(tmpDir, 'UserSettings', 'AI-Game-Developer-Config.json');
+    expect(fs.existsSync(configPath)).toBe(false);
+  });
+
+  it('--dry-run does not modify an existing file', () => {
+    const preSeed: UnityConnectionConfig = {
+      connectionMode: 'Cloud',
+      cloudToken: 'cloud-secret',
+    };
+    fs.mkdirSync(path.join(tmpDir, 'UserSettings'), { recursive: true });
+    const configPath = path.join(tmpDir, 'UserSettings', 'AI-Game-Developer-Config.json');
+    fs.writeFileSync(configPath, JSON.stringify(preSeed, null, 2) + '\n');
+    const before = fs.readFileSync(configPath, 'utf-8');
+
+    const { exitCode } = runCli([
+      'bootstrap-local',
+      '--path', tmpDir,
+      '--url', 'http://localhost:5140',
+      '--token', 'tok',
+      '--dry-run',
+    ]);
+    expect(exitCode).toBe(0);
+
+    const after = fs.readFileSync(configPath, 'utf-8');
+    expect(after).toBe(before);
+  });
+
+  it('fails when project path does not exist', () => {
+    const { exitCode, stdout } = runCli([
+      'bootstrap-local',
+      '--path', path.join(tmpDir, 'does-not-exist-xyz'),
+      '--url', 'http://localhost:5140',
+      '--token', 'tok',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toMatch(/does not exist/i);
+  });
+});
+
+describe('bootstrap-local help discoverability', () => {
+  it('bootstrap-local appears in the global --help listing', () => {
+    const { stdout, exitCode } = runCli(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('bootstrap-local');
+  });
+});


### PR DESCRIPTION
## Summary

Introduce `unity-mcp-cli bootstrap-local <path> --url <url> --token <token>`: a narrow, idempotent command that writes `UserSettings/AI-Game-Developer-Config.json` with `connectionMode: "Custom"`, `host: <url>`, `token: <token>` — preserving any other keys already on disk.

## Motivation (#684)

In a freshly provisioned worktree the plugin creates its config on first `[InitializeOnLoad]` defaulted to `connectionMode: "Cloud"` pointing at `https://ai-game.dev/mcp`. The worktree's local dev token is rejected by the cloud server with HTTP 401, and the plugin only boots its embedded local MCP server when `connectionMode` is `Custom` (the enum value for "Local"). Consequently `wait-for-ready` and every `run-tool` call against the worktree's deterministic localhost port are unreachable until a human manually flips the config file.

`bootstrap-local` closes the gap for scripted / CI bring-up:

- Small, scripting-friendly surface — three flags, exit 0 on success.
- Idempotent — if the file already reflects local mode with matching url/token, reports "already pinned" and exits 0 without rewriting the file (mtime preserved).
- `--dry-run` — reports what would change without writing anything.
- Preserves unrelated keys (`cloudToken`, `logLevel`, `tools`, …).
- No new plugin-side runtime-reload RPC is needed for the fresh-worktree path: run `bootstrap-local` BEFORE `unity-mcp-cli open`, and the plugin's `[InitializeOnLoad]` startup reads the already-pinned config.

## Design rationale (why option A from the issue body, not B or C)

- Option B (`set-connection-mode <mode>`) is a larger command surface (mode values, validation, cloud-side URL/token sync).
- Option C (`wait-for-ready` auto-recovery) requires detecting 401, rewriting the file mid-wait, AND a plugin-side runtime-reload RPC to re-read the file — much broader scope.
- Option A is the minimal floor the scripting use-case needs, and composes with the existing `wait-for-ready --url --token` flags already documented as the defensive-override pattern.

## Test plan

Validation on a fresh worktree (slot 5140–5149, token `local-dev-mcp-token-abc123`):

- [x] `bootstrap-local` writes the config (20ms).
- [x] `unity-mcp-cli open` launches Unity 2022.3.62f3.
- [x] `wait-for-ready` succeeds in 20.1s against `localhost:5140`.
- [x] `tests-run` EditMode: 790/790 passed in 20.26s.
- [x] `tests/bootstrap-local.test.ts` — 21 new tests covering pure helpers (`pinLocalModeConfig` / `isAlreadyPinned`, including legacy integer enum representations) and CLI integration (creation, pre-existing Cloud flip, idempotence with mtime check, `--dry-run` no-op for both existing and missing files, required-flag validation).
- [x] Full CLI suite: 228/228 passed.

Closes #684