### PR TITLE
fix: config priority — flags > env vars > on-disk config > defaults

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Config.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Config.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using Microsoft.Extensions.Logging;
 using UnityEngine;
 
@@ -161,13 +162,30 @@ namespace com.IvanMurzak.Unity.MCP
                         : UnityConnectionConfig.DefaultResources;
                 }
 
-                var json = JsonSerializer.Serialize(unityConnectionConfig, new JsonSerializerOptions
+                // Runtime-only overrides (env vars / CLI flags) MUST NOT be persisted to disk.
+                // Temporarily restore the disk-baseline values for any overridden field, serialize,
+                // then re-apply the overrides so the in-memory config keeps its runtime values.
+                // The "in-memory keeps overrides" property is critical: callers (UI, configurators,
+                // SignalR client) hold references to unityConnectionConfig and continue reading
+                // from it after Save returns. Restoring overrides ensures behaviour is unchanged.
+                var hasRuntimeOverrides = RuntimeOverrides != null && RuntimeOverrides.HasAny;
+                if (hasRuntimeOverrides)
+                    EnvironmentUtils.ApplyBaseline(unityConnectionConfig, RuntimeOverrides!);
+                try
                 {
-                    WriteIndented = true,
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    Converters = { new JsonStringEnumConverter() }
-                });
-                File.WriteAllText(AssetsFileAbsolutePath, json);
+                    var json = JsonSerializer.Serialize(unityConnectionConfig, new JsonSerializerOptions
+                    {
+                        WriteIndented = true,
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                        Converters = { new JsonStringEnumConverter() }
+                    });
+                    File.WriteAllText(AssetsFileAbsolutePath, json);
+                }
+                finally
+                {
+                    if (hasRuntimeOverrides)
+                        EnvironmentUtils.ApplyOverrides(unityConnectionConfig, RuntimeOverrides!);
+                }
 
                 var assetFile = AssetFile;
                 if (assetFile != null)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.cs
@@ -20,12 +20,24 @@ namespace com.IvanMurzak.Unity.MCP
     /// </summary>
     public partial class UnityMcpPluginEditor : UnityMcpPlugin
     {
+        /// <summary>
+        /// Captures runtime overrides (env vars / CLI flags) that were layered on top of the
+        /// on-disk config during construction. Used by <see cref="Save"/> to round-trip the
+        /// disk-baseline values to disk while keeping the runtime overrides on the in-memory
+        /// config — runtime-only overrides MUST NOT leak into the persisted JSON.
+        /// </summary>
+        internal EnvironmentUtils.OverrideRecord RuntimeOverrides { get; private set; }
+            = new EnvironmentUtils.OverrideRecord();
+
         protected UnityMcpPluginEditor() : base()
         {
             var config = GetOrCreateConfig(out var wasCreated);
             unityConnectionConfig = config;
             ApplyLogLevel(unityConnectionConfig.LogLevel);
-            EnvironmentUtils.ApplyEnvironmentOverrides(unityConnectionConfig);
+            // Layered loader: disk values are already on `config`; env vars and CLI flags
+            // are applied here as runtime overrides. The OverrideRecord captures the
+            // disk-baseline values so Save() can persist them without leaking the overrides.
+            RuntimeOverrides = EnvironmentUtils.ApplyEnvironmentOverrides(unityConnectionConfig);
             if (wasCreated)
                 Save();
             IncrementSingletonCount();

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
@@ -18,14 +18,28 @@ using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
 
 namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
 {
+    /// <summary>
+    /// Loads MCP plugin configuration from layered sources and (optionally) applies
+    /// runtime overrides from environment variables and process command-line arguments.
+    ///
+    /// Priority (highest wins):
+    ///   1. Process command-line flags (e.g. <c>--url</c>, <c>--token</c>, <c>--auth</c>,
+    ///      or any <c>--UNITY_MCP_*</c> variant)
+    ///   2. Process environment variables (<c>UNITY_MCP_*</c>)
+    ///   3. On-disk config (<c>UserSettings/AI-Game-Developer-Config.json</c>)
+    ///   4. Built-in defaults
+    ///
+    /// Overrides applied via env vars / flags are NEVER persisted back to disk —
+    /// they are runtime-only. The <see cref="OverrideRecord"/> returned by
+    /// <see cref="ApplyEnvironmentOverrides"/> captures both the disk-baseline values
+    /// and the override values so that the editor's Save() flow can restore the
+    /// baseline before serializing. See <c>UnityMcpPluginEditor.Save</c>.
+    /// </summary>
     public static class EnvironmentUtils
     {
         static readonly ILogger _logger = UnityLoggerFactory.LoggerFactory.CreateLogger(nameof(EnvironmentUtils));
+
         // Environment variable names for MCP connection overrides.
-        // These override values loaded from the JSON config file. On first run (when the config
-        // is newly created), overrides are applied before Save() so they are persisted to disk.
-        // On subsequent runs the config already exists, so overrides are applied at runtime only.
-        // Exception: UNITY_MCP_TOOLS uses [JsonIgnore] and is never persisted.
         public const string EnvHost = "UNITY_MCP_HOST";
         public const string EnvKeepConnected = "UNITY_MCP_KEEP_CONNECTED";
         public const string EnvAuthOption = "UNITY_MCP_AUTH_OPTION";
@@ -34,6 +48,48 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
         public const string EnvStartServer = "UNITY_MCP_START_SERVER";
         public const string EnvTransport = "UNITY_MCP_TRANSPORT";
         public const string EnvCloudUrl = "UNITY_MCP_CLOUD_URL";
+        public const string EnvConnectionMode = "UNITY_MCP_CONNECTION_MODE";
+
+        // Short flag aliases recognised by the in-plugin command-line parser.
+        // The CLI tool already translates these to the equivalent env vars before
+        // launching Unity, but the plugin still parses them directly so
+        // out-of-band invocations (manual editor launch, IDE config, etc.) work.
+        public const string FlagUrl = "url";
+        public const string FlagToken = "token";
+        public const string FlagAuth = "auth";
+
+        // Field-name keys used by OverrideRecord to track which fields were overridden
+        // by env/flags so the Save flow can restore disk-baseline values before writing.
+        public const string FieldHost = nameof(UnityMcpPlugin.UnityConnectionConfig.LocalHost);
+        public const string FieldKeepConnected = "KeepConnected";
+        public const string FieldAuthOption = "AuthOption";
+        public const string FieldLocalToken = nameof(UnityMcpPlugin.UnityConnectionConfig.LocalToken);
+        public const string FieldCloudToken = nameof(UnityMcpPlugin.UnityConnectionConfig.CloudToken);
+        public const string FieldTools = "EnabledToolsOverride";
+        public const string FieldStartServer = "KeepServerRunning";
+        public const string FieldTransport = "TransportMethod";
+        public const string FieldConnectionMode = "ConnectionMode";
+
+        /// <summary>
+        /// Captures, per overridden field, the disk-baseline value (what was read from JSON)
+        /// and the runtime override value applied on top. Allows <c>Save()</c> to round-trip
+        /// the baseline to disk while keeping the runtime override on the in-memory config.
+        /// Empty when no env/flag overrides were detected.
+        /// </summary>
+        public sealed class OverrideRecord
+        {
+            public Dictionary<string, object?> BaselineValues { get; } = new();
+            public Dictionary<string, object?> OverrideValues { get; } = new();
+
+            public bool HasAny => BaselineValues.Count > 0;
+            public bool Contains(string fieldName) => BaselineValues.ContainsKey(fieldName);
+
+            internal void Track(string fieldName, object? baselineValue, object? overrideValue)
+            {
+                BaselineValues[fieldName] = baselineValue;
+                OverrideValues[fieldName] = overrideValue;
+            }
+        }
 
         /// <summary>
         /// Checks if the current environment is a CI environment.
@@ -52,86 +108,272 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
         }
 
         /// <summary>
-        /// Applies environment variable (or command-line argument) overrides to the given config.
-        /// Checks command-line args first, then falls back to process environment variables.
-        /// Invalid or missing values are silently ignored, leaving the config field unchanged.
-        /// On first run (when the config is newly created), overrides are applied before Save()
-        /// so they are persisted to disk. On subsequent runs they act as runtime-only overrides.
-        /// Exception: <see cref="EnvTools"/> (<c>UNITY_MCP_TOOLS</c>) targets a
-        /// <c>[JsonIgnore]</c> property and is never persisted regardless of timing.
+        /// Applies environment-variable and command-line-argument overrides to the given config.
+        /// Args (highest priority) override env vars, env vars override the disk-baseline values
+        /// already present on <paramref name="config"/>. Returns an <see cref="OverrideRecord"/>
+        /// that captures the disk-baseline value for each field that was overridden.
         /// </summary>
-        public static void ApplyEnvironmentOverrides(UnityMcpPlugin.UnityConnectionConfig config)
+        public static OverrideRecord ApplyEnvironmentOverrides(UnityMcpPlugin.UnityConnectionConfig config)
         {
             var args = ArgsUtils.ParseCommandLineArguments();
+            return ApplyEnvironmentOverrides(config, args, Environment.GetEnvironmentVariable);
+        }
 
-            // Host URL override
-            var host = args.GetValueOrDefault(EnvHost) ?? Environment.GetEnvironmentVariable(EnvHost);
-            if (!string.IsNullOrWhiteSpace(host))
+        /// <summary>
+        /// Test-friendly overload. <paramref name="argReader"/> is the parsed command-line
+        /// arg dictionary (keys without leading dashes); <paramref name="envReader"/> resolves
+        /// environment variables. Either may be empty / always-null to disable that source.
+        /// </summary>
+        public static OverrideRecord ApplyEnvironmentOverrides(
+            UnityMcpPlugin.UnityConnectionConfig config,
+            IReadOnlyDictionary<string, string> argReader,
+            Func<string, string?> envReader)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (argReader == null) throw new ArgumentNullException(nameof(argReader));
+            if (envReader == null) throw new ArgumentNullException(nameof(envReader));
+
+            var record = new OverrideRecord();
+
+            // Resolve a value with priority: short-flag-alias (highest) > UNITY_MCP_* env-style flag > env var.
+            // Returns null if no source provided a non-empty value.
+            string? Resolve(string envKey, string? flagAlias)
             {
-                config.Host = host.Trim().Trim('"');
-                _logger.LogInformation("[MCP] Env override: {Key}={Value}", EnvHost, config.Host);
+                // 1. Short flag alias (e.g. "url", "token", "auth")
+                if (!string.IsNullOrEmpty(flagAlias)
+                    && argReader.TryGetValue(flagAlias, out var flagValue)
+                    && !string.IsNullOrWhiteSpace(flagValue))
+                {
+                    return flagValue;
+                }
+                // 2. UNITY_MCP_* style flag
+                if (argReader.TryGetValue(envKey, out var envFlagValue)
+                    && !string.IsNullOrWhiteSpace(envFlagValue))
+                {
+                    return envFlagValue;
+                }
+                // 3. Process env var
+                var envValue = envReader(envKey);
+                if (!string.IsNullOrWhiteSpace(envValue))
+                    return envValue;
+                return null;
             }
 
-            // KeepConnected (active connection) override
-            var keepConnected = args.GetValueOrDefault(EnvKeepConnected) ?? Environment.GetEnvironmentVariable(EnvKeepConnected);
-            if (!string.IsNullOrWhiteSpace(keepConnected)
-                && bool.TryParse(keepConnected.Trim().Trim('"'), out var kc))
+            string Sanitize(string raw) => raw.Trim().Trim('"');
+
+            // --- Host URL override (UNITY_MCP_HOST or UNITY_MCP_CLOUD_URL or --url) ---
+            // UNITY_MCP_CLOUD_URL is the canonical key in the layered loader contract.
+            // UNITY_MCP_HOST is preserved for backward compatibility.
+            // --url is a short alias.
+            // All values are defensively trimmed of trailing slashes.
+            string? sanitizedHost = null;
+            var rawHost = Resolve(EnvCloudUrl, FlagUrl) ?? Resolve(EnvHost, flagAlias: null);
+            if (rawHost != null)
             {
-                config.KeepConnected = kc;
-                _logger.LogInformation("[MCP] Env override: {Key}={Value}", EnvKeepConnected, config.KeepConnected);
+                var host = Sanitize(rawHost).TrimEnd('/');
+                if (host.Length > 0)
+                {
+                    sanitizedHost = host;
+                    if (!string.Equals(host, config.LocalHost, StringComparison.Ordinal))
+                    {
+                        record.Track(FieldHost, config.LocalHost, host);
+                        config.LocalHost = host;
+                        _logger.LogInformation("[MCP] Override: {Key}={Value}", FieldHost, host);
+                    }
+                }
             }
 
-            // AuthOption override (none / required)
-            var authOption = args.GetValueOrDefault(EnvAuthOption) ?? Environment.GetEnvironmentVariable(EnvAuthOption);
-            if (!string.IsNullOrWhiteSpace(authOption)
-                && Enum.TryParse<AuthOption>(authOption.Trim().Trim('"'), ignoreCase: true, out var ao))
+            // --- Connection mode override (UNITY_MCP_CONNECTION_MODE) ---
+            // Explicit env / flag wins; otherwise, if a host URL was provided and points to
+            // a loopback address, infer Custom mode (worktree / local-dev scenarios). If the
+            // URL points to a remote host, leave the disk-baseline ConnectionMode untouched.
+            var rawMode = Resolve(EnvConnectionMode, flagAlias: null);
+            ConnectionMode? targetMode = null;
+            if (rawMode != null && Enum.TryParse<ConnectionMode>(Sanitize(rawMode), ignoreCase: true, out var explicitMode))
             {
+                targetMode = explicitMode;
+            }
+            else if (sanitizedHost != null && IsLoopbackUrl(sanitizedHost))
+            {
+                targetMode = ConnectionMode.Custom;
+            }
+            if (targetMode.HasValue && targetMode.Value != config.ConnectionMode)
+            {
+                record.Track(FieldConnectionMode, config.ConnectionMode, targetMode.Value);
+                config.ConnectionMode = targetMode.Value;
+                _logger.LogInformation("[MCP] Override: {Key}={Value}", FieldConnectionMode, targetMode.Value);
+            }
+
+            // --- KeepConnected override ---
+            var rawKeep = Resolve(EnvKeepConnected, flagAlias: null);
+            if (rawKeep != null && bool.TryParse(Sanitize(rawKeep), out var keep) && keep != config.KeepConnected)
+            {
+                record.Track(FieldKeepConnected, config.KeepConnected, keep);
+                config.KeepConnected = keep;
+                _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvKeepConnected, keep);
+            }
+
+            // --- AuthOption override (none / required / optional) ---
+            var rawAuth = Resolve(EnvAuthOption, FlagAuth);
+            if (rawAuth != null
+                && Enum.TryParse<AuthOption>(Sanitize(rawAuth), ignoreCase: true, out var ao)
+                && ao != config.AuthOption)
+            {
+                record.Track(FieldAuthOption, config.AuthOption, ao);
                 config.AuthOption = ao;
-                _logger.LogInformation("[MCP] Env override: {Key}={Value}", EnvAuthOption, config.AuthOption);
+                _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvAuthOption, ao);
             }
 
-            // Auth token override
-            var token = args.GetValueOrDefault(EnvToken) ?? Environment.GetEnvironmentVariable(EnvToken);
-            if (!string.IsNullOrWhiteSpace(token))
+            // --- Auth token override ---
+            // Resolved AFTER ConnectionMode so we route to the correct underlying field
+            // (LocalToken in Custom mode, CloudToken in Cloud mode). We track the specific
+            // backing field rather than the abstract Token property because only the backing
+            // fields are serialised — restoring the baseline must target the same field that
+            // was clobbered.
+            var rawToken = Resolve(EnvToken, FlagToken);
+            if (rawToken != null)
             {
-                config.Token = token.Trim().Trim('"');
-                _logger.LogInformation("[MCP] Env override: {Key}=***", EnvToken);
+                var token = Sanitize(rawToken);
+                if (config.ConnectionMode == ConnectionMode.Cloud)
+                {
+                    if (!string.Equals(token, config.CloudToken, StringComparison.Ordinal))
+                    {
+                        record.Track(FieldCloudToken, config.CloudToken, token);
+                        config.CloudToken = token;
+                        _logger.LogInformation("[MCP] Override: {Key}=*** (CloudToken)", EnvToken);
+                    }
+                }
+                else
+                {
+                    if (!string.Equals(token, config.LocalToken, StringComparison.Ordinal))
+                    {
+                        record.Track(FieldLocalToken, config.LocalToken, token);
+                        config.LocalToken = token;
+                        _logger.LogInformation("[MCP] Override: {Key}=*** (LocalToken)", EnvToken);
+                    }
+                }
             }
 
-            // Transport method override (streamableHttp / stdio)
-            var transport = args.GetValueOrDefault(EnvTransport) ?? Environment.GetEnvironmentVariable(EnvTransport);
-            if (!string.IsNullOrWhiteSpace(transport)
-                && Enum.TryParse<TransportMethod>(transport.Trim().Trim('"'), ignoreCase: true, out var tm))
+            // --- Transport method override ---
+            var rawTransport = Resolve(EnvTransport, flagAlias: null);
+            if (rawTransport != null
+                && Enum.TryParse<TransportMethod>(Sanitize(rawTransport), ignoreCase: true, out var tm)
+                && tm != config.TransportMethod)
             {
+                record.Track(FieldTransport, config.TransportMethod, tm);
                 config.TransportMethod = tm;
-                _logger.LogInformation("[MCP] Env override: {Key}={Value}", EnvTransport, config.TransportMethod);
+                _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvTransport, tm);
             }
 
-            // Start server override — controls whether MCP server auto-starts in streamableHttp mode
-            var startServer = args.GetValueOrDefault(EnvStartServer) ?? Environment.GetEnvironmentVariable(EnvStartServer);
-            if (!string.IsNullOrWhiteSpace(startServer)
-                && bool.TryParse(startServer.Trim().Trim('"'), out var ss))
+            // --- Start server override ---
+            var rawStart = Resolve(EnvStartServer, flagAlias: null);
+            if (rawStart != null && bool.TryParse(Sanitize(rawStart), out var ss) && ss != config.KeepServerRunning)
             {
+                record.Track(FieldStartServer, config.KeepServerRunning, ss);
                 config.KeepServerRunning = ss;
-                _logger.LogInformation("[MCP] Env override: {Key}={Value}", EnvStartServer, config.KeepServerRunning);
+                _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvStartServer, ss);
             }
 
-            // Enabled tools override — comma-separated tool IDs
-            var tools = args.GetValueOrDefault(EnvTools) ?? Environment.GetEnvironmentVariable(EnvTools);
-            if (!string.IsNullOrWhiteSpace(tools))
+            // --- Enabled tools override (comma-separated) ---
+            // EnabledToolsOverride is [JsonIgnore] so it is never persisted regardless of the
+            // baseline-restoration logic; we still track it for completeness.
+            var rawTools = Resolve(EnvTools, flagAlias: null);
+            if (rawTools != null)
             {
-                var ids = tools.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                var ids = rawTools.Split(',', StringSplitOptions.RemoveEmptyEntries);
                 var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 var trimmed = new List<string>(ids.Length);
                 foreach (var id in ids)
                 {
-                    var value = id.Trim().Trim('"');
+                    var value = Sanitize(id);
                     if (!string.IsNullOrWhiteSpace(value) && seen.Add(value))
                         trimmed.Add(value);
                 }
+                record.Track(FieldTools, config.EnabledToolsOverride, trimmed);
                 config.EnabledToolsOverride = trimmed;
-                _logger.LogInformation("[MCP] Env override: {Key}={Value}", EnvTools, tools.Trim());
+                _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvTools, rawTools.Trim());
             }
+
+            return record;
+        }
+
+        /// <summary>
+        /// Applies the BaselineValues from <paramref name="record"/> to <paramref name="config"/>
+        /// (i.e. reverses runtime overrides so the in-memory config reflects what is on disk).
+        /// Used by the editor's Save() flow to ensure runtime-only overrides are not persisted.
+        /// </summary>
+        public static void ApplyBaseline(UnityMcpPlugin.UnityConnectionConfig config, OverrideRecord record)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            ApplyValues(config, record.BaselineValues);
+        }
+
+        /// <summary>
+        /// Re-applies the OverrideValues from <paramref name="record"/> to <paramref name="config"/>
+        /// (i.e. restores runtime overrides after a temporary baseline-restore).
+        /// </summary>
+        public static void ApplyOverrides(UnityMcpPlugin.UnityConnectionConfig config, OverrideRecord record)
+        {
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (record == null) throw new ArgumentNullException(nameof(record));
+            ApplyValues(config, record.OverrideValues);
+        }
+
+        static void ApplyValues(UnityMcpPlugin.UnityConnectionConfig config, IReadOnlyDictionary<string, object?> values)
+        {
+            foreach (var kvp in values)
+            {
+                switch (kvp.Key)
+                {
+                    case FieldHost:
+                        config.LocalHost = (string?)kvp.Value ?? string.Empty;
+                        break;
+                    case FieldKeepConnected:
+                        if (kvp.Value is bool kc) config.KeepConnected = kc;
+                        break;
+                    case FieldAuthOption:
+                        if (kvp.Value is AuthOption ao) config.AuthOption = ao;
+                        break;
+                    case FieldLocalToken:
+                        config.LocalToken = (string?)kvp.Value;
+                        break;
+                    case FieldCloudToken:
+                        config.CloudToken = (string?)kvp.Value;
+                        break;
+                    case FieldTools:
+                        config.EnabledToolsOverride = (List<string>?)kvp.Value;
+                        break;
+                    case FieldStartServer:
+                        if (kvp.Value is bool ss) config.KeepServerRunning = ss;
+                        break;
+                    case FieldTransport:
+                        if (kvp.Value is TransportMethod tm) config.TransportMethod = tm;
+                        break;
+                    case FieldConnectionMode:
+                        if (kvp.Value is ConnectionMode cm) config.ConnectionMode = cm;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the given URL targets a loopback host
+        /// (<c>localhost</c>, <c>127.0.0.0/8</c>, or IPv6 <c>::1</c>).
+        /// Used to infer <see cref="ConnectionMode.Custom"/> when a worktree-style local URL is supplied.
+        /// </summary>
+        public static bool IsLoopbackUrl(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return false;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                return false;
+            var host = uri.Host;
+            if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (System.Net.IPAddress.TryParse(host, out var ip))
+                return System.Net.IPAddress.IsLoopback(ip);
+            return false;
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
@@ -61,14 +61,14 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
         // Field-name keys used by OverrideRecord to track which fields were overridden
         // by env/flags so the Save flow can restore disk-baseline values before writing.
         public const string FieldHost = nameof(UnityMcpPlugin.UnityConnectionConfig.LocalHost);
-        public const string FieldKeepConnected = "KeepConnected";
-        public const string FieldAuthOption = "AuthOption";
+        public const string FieldKeepConnected = nameof(UnityMcpPlugin.UnityConnectionConfig.KeepConnected);
+        public const string FieldAuthOption = nameof(UnityMcpPlugin.UnityConnectionConfig.AuthOption);
         public const string FieldLocalToken = nameof(UnityMcpPlugin.UnityConnectionConfig.LocalToken);
         public const string FieldCloudToken = nameof(UnityMcpPlugin.UnityConnectionConfig.CloudToken);
-        public const string FieldTools = "EnabledToolsOverride";
-        public const string FieldStartServer = "KeepServerRunning";
-        public const string FieldTransport = "TransportMethod";
-        public const string FieldConnectionMode = "ConnectionMode";
+        public const string FieldTools = nameof(UnityMcpPlugin.UnityConnectionConfig.EnabledToolsOverride);
+        public const string FieldStartServer = nameof(UnityMcpPlugin.UnityConnectionConfig.KeepServerRunning);
+        public const string FieldTransport = nameof(UnityMcpPlugin.UnityConnectionConfig.TransportMethod);
+        public const string FieldConnectionMode = nameof(UnityMcpPlugin.UnityConnectionConfig.ConnectionMode);
 
         /// <summary>
         /// Captures, per overridden field, the disk-baseline value (what was read from JSON)
@@ -78,16 +78,19 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
         /// </summary>
         public sealed class OverrideRecord
         {
-            public Dictionary<string, object?> BaselineValues { get; } = new();
-            public Dictionary<string, object?> OverrideValues { get; } = new();
+            readonly Dictionary<string, object?> _baselineValues = new();
+            readonly Dictionary<string, object?> _overrideValues = new();
 
-            public bool HasAny => BaselineValues.Count > 0;
-            public bool Contains(string fieldName) => BaselineValues.ContainsKey(fieldName);
+            public IReadOnlyDictionary<string, object?> BaselineValues => _baselineValues;
+            public IReadOnlyDictionary<string, object?> OverrideValues => _overrideValues;
+
+            public bool HasAny => _baselineValues.Count > 0;
+            public bool Contains(string fieldName) => _baselineValues.ContainsKey(fieldName);
 
             internal void Track(string fieldName, object? baselineValue, object? overrideValue)
             {
-                BaselineValues[fieldName] = baselineValue;
-                OverrideValues[fieldName] = overrideValue;
+                _baselineValues[fieldName] = baselineValue;
+                _overrideValues[fieldName] = overrideValue;
             }
         }
 
@@ -139,20 +142,17 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
             // Returns null if no source provided a non-empty value.
             string? Resolve(string envKey, string? flagAlias)
             {
-                // 1. Short flag alias (e.g. "url", "token", "auth")
                 if (!string.IsNullOrEmpty(flagAlias)
                     && argReader.TryGetValue(flagAlias, out var flagValue)
                     && !string.IsNullOrWhiteSpace(flagValue))
                 {
                     return flagValue;
                 }
-                // 2. UNITY_MCP_* style flag
                 if (argReader.TryGetValue(envKey, out var envFlagValue)
                     && !string.IsNullOrWhiteSpace(envFlagValue))
                 {
                     return envFlagValue;
                 }
-                // 3. Process env var
                 var envValue = envReader(envKey);
                 if (!string.IsNullOrWhiteSpace(envValue))
                     return envValue;
@@ -161,11 +161,7 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
 
             string Sanitize(string raw) => raw.Trim().Trim('"');
 
-            // --- Host URL override (UNITY_MCP_HOST or UNITY_MCP_CLOUD_URL or --url) ---
-            // UNITY_MCP_CLOUD_URL is the canonical key in the layered loader contract.
-            // UNITY_MCP_HOST is preserved for backward compatibility.
-            // --url is a short alias.
-            // All values are defensively trimmed of trailing slashes.
+            // UNITY_MCP_HOST is the legacy alias for UNITY_MCP_CLOUD_URL.
             string? sanitizedHost = null;
             var rawHost = Resolve(EnvCloudUrl, FlagUrl) ?? Resolve(EnvHost, flagAlias: null);
             if (rawHost != null)
@@ -183,10 +179,8 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 }
             }
 
-            // --- Connection mode override (UNITY_MCP_CONNECTION_MODE) ---
-            // Explicit env / flag wins; otherwise, if a host URL was provided and points to
-            // a loopback address, infer Custom mode (worktree / local-dev scenarios). If the
-            // URL points to a remote host, leave the disk-baseline ConnectionMode untouched.
+            // Loopback URLs without an explicit mode infer Custom (worktree / local-dev).
+            // Remote URLs without an explicit mode leave the disk-baseline ConnectionMode untouched.
             var rawMode = Resolve(EnvConnectionMode, flagAlias: null);
             ConnectionMode? targetMode = null;
             if (rawMode != null && Enum.TryParse<ConnectionMode>(Sanitize(rawMode), ignoreCase: true, out var explicitMode))
@@ -204,7 +198,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 _logger.LogInformation("[MCP] Override: {Key}={Value}", FieldConnectionMode, targetMode.Value);
             }
 
-            // --- KeepConnected override ---
             var rawKeep = Resolve(EnvKeepConnected, flagAlias: null);
             if (rawKeep != null && bool.TryParse(Sanitize(rawKeep), out var keep) && keep != config.KeepConnected)
             {
@@ -213,7 +206,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvKeepConnected, keep);
             }
 
-            // --- AuthOption override (none / required / optional) ---
             var rawAuth = Resolve(EnvAuthOption, FlagAuth);
             if (rawAuth != null
                 && Enum.TryParse<AuthOption>(Sanitize(rawAuth), ignoreCase: true, out var ao)
@@ -224,7 +216,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvAuthOption, ao);
             }
 
-            // --- Auth token override ---
             // Resolved AFTER ConnectionMode so we route to the correct underlying field
             // (LocalToken in Custom mode, CloudToken in Cloud mode). We track the specific
             // backing field rather than the abstract Token property because only the backing
@@ -254,7 +245,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 }
             }
 
-            // --- Transport method override ---
             var rawTransport = Resolve(EnvTransport, flagAlias: null);
             if (rawTransport != null
                 && Enum.TryParse<TransportMethod>(Sanitize(rawTransport), ignoreCase: true, out var tm)
@@ -265,7 +255,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvTransport, tm);
             }
 
-            // --- Start server override ---
             var rawStart = Resolve(EnvStartServer, flagAlias: null);
             if (rawStart != null && bool.TryParse(Sanitize(rawStart), out var ss) && ss != config.KeepServerRunning)
             {
@@ -274,7 +263,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvStartServer, ss);
             }
 
-            // --- Enabled tools override (comma-separated) ---
             // EnabledToolsOverride is [JsonIgnore] so it is never persisted regardless of the
             // baseline-restoration logic; we still track it for completeness.
             var rawTools = Resolve(EnvTools, flagAlias: null);
@@ -327,7 +315,7 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 switch (kvp.Key)
                 {
                     case FieldHost:
-                        config.LocalHost = (string?)kvp.Value ?? string.Empty;
+                        config.LocalHost = (string?)kvp.Value ?? UnityMcpPlugin.UnityConnectionConfig.DefaultHost;
                         break;
                     case FieldKeepConnected:
                         if (kvp.Value is bool kc) config.KeepConnected = kc;
@@ -353,6 +341,10 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                     case FieldConnectionMode:
                         if (kvp.Value is ConnectionMode cm) config.ConnectionMode = cm;
                         break;
+                    default:
+                        // Fail loudly if a new Field* constant is added to Track but forgotten here —
+                        // a silent miss would let runtime overrides leak to disk on Save.
+                        throw new InvalidOperationException($"Unhandled override field: {kvp.Key}");
                 }
             }
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
@@ -1,0 +1,320 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using NUnit.Framework;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Covers the layered config-loader contract:
+    ///   flags > env vars > on-disk config > defaults
+    /// implemented by <see cref="EnvironmentUtils.ApplyEnvironmentOverrides"/>.
+    /// </summary>
+    public class EnvironmentUtilsTests
+    {
+        const string DiskHost = "http://localhost:24029";
+        const string DiskLocalToken = "DISK_LOCAL_TOKEN";
+        const string DiskCloudToken = "DISK_CLOUD_TOKEN";
+
+        static UnityMcpPlugin.UnityConnectionConfig BuildDiskConfig(ConnectionMode mode = ConnectionMode.Cloud)
+        {
+            // Simulates a config that came back from disk: explicit values for both
+            // local and cloud tokens, default mode = Cloud (matching the plugin's default).
+            return new UnityMcpPlugin.UnityConnectionConfig
+            {
+                LocalHost = DiskHost,
+                LocalToken = DiskLocalToken,
+                CloudToken = DiskCloudToken,
+                ConnectionMode = mode,
+                AuthOption = AuthOption.required,
+                KeepConnected = true,
+                KeepServerRunning = false,
+                TransportMethod = TransportMethod.streamableHttp
+            };
+        }
+
+        static IReadOnlyDictionary<string, string> NoArgs()
+            => new Dictionary<string, string>();
+        static Func<string, string?> NoEnv()
+            => _ => null;
+        static Func<string, string?> Env(params (string k, string v)[] pairs)
+        {
+            var dict = new Dictionary<string, string?>(StringComparer.Ordinal);
+            foreach (var (k, v) in pairs) dict[k] = v;
+            return key => dict.TryGetValue(key, out var val) ? val : null;
+        }
+        static IReadOnlyDictionary<string, string> Args(params (string k, string v)[] pairs)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var (k, v) in pairs) dict[k] = v;
+            return dict;
+        }
+
+        // --- Disk-only path: env / args absent ---
+
+        [Test]
+        public void Override_DiskOnly_NoEnvNoArgs_LeavesConfigUnchanged()
+        {
+            var config = BuildDiskConfig();
+            var record = EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), NoEnv());
+
+            Assert.IsFalse(record.HasAny, "Expected no overrides when env and args are empty.");
+            Assert.AreEqual(DiskHost, config.LocalHost);
+            Assert.AreEqual(DiskCloudToken, config.CloudToken);
+            Assert.AreEqual(DiskLocalToken, config.LocalToken);
+            Assert.AreEqual(ConnectionMode.Cloud, config.ConnectionMode);
+            Assert.AreEqual(AuthOption.required, config.AuthOption);
+        }
+
+        // --- Env var override ---
+
+        [Test]
+        public void Override_EnvToken_WritesToCloudTokenWhenModeIsCloud()
+        {
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var env = Env((EnvironmentUtils.EnvToken, "ENV_TOKEN"));
+
+            var record = EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.IsTrue(record.HasAny);
+            Assert.IsTrue(record.Contains(EnvironmentUtils.FieldCloudToken),
+                "Expected the CloudToken backing field to be tracked when mode is Cloud.");
+            Assert.AreEqual("ENV_TOKEN", config.CloudToken);
+            Assert.AreEqual(DiskLocalToken, config.LocalToken,
+                "LocalToken must remain at the disk baseline when mode is Cloud.");
+        }
+
+        [Test]
+        public void Override_EnvToken_WritesToLocalTokenWhenModeIsCustom()
+        {
+            var config = BuildDiskConfig(mode: ConnectionMode.Custom);
+            var env = Env((EnvironmentUtils.EnvToken, "ENV_TOKEN"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual("ENV_TOKEN", config.LocalToken);
+            Assert.AreEqual(DiskCloudToken, config.CloudToken);
+        }
+
+        // --- Flag override (highest priority, beats env) ---
+
+        [Test]
+        public void Override_FlagToken_BeatsEnvToken()
+        {
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var args = Args((EnvironmentUtils.FlagToken, "FLAG_TOKEN"));
+            var env = Env((EnvironmentUtils.EnvToken, "ENV_TOKEN"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, args, env);
+
+            Assert.AreEqual("FLAG_TOKEN", config.CloudToken,
+                "When both --token and UNITY_MCP_TOKEN are set, the flag must win.");
+        }
+
+        [Test]
+        public void Override_UnityMcpStyleFlag_BeatsEnvVar()
+        {
+            // CLI translates --token foo into UNITY_MCP_TOKEN env, but the plugin still
+            // accepts --UNITY_MCP_TOKEN=foo style flags directly. They must beat env vars.
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var args = Args((EnvironmentUtils.EnvToken, "FLAG_VIA_FULL_NAME"));
+            var env = Env((EnvironmentUtils.EnvToken, "ENV_TOKEN"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, args, env);
+
+            Assert.AreEqual("FLAG_VIA_FULL_NAME", config.CloudToken);
+        }
+
+        // --- Per-field layering ---
+
+        [Test]
+        public void Override_PerField_TokenFromEnv_HostFromDisk()
+        {
+            var config = BuildDiskConfig();
+            var env = Env((EnvironmentUtils.EnvToken, "ENV_TOKEN"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual(DiskHost, config.LocalHost,
+                "Host must remain at the disk baseline when only the token was overridden.");
+            Assert.AreEqual("ENV_TOKEN", config.CloudToken);
+        }
+
+        // --- Trailing-slash robustness ---
+
+        [Test]
+        public void Override_TrailingSlashOnHostUrl_IsStripped()
+        {
+            var config = BuildDiskConfig();
+            var env = Env((EnvironmentUtils.EnvCloudUrl, "http://localhost:5220/"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual("http://localhost:5220", config.LocalHost,
+                "Trailing slash must be stripped defensively.");
+        }
+
+        [TestCase("http://localhost:5220/", true)]
+        [TestCase("http://127.0.0.1:5220", true)]
+        [TestCase("http://[::1]:5220/", true)]
+        [TestCase("https://ai-game.dev", false)]
+        [TestCase("not-a-url", false)]
+        [TestCase("", false)]
+        public void IsLoopbackUrl_RecognisesLoopbackHosts(string url, bool expected)
+        {
+            Assert.AreEqual(expected, EnvironmentUtils.IsLoopbackUrl(url),
+                $"IsLoopbackUrl mismatch for '{url}'.");
+        }
+
+        [Test]
+        public void Override_LoopbackHostUrl_InfersCustomMode()
+        {
+            // Worktree scenario: disk says Cloud, env supplies a localhost URL.
+            // Expected: ConnectionMode is inferred to Custom so the worktree's local
+            // dev token routes to LocalToken (not CloudToken) and the SignalR client
+            // talks to <host>/hub/mcp-server (not <host>/mcp/hub/mcp-server).
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var env = Env(
+                (EnvironmentUtils.EnvCloudUrl, "http://localhost:5220/"),
+                (EnvironmentUtils.EnvToken, "WORKTREE_TOKEN"));
+
+            var record = EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual(ConnectionMode.Custom, config.ConnectionMode,
+                "Loopback host URL should infer Custom mode.");
+            Assert.AreEqual("http://localhost:5220", config.LocalHost);
+            Assert.AreEqual("WORKTREE_TOKEN", config.LocalToken,
+                "Token override must route to LocalToken once mode is inferred Custom.");
+            Assert.AreEqual(DiskCloudToken, config.CloudToken,
+                "CloudToken on disk must NOT be clobbered by the env override.");
+            Assert.IsTrue(record.Contains(EnvironmentUtils.FieldConnectionMode));
+            Assert.IsTrue(record.Contains(EnvironmentUtils.FieldHost));
+            Assert.IsTrue(record.Contains(EnvironmentUtils.FieldLocalToken));
+        }
+
+        [Test]
+        public void Override_RemoteHostUrl_DoesNotInferCustomMode()
+        {
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var env = Env((EnvironmentUtils.EnvCloudUrl, "https://ai-game.dev"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual(ConnectionMode.Cloud, config.ConnectionMode,
+                "Non-loopback URL must NOT auto-flip the mode.");
+        }
+
+        [Test]
+        public void Override_ExplicitConnectionMode_BeatsLoopbackInference()
+        {
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var env = Env(
+                (EnvironmentUtils.EnvCloudUrl, "http://localhost:5220"),
+                (EnvironmentUtils.EnvConnectionMode, "Cloud"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual(ConnectionMode.Cloud, config.ConnectionMode,
+                "Explicit UNITY_MCP_CONNECTION_MODE must beat loopback inference.");
+        }
+
+        // --- Persistence: overrides MUST NOT be written to disk ---
+
+        [Test]
+        public void Persistence_BaselineRoundTripsToDiskWithoutOverrides()
+        {
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var env = Env(
+                (EnvironmentUtils.EnvCloudUrl, "http://localhost:5220"),
+                (EnvironmentUtils.EnvToken, "ENV_TOKEN"));
+
+            var record = EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+            // sanity
+            Assert.AreEqual(ConnectionMode.Custom, config.ConnectionMode);
+            Assert.AreEqual("http://localhost:5220", config.LocalHost);
+            Assert.AreEqual("ENV_TOKEN", config.LocalToken);
+
+            // Simulate Save: restore baseline → serialize → restore overrides.
+            EnvironmentUtils.ApplyBaseline(config, record);
+
+            Assert.AreEqual(DiskHost, config.LocalHost, "Baseline restore failed for LocalHost.");
+            Assert.AreEqual(DiskLocalToken, config.LocalToken, "Baseline restore failed for LocalToken.");
+            Assert.AreEqual(ConnectionMode.Cloud, config.ConnectionMode, "Baseline restore failed for ConnectionMode.");
+
+            var json = SerializeForDisk(config);
+            // The serialized JSON must NOT contain the runtime override values.
+            StringAssert.DoesNotContain("http://localhost:5220", json);
+            StringAssert.DoesNotContain("ENV_TOKEN", json);
+            StringAssert.Contains(DiskHost, json);
+            StringAssert.Contains(DiskLocalToken, json);
+
+            // After serialization, re-apply overrides.
+            EnvironmentUtils.ApplyOverrides(config, record);
+            Assert.AreEqual(ConnectionMode.Custom, config.ConnectionMode);
+            Assert.AreEqual("http://localhost:5220", config.LocalHost);
+            Assert.AreEqual("ENV_TOKEN", config.LocalToken);
+        }
+
+        [Test]
+        public void Persistence_EmptyRecord_NoOpOnApplyBaselineAndOverrides()
+        {
+            var config = BuildDiskConfig();
+            var record = new EnvironmentUtils.OverrideRecord();
+            EnvironmentUtils.ApplyBaseline(config, record);
+            EnvironmentUtils.ApplyOverrides(config, record);
+            // No exceptions, values unchanged.
+            Assert.AreEqual(DiskHost, config.LocalHost);
+        }
+
+        // --- Validation: bad inputs are tolerated ---
+
+        [Test]
+        public void Override_InvalidEnumValue_IsIgnored()
+        {
+            var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
+            var env = Env((EnvironmentUtils.EnvConnectionMode, "Bogus"));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual(ConnectionMode.Cloud, config.ConnectionMode,
+                "Unparseable enum values must be silently ignored.");
+        }
+
+        [Test]
+        public void Override_QuotedValue_IsTrimmed()
+        {
+            var config = BuildDiskConfig();
+            var env = Env((EnvironmentUtils.EnvToken, "\"QUOTED_TOKEN\""));
+
+            EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
+
+            Assert.AreEqual("QUOTED_TOKEN", config.CloudToken);
+        }
+
+        // --- Helpers ---
+
+        static string SerializeForDisk(UnityMcpPlugin.UnityConnectionConfig config)
+        {
+            return JsonSerializer.Serialize(config, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                Converters = { new JsonStringEnumConverter() }
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca51d64e0d3d465989a9ed1f24ca938b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

The plugin's startup config loader treated `UserSettings/AI-Game-Developer-Config.json` as authoritative even when overrides were supplied via `UNITY_MCP_*` environment variables or short flags (`--url`, `--token`, `--auth`). This commit implements the standard layered priority:

```
flags > env vars > on-disk config > built-in defaults
```

## The user-reported failure mode

In a worktree with `.worktree.env` providing a fresh `UNITY_MCP_TOKEN` / `UNITY_MCP_CLOUD_URL` (pointing at a localhost MCP server in that worktree), the editor was opened by `unity-mcp-cli open --url <U> --token <T>`. The plugin still booted with `connectionMode: Cloud` from a stale on-disk config and tried to authenticate against the cloud server with the worktree's local-dev token — surfacing a "Cloud mode requires authentication" dialog. The downstream `unity-mcp` pipeline (in [`ai-game-developer-infra/.claude/pipeline/workflows/implement-task/targets/unity-mcp/setup.md`](https://github.com/IvanMurzak/ai-game-developer-infra)) was forced to write the JSON config directly before opening the editor as a brittle workaround.

## What changed

### Layered loader

* `EnvironmentUtils.ApplyEnvironmentOverrides` now takes optional `argReader` / `envReader` parameters (testable) and returns an `OverrideRecord` that captures the disk-baseline value for every overridden field.
* `UnityMcpPluginEditor` stashes the `OverrideRecord` so `Save()` can restore baseline values before serialising and re-apply runtime overrides afterwards. This guarantees runtime-only overrides NEVER leak into the persisted JSON.

### Env-var contract

| Variable | Semantics |
|---|---|
| `UNITY_MCP_CLOUD_URL` | Canonical host URL override. Trailing `/` stripped defensively. |
| `UNITY_MCP_HOST` | Backward-compatible alias for the host URL. |
| `UNITY_MCP_TOKEN` | Bearer token. Routes to `LocalToken` or `CloudToken` based on the post-mode-override `ConnectionMode`. |
| `UNITY_MCP_CONNECTION_MODE` | Explicit `Cloud` / `Custom` override. If absent and the URL is a loopback host (`localhost` / `127.0.0.0/8` / `::1`), `Custom` is inferred. |
| `UNITY_MCP_AUTH_OPTION` | `none` / `required`. |
| `UNITY_MCP_KEEP_CONNECTED`, `UNITY_MCP_TRANSPORT`, `UNITY_MCP_START_SERVER`, `UNITY_MCP_TOOLS` | Pre-existing env vars, now also tracked in `OverrideRecord` so Save doesn't persist them. |

### Flag contract

The plugin parses `Environment.GetCommandLineArgs()` via the existing `ArgsUtils` and accepts both `--UNITY_MCP_*` style flags and these short aliases (highest precedence):

* `--url <U>`
* `--token <T>`
* `--auth <required|none>`

Flags beat env vars; env vars beat disk; disk beats defaults.

### Loopback inference

When a URL override is supplied without an explicit `UNITY_MCP_CONNECTION_MODE`, the plugin infers `Custom` mode if the URL targets a loopback host. This fixes the worktree scenario: `UNITY_MCP_CLOUD_URL=http://localhost:5220/` + `UNITY_MCP_TOKEN=foo` now resolves to `LocalHost=http://localhost:5220`, `ConnectionMode=Custom`, `LocalToken=foo`, with no leakage into the on-disk `cloudToken` field.

### Persistence

Save round-trips disk values to disk regardless of overrides. The in-memory config keeps its active overrides, so callers (UI, configurators, SignalR client) see no behaviour change.

## Test plan

20 new EditMode test cases in `Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs`:

- [x] Disk-only: env vars and args absent → values come from disk
- [x] Env-var override of token in Cloud mode → writes to `CloudToken`
- [x] Env-var override of token in Custom mode → writes to `LocalToken`
- [x] Flag override (`--token bar`) beats env var (`UNITY_MCP_TOKEN=foo`)
- [x] `--UNITY_MCP_TOKEN=foo` style flag beats env var
- [x] Per-field layering: env sets only token, host comes from disk
- [x] Trailing-slash robustness: `UNITY_MCP_CLOUD_URL=http://localhost:5220/` → `host=http://localhost:5220`
- [x] `IsLoopbackUrl` recognises `localhost`, `127.0.0.0/8`, `::1`; rejects remote hosts and malformed URLs
- [x] Loopback URL infers `Custom` mode and routes token to `LocalToken`
- [x] Remote URL does NOT auto-flip the mode
- [x] Explicit `UNITY_MCP_CONNECTION_MODE=Cloud` beats loopback inference
- [x] Persistence: baseline values round-trip to disk, override values do not appear in serialised JSON, in-memory state has overrides reapplied
- [x] Empty `OverrideRecord` is a no-op for `ApplyBaseline` / `ApplyOverrides`
- [x] Invalid enum values (e.g. `UNITY_MCP_CONNECTION_MODE=Bogus`) are silently ignored
- [x] Quoted env values (`"VAL"`) are trimmed

All 810 existing EditMode tests still pass:

```
$ Unity.exe ... -runTests -testPlatform EditMode
testcasecount="810" result="Passed" total="810" passed="810" failed="0"
```

## Notes

* No version bumps; release coordination is out of scope.
* Independent of #687 (the test-coverage PR) — different files, different concern.
* This unblocks the consumer pipeline at [`.claude/pipeline/workflows/implement-task/targets/unity-mcp/setup.md`](https://github.com/IvanMurzak/ai-game-developer-infra) — it can drop the JSON-pinning workaround once this lands.