### PR TITLE
feat(cli): add close subcommand for Unity Editor

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -307,6 +307,8 @@ unity-mcp-cli close ./MyGame
 5. Idempotent — closing an already-closed Editor (or a project whose Editor was never running) exits 0 with `no running Editor for project at <path>`.
 6. Refuses to act on any path that is not a Unity project root (`ProjectSettings/ProjectVersion.txt` must exist) — protects against accidental kill-all-Unity-on-host invocations.
 
+> **Windows headless caveat:** the polite-quit step uses `taskkill` (no `/F`), which delivers `WM_CLOSE`. That message only reaches processes owning a top-level window on the **same desktop/session** as the CLI. If Unity was launched by a Windows service in session 0 (or any other non-interactive desktop), the polite-quit will be silently dropped, the `--timeout` will elapse, and `--force` becomes the only path that brings the Editor down. Plan accordingly in headless CI runners.
+
 **Example — close, fall back to force after 60s:**
 
 ```bash

--- a/cli/README.md
+++ b/cli/README.md
@@ -96,6 +96,7 @@ npx unity-mcp-cli install-plugin /path/to/unity/project
   - [`install-plugin`](#install-plugin)
   - [`install-unity`](#install-unity)
   - [`open`](#open)
+  - [`close`](#close)
   - [`run-tool`](#run-tool)
   - [`wait-for-ready`](#wait-for-ready)
   - [`setup-mcp`](#setup-mcp)
@@ -279,6 +280,46 @@ unity-mcp-cli open ./MyGame \
   --token my-secret-token \
   --auth required \
   --tools gameobject-create,gameobject-find
+```
+
+![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
+
+## `close`
+
+Gracefully terminate the Unity Editor instance running for a given project path. Symmetric counterpart of [`open`](#open) — for scripted workflows (CI agents, pipeline executors, integration test fixtures) that need a clean tear-down without resorting to OS-level process kills.
+
+```bash
+unity-mcp-cli close ./MyGame
+```
+
+| Option | Required | Description |
+|---|---|---|
+| `[path]` | No | Path to the Unity project (positional, defaults to current directory) |
+| `--timeout <seconds>` | No | Polite-quit timeout in seconds (default: 30) |
+| `--force` | No | Hard-kill the Editor if it does not exit within `--timeout` |
+
+**How it works:**
+
+1. Resolves the running Editor's PID by reading `<project>/Temp/UnityLockfile` (4-byte little-endian uint32) and cross-checking against process enumeration to handle stale lock files.
+2. Sends a polite-quit signal — `SIGTERM` on Linux/macOS, `taskkill` (no `/F`) on Windows — letting Unity finish autosave / asset-import.
+3. Polls every 250ms until the process exits or `--timeout` elapses.
+4. If the timeout expires AND `--force` is set, falls back to `SIGKILL` / `taskkill /F`.
+5. Idempotent — closing an already-closed Editor (or a project whose Editor was never running) exits 0 with `no running Editor for project at <path>`.
+6. Refuses to act on any path that is not a Unity project root (`ProjectSettings/ProjectVersion.txt` must exist) — protects against accidental kill-all-Unity-on-host invocations.
+
+**Example — close, fall back to force after 60s:**
+
+```bash
+unity-mcp-cli close ./MyGame --timeout 60 --force
+```
+
+**Example — clean tear-down at the end of an automation script:**
+
+```bash
+unity-mcp-cli open ./MyGame
+unity-mcp-cli wait-for-ready ./MyGame
+unity-mcp-cli run-tool tests-run ./MyGame --input '{"testMode":"EditMode"}'
+unity-mcp-cli close ./MyGame
 ```
 
 ![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)

--- a/cli/src/commands/close.ts
+++ b/cli/src/commands/close.ts
@@ -80,11 +80,10 @@ export function parseTimeoutSeconds(raw: string | undefined): number | null {
 /**
  * Resolve the editor PID for a given project path.
  *
- * Strategy (cheapest first):
- *  1. Read `<project>/Temp/UnityLockfile` (4 bytes LE uint32).
- *  2. Verify the PID is alive AND its command line includes `-projectPath <path>`
- *     pointing at the same project — handles stale lockfiles.
- *  3. Fall back to enumerating Unity processes by command line.
+ * Reads `<project>/Temp/UnityLockfile` (4 bytes LE uint32) and enumerates
+ * Unity processes by command line, then prefers the lockfile PID when it
+ * is alive and matches the enumerated process for this project (handles
+ * stale lockfiles); otherwise uses the enumerated PID.
  *
  * Returns `null` when no live editor matches the project. Exported for tests.
  */

--- a/cli/src/commands/close.ts
+++ b/cli/src/commands/close.ts
@@ -64,6 +64,10 @@ export function isUnityProjectRoot(projectPath: string): boolean {
  * Parse a positive-integer `--timeout` value (seconds). Returns the parsed
  * value, or `null` when the input is not a valid positive integer.
  *
+ * The `undefined` branch falls back to the default for ergonomic
+ * direct-call use (e.g., unit tests). The action handler never reaches it
+ * because commander always materialises the configured default string.
+ *
  * Exported for unit tests.
  */
 export function parseTimeoutSeconds(raw: string | undefined): number | null {
@@ -86,11 +90,12 @@ export function parseTimeoutSeconds(raw: string | undefined): number | null {
  */
 export function resolveEditorPid(projectPath: string, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): number | null {
   const lockPid = readLockfilePid(projectPath);
+  // Enumerate Unity processes once. `findUnityProcess` shells out (3s timeout
+  // on Windows via PowerShell+CIM, 5s on POSIX via `ps`), so calling it twice
+  // on the stale-lockfile path used to roughly double close latency.
+  const proc = findUnityProcess(projectPath);
+
   if (lockPid !== null && isProcessAlive(lockPid, platform)) {
-    // Cross-check: the live PID's project path must match our target. The
-    // unity-process util already does case-insensitive normalisation on
-    // Windows, so reuse it rather than re-implementing comparison here.
-    const proc = findUnityProcess(projectPath);
     if (proc && proc.pid === lockPid) {
       verbose(`Lockfile PID ${lockPid} confirmed via process enumeration`);
       return lockPid;
@@ -98,7 +103,6 @@ export function resolveEditorPid(projectPath: string, platform: SupportedPlatfor
     verbose(`Lockfile PID ${lockPid} did not match enumerated Unity process for project — treating as stale`);
   }
 
-  const proc = findUnityProcess(projectPath);
   return proc ? proc.pid : null;
 }
 
@@ -117,7 +121,7 @@ export const closeCommand = new Command('close')
     }
 
     if (!isUnityProjectRoot(projectPath)) {
-      ui.error(`not a Unity project root: ${projectPath}`);
+      ui.error(`Not a Unity project root: ${projectPath}`);
       process.exit(1);
     }
 
@@ -142,6 +146,13 @@ export const closeCommand = new Command('close')
     ui.label('Force', options.force ? 'yes' : 'no');
     ui.divider();
 
+    // TOCTOU window: between resolveEditorPid returning and the signal call
+    // below, the original Unity process could exit and the OS could reuse
+    // the same numeric PID for an unrelated process (more likely on POSIX,
+    // where PIDs cycle aggressively). We accept the residual risk — the
+    // lockfile cross-check above already narrows it, holding a lock across
+    // a spawned Editor's lifetime is impractical, and the signals we send
+    // (SIGTERM / WM_CLOSE) are politest-effort, not destructive.
     const spinner = ui.startSpinner(`Sending polite-quit to PID ${pid}...`);
     const sent = sendGracefulShutdown(pid, platform);
     if (!sent) {

--- a/cli/src/commands/close.ts
+++ b/cli/src/commands/close.ts
@@ -85,6 +85,12 @@ export function parseTimeoutSeconds(raw: string | undefined): number | null {
  * is alive and matches the enumerated process for this project (handles
  * stale lockfiles); otherwise uses the enumerated PID.
  *
+ * Symlink/realpath handling: `resolveCloseProjectPath` canonicalises via
+ * `realpathSync` while `findUnityProcess` only `path.resolve`s the cmdline
+ * `-projectPath` argument. If Unity was launched via a symlink, the first
+ * lookup misses. We retry against the un-canonicalised form so a symlinked
+ * launch path doesn't silently degrade close to a no-op.
+ *
  * Returns `null` when no live editor matches the project. Exported for tests.
  */
 export function resolveEditorPid(projectPath: string, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): number | null {
@@ -92,11 +98,29 @@ export function resolveEditorPid(projectPath: string, platform: SupportedPlatfor
   // Enumerate Unity processes once. `findUnityProcess` shells out (3s timeout
   // on Windows via PowerShell+CIM, 5s on POSIX via `ps`), so calling it twice
   // on the stale-lockfile path used to roughly double close latency.
-  const proc = findUnityProcess(projectPath);
+  let proc = findUnityProcess(projectPath);
+
+  // Symlink fallback: if the canonical realpath form found no process, retry
+  // with `path.resolve` only (no realpath collapse) — that matches what
+  // `findUnityProcess` derives from the cmdline `-projectPath` argument.
+  if (!proc) {
+    const resolvedNoRealpath = path.resolve(projectPath);
+    if (resolvedNoRealpath !== projectPath) {
+      proc = findUnityProcess(resolvedNoRealpath);
+    }
+  }
 
   if (lockPid !== null && isProcessAlive(lockPid, platform)) {
     if (proc && proc.pid === lockPid) {
       verbose(`Lockfile PID ${lockPid} confirmed via process enumeration`);
+      return lockPid;
+    }
+    // Lockfile alive but no matching enumerated process — the lockfile may
+    // still be authoritative if the asymmetry is purely realpath/symlink
+    // related (process listed under symlink path while we queried by realpath).
+    // Trust the live lockfile PID in that case rather than discarding it.
+    if (!proc) {
+      verbose(`Lockfile PID ${lockPid} alive but no enumerated match — using lockfile PID (likely symlink/path mismatch)`);
       return lockPid;
     }
     verbose(`Lockfile PID ${lockPid} did not match enumerated Unity process for project — treating as stale`);
@@ -151,7 +175,7 @@ export const closeCommand = new Command('close')
     // where PIDs cycle aggressively). We accept the residual risk — the
     // lockfile cross-check above already narrows it, holding a lock across
     // a spawned Editor's lifetime is impractical, and the signals we send
-    // (SIGTERM / WM_CLOSE) are politest-effort, not destructive.
+    // (SIGTERM / WM_CLOSE) are best-effort, not destructive.
     const spinner = ui.startSpinner(`Sending polite-quit to PID ${pid}...`);
     const sent = sendGracefulShutdown(pid, platform);
     if (!sent) {

--- a/cli/src/commands/close.ts
+++ b/cli/src/commands/close.ts
@@ -1,0 +1,186 @@
+import { Command } from 'commander';
+import * as fs from 'fs';
+import * as path from 'path';
+import { platform as nodePlatform } from 'os';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { findUnityProcess } from '../utils/unity-process.js';
+import {
+  readLockfilePid,
+  isProcessAlive,
+  sendGracefulShutdown,
+  sendForceKill,
+  waitForExit,
+  type SupportedPlatform,
+} from '../utils/unity-shutdown.js';
+
+export interface CloseOptions {
+  timeout?: string;
+  force?: boolean;
+}
+
+const DEFAULT_TIMEOUT_SECONDS = 30;
+
+/**
+ * Resolve the project path argument to an absolute, canonical path.
+ *
+ * Mirrors the convention used by `open` / `wait-for-ready` — accepts a
+ * positional argument or `process.cwd()` fallback, normalises symlinks where
+ * possible, and trims any trailing path separator. Exported for unit tests.
+ */
+export function resolveCloseProjectPath(positionalPath: string | undefined, cwd: string): string {
+  const explicit = positionalPath ?? cwd;
+  let resolved = path.resolve(explicit);
+
+  // realpathSync collapses symlinks, ".." segments, and trailing separators
+  // when the path exists. When it does not, fall through to the resolved
+  // form so the caller can produce a "path does not exist" error.
+  try {
+    resolved = fs.realpathSync(resolved);
+  } catch {
+    // Path may not exist — let the caller decide what to do.
+  }
+
+  return resolved;
+}
+
+/**
+ * Returns true when `<projectPath>/ProjectSettings/ProjectVersion.txt` exists.
+ *
+ * The issue's acceptance criteria require refusing to act on any path that
+ * does not look like a Unity project root (`ProjectVersion.txt` is the
+ * canonical marker). This is intentionally narrower than the `open`
+ * subcommand's check — the goal here is to defend against accidental
+ * "kill all Unity processes on host" invocations, so a positive ID of
+ * "this is a Unity project" is required.
+ *
+ * Exported for unit tests.
+ */
+export function isUnityProjectRoot(projectPath: string): boolean {
+  return fs.existsSync(path.join(projectPath, 'ProjectSettings', 'ProjectVersion.txt'));
+}
+
+/**
+ * Parse a positive-integer `--timeout` value (seconds). Returns the parsed
+ * value, or `null` when the input is not a valid positive integer.
+ *
+ * Exported for unit tests.
+ */
+export function parseTimeoutSeconds(raw: string | undefined): number | null {
+  if (raw === undefined) return DEFAULT_TIMEOUT_SECONDS;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+/**
+ * Resolve the editor PID for a given project path.
+ *
+ * Strategy (cheapest first):
+ *  1. Read `<project>/Temp/UnityLockfile` (4 bytes LE uint32).
+ *  2. Verify the PID is alive AND its command line includes `-projectPath <path>`
+ *     pointing at the same project — handles stale lockfiles.
+ *  3. Fall back to enumerating Unity processes by command line.
+ *
+ * Returns `null` when no live editor matches the project. Exported for tests.
+ */
+export function resolveEditorPid(projectPath: string, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): number | null {
+  const lockPid = readLockfilePid(projectPath);
+  if (lockPid !== null && isProcessAlive(lockPid, platform)) {
+    // Cross-check: the live PID's project path must match our target. The
+    // unity-process util already does case-insensitive normalisation on
+    // Windows, so reuse it rather than re-implementing comparison here.
+    const proc = findUnityProcess(projectPath);
+    if (proc && proc.pid === lockPid) {
+      verbose(`Lockfile PID ${lockPid} confirmed via process enumeration`);
+      return lockPid;
+    }
+    verbose(`Lockfile PID ${lockPid} did not match enumerated Unity process for project — treating as stale`);
+  }
+
+  const proc = findUnityProcess(projectPath);
+  return proc ? proc.pid : null;
+}
+
+export const closeCommand = new Command('close')
+  .description('Gracefully terminate the Unity Editor instance running for a given project path')
+  .argument('[path]', 'Path to the Unity project (defaults to current directory)')
+  .option('--timeout <seconds>', `Polite-quit timeout in seconds (default: ${DEFAULT_TIMEOUT_SECONDS})`, String(DEFAULT_TIMEOUT_SECONDS))
+  .option('--force', 'Hard-kill the Editor if it does not exit within --timeout')
+  .action(async (positionalPath: string | undefined, options: CloseOptions) => {
+    const projectPath = resolveCloseProjectPath(positionalPath, process.cwd());
+    verbose(`close invoked for project: ${projectPath}`);
+
+    if (!fs.existsSync(projectPath)) {
+      ui.error(`Project path does not exist: ${projectPath}`);
+      process.exit(1);
+    }
+
+    if (!isUnityProjectRoot(projectPath)) {
+      ui.error(`not a Unity project root: ${projectPath}`);
+      process.exit(1);
+    }
+
+    const timeoutSeconds = parseTimeoutSeconds(options.timeout);
+    if (timeoutSeconds === null) {
+      ui.error(`Invalid --timeout value: "${options.timeout}". Must be a positive integer (seconds).`);
+      process.exit(1);
+    }
+
+    const platform = nodePlatform() as SupportedPlatform;
+    const pid = resolveEditorPid(projectPath, platform);
+
+    if (pid === null) {
+      ui.success(`no running Editor for project at ${projectPath}`);
+      process.exit(0);
+    }
+
+    ui.heading('Closing Unity Editor');
+    ui.label('Project', projectPath);
+    ui.label('PID', String(pid));
+    ui.label('Timeout', `${timeoutSeconds}s`);
+    ui.label('Force', options.force ? 'yes' : 'no');
+    ui.divider();
+
+    const spinner = ui.startSpinner(`Sending polite-quit to PID ${pid}...`);
+    const sent = sendGracefulShutdown(pid, platform);
+    if (!sent) {
+      spinner.error(`Failed to deliver polite-quit signal to PID ${pid}`);
+      process.exit(1);
+    }
+
+    spinner.text = `Waiting up to ${timeoutSeconds}s for PID ${pid} to exit...`;
+    const timeoutMs = timeoutSeconds * 1000;
+    const exited = await waitForExit(pid, timeoutMs, platform);
+
+    if (exited) {
+      spinner.success(`Unity Editor (PID ${pid}) exited cleanly`);
+      process.exit(0);
+    }
+
+    if (!options.force) {
+      spinner.error(
+        `Unity Editor (PID ${pid}) did not exit within ${timeoutSeconds}s. ` +
+          `Re-run with --force to hard-kill, or close it manually.`,
+      );
+      process.exit(1);
+    }
+
+    spinner.text = `Force-killing PID ${pid}...`;
+    const killed = sendForceKill(pid, platform);
+    if (!killed) {
+      spinner.error(`Failed to force-kill PID ${pid}`);
+      process.exit(1);
+    }
+
+    // Brief secondary wait so we report a true terminal state — the OS may
+    // need a moment to reap the process even after SIGKILL / `taskkill /F`.
+    const reaped = await waitForExit(pid, 5000, platform);
+    if (reaped) {
+      spinner.success(`Unity Editor (PID ${pid}) force-killed`);
+      process.exit(0);
+    }
+
+    spinner.error(`Unity Editor (PID ${pid}) is still alive after force-kill`);
+    process.exit(1);
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { createRequire } from 'module';
 import { bootstrapLocalCommand } from './commands/bootstrap-local.js';
+import { closeCommand } from './commands/close.js';
 import { createProjectCommand } from './commands/create-project.js';
 import { installUnityCommand } from './commands/install-unity.js';
 import { openCommand } from './commands/open.js';
@@ -32,6 +33,7 @@ program
 // Register all subcommands
 const subcommands = [
   bootstrapLocalCommand,
+  closeCommand,
   configureCommand,
   createProjectCommand,
   installPluginCommand,

--- a/cli/src/utils/unity-shutdown.ts
+++ b/cli/src/utils/unity-shutdown.ts
@@ -69,8 +69,10 @@ export function readLockfilePid(projectPath: string): number | null {
     return null;
   }
 
+  // `readUInt32LE` always returns a finite integer in [0, 2^32-1], so a
+  // non-positive check is the only meaningful filter here.
   const pid = buf.readUInt32LE(0);
-  if (!Number.isFinite(pid) || pid <= 0) {
+  if (pid <= 0) {
     verbose(`Unity lockfile holds non-positive PID: ${pid}`);
     return null;
   }
@@ -80,36 +82,65 @@ export function readLockfilePid(projectPath: string): number | null {
 /**
  * Returns true when a process with the given PID is alive.
  *
- * Uses signal 0 on POSIX (no actual signal sent — just permission/existence
- * check) and `tasklist /FI "PID eq <pid>"` on Windows. On any failure the
- * function errs on the side of "not running" and returns false, which keeps
- * the wait loop progressing rather than spinning forever on a transient error.
+ * Both platforms first try `process.kill(pid, 0)` — Node maps it through
+ * `OpenProcess` on Windows, so the check is in-process and effectively free
+ * compared to spawning `tasklist`. At a 250ms `waitForExit` cadence with a
+ * 30s default timeout that's ~120 fewer subprocesses per close on Windows.
+ *
+ * The Windows fallback to `tasklist` is kept as defence-in-depth: if a
+ * future Node release ever changes behaviour or `OpenProcess` denies access
+ * for a process owned by another session, we still get the right answer
+ * (just more slowly).
+ *
+ * On any failure the function errs on the side of "not running" and returns
+ * false, which keeps the wait loop progressing rather than spinning forever
+ * on a transient error.
  */
 export function isProcessAlive(pid: number, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): boolean {
   if (!Number.isFinite(pid) || pid <= 0) return false;
 
-  if (platform === 'win32') {
-    try {
-      const out = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'], {
-        encoding: 'utf-8',
-        timeout: 3000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
-      // tasklist prints "INFO: No tasks are running ..." when nothing matches.
-      return out.includes(`"${pid}"`);
-    } catch {
-      return false;
-    }
-  }
-
-  // POSIX: signal 0 returns success if the process exists and we can signal it.
   try {
     process.kill(pid, 0);
     return true;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     // EPERM means the process exists but we can't signal it — treat as alive.
-    return code === 'EPERM';
+    if (code === 'EPERM') return true;
+    if (code !== 'ESRCH') {
+      // Anything other than ESRCH is unexpected; fall through to the
+      // Windows-only verification path so we don't return a wrong answer
+      // on a transient OS hiccup. POSIX paths just return false.
+      if (platform !== 'win32') return false;
+    }
+  }
+
+  if (platform !== 'win32') return false;
+
+  // Windows fallback: `tasklist /FI "PID eq <pid>" /NH /FO CSV`.
+  // The first CSV column is the image name, the second is the PID. Parse
+  // field-wise so a digit run that happens to appear in another column
+  // (image name, session, memory, status) cannot produce a false positive.
+  try {
+    const out = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    // tasklist prints "INFO: No tasks are running ..." when nothing matches.
+    const target = `"${pid}"`;
+    for (const line of out.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      // Second CSV field — split on `,` and check column index 1. CSV from
+      // tasklist quotes every field, so a simple split is safe (image names
+      // with embedded commas are exceedingly rare and would still place the
+      // PID in some later column we can scan).
+      const cols = trimmed.split(',');
+      if (cols.length >= 2 && cols[1] === target) return true;
+    }
+    return false;
+  } catch {
+    return false;
   }
 }
 
@@ -119,6 +150,17 @@ export function isProcessAlive(pid: number, platform: SupportedPlatform = nodePl
  * Returns true on apparent success (the OS accepted the signal); false if the
  * underlying call threw. The caller still has to poll `isProcessAlive` — the
  * editor may take seconds to wind down.
+ *
+ * Windows caveat: `taskkill /PID <pid>` (no `/F`) delivers `WM_CLOSE`, which
+ * only reaches processes that own a top-level window on the same desktop /
+ * session as the caller. In headless contexts (Unity launched in session 0
+ * by a Windows service, or another non-interactive desktop) `taskkill` will
+ * exit 0 and this function will report `true`, but the editor will never
+ * receive the message. The `--timeout` will then elapse, and `--force` is
+ * the only path that brings the process down. This is documented in the
+ * close subcommand README and is consistent with the design decision to
+ * stick to OS-level polite-quit (rather than a Unity-side MCP `editor-quit`
+ * tool which would route through SignalR and bypass session walls).
  */
 export function sendGracefulShutdown(pid: number, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): boolean {
   if (!Number.isFinite(pid) || pid <= 0) return false;

--- a/cli/src/utils/unity-shutdown.ts
+++ b/cli/src/utils/unity-shutdown.ts
@@ -178,6 +178,15 @@ export function sendGracefulShutdown(pid: number, platform: SupportedPlatform = 
     process.kill(pid, sig);
     return true;
   } catch (err) {
+    // Race: the editor can exit between PID resolution and signal delivery.
+    // POSIX surfaces this as ESRCH; Windows `taskkill` exits non-zero with
+    // "process … not found". The desired end state (process gone) is already
+    // reached, so we re-check liveness and report success when the PID is
+    // truly absent. This preserves close's idempotency contract.
+    if (!isProcessAlive(pid, platform)) {
+      verbose(`Graceful shutdown: PID ${pid} already gone — treating as success`);
+      return true;
+    }
     verbose(`Graceful shutdown failed: ${err instanceof Error ? err.message : String(err)}`);
     return false;
   }
@@ -203,6 +212,12 @@ export function sendForceKill(pid: number, platform: SupportedPlatform = nodePla
     process.kill(pid, sig);
     return true;
   } catch (err) {
+    // Same race as sendGracefulShutdown — the polite-quit path may have
+    // already won between waitForExit's last poll and our SIGKILL call.
+    if (!isProcessAlive(pid, platform)) {
+      verbose(`Force kill: PID ${pid} already gone — treating as success`);
+      return true;
+    }
     verbose(`Force kill failed: ${err instanceof Error ? err.message : String(err)}`);
     return false;
   }

--- a/cli/src/utils/unity-shutdown.ts
+++ b/cli/src/utils/unity-shutdown.ts
@@ -132,9 +132,11 @@ export function isProcessAlive(pid: number, platform: SupportedPlatform = nodePl
       const trimmed = line.trim();
       if (trimmed.length === 0) continue;
       // Second CSV field — split on `,` and check column index 1. CSV from
-      // tasklist quotes every field, so a simple split is safe (image names
-      // with embedded commas are exceedingly rare and would still place the
-      // PID in some later column we can scan).
+      // tasklist quotes every field, so a simple split is safe. Image names
+      // with embedded commas would shift the PID into a later column and
+      // produce a false negative; that's an accepted trade-off — Unity
+      // executable names don't contain commas in practice, and any false
+      // negative simply ends the wait loop one tick early.
       const cols = trimmed.split(',');
       if (cols.length >= 2 && cols[1] === target) return true;
     }
@@ -244,5 +246,7 @@ export async function waitForExit(
     }
     await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
   }
+  // One last check after the deadline elapses — the process may have exited
+  // in the trailing poll-interval slice we slept through.
   return !isProcessAlive(pid, platform);
 }

--- a/cli/src/utils/unity-shutdown.ts
+++ b/cli/src/utils/unity-shutdown.ts
@@ -1,0 +1,191 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { platform as nodePlatform } from 'os';
+import { verbose } from './ui.js';
+
+/**
+ * Supported Node.js `process.platform` values for the close subcommand.
+ * Narrowed alias of NodeJS.Platform — keeps signal-selection logic exhaustive
+ * in tests without forcing callers to import a Node-internal type.
+ */
+export type SupportedPlatform = 'win32' | 'darwin' | 'linux';
+
+/**
+ * The polite-quit "graceful shutdown" signal for the current platform.
+ *
+ * - Linux / macOS: `SIGTERM` — Unity catches this and runs its normal exit
+ *   path (autosave, asset-import finalisation, plugin disconnect).
+ * - Windows: `WM_CLOSE` via `taskkill` (no `/F`) — same idea, sent through
+ *   `taskkill /PID <pid>` in the runtime helper. We return the string
+ *   sentinel `WM_CLOSE` here so the call site can branch on it.
+ *
+ * Exposed as a pure function so the unit test suite can assert the platform
+ * matrix without booting an editor.
+ */
+export function gracefulShutdownSignal(platform: SupportedPlatform): NodeJS.Signals | 'WM_CLOSE' {
+  if (platform === 'win32') return 'WM_CLOSE';
+  return 'SIGTERM';
+}
+
+/**
+ * The hard-kill signal for the current platform.
+ *
+ * - Linux / macOS: `SIGKILL`.
+ * - Windows: `taskkill /F` — represented here by the sentinel `TASKKILL_FORCE`.
+ */
+export function forceKillSignal(platform: SupportedPlatform): NodeJS.Signals | 'TASKKILL_FORCE' {
+  if (platform === 'win32') return 'TASKKILL_FORCE';
+  return 'SIGKILL';
+}
+
+/**
+ * Read the editor PID stored in `<project>/Temp/UnityLockfile`.
+ *
+ * Unity writes the running editor's PID into the first 4 bytes of this file
+ * as a little-endian uint32 the moment it acquires the project lock. Returns
+ * `null` when the lockfile is missing, too small, or holds a zero/negative PID.
+ *
+ * The caller is responsible for cross-checking the PID against a live process
+ * list — stale lockfiles can survive an unclean editor exit.
+ */
+export function readLockfilePid(projectPath: string): number | null {
+  const lockfilePath = path.join(projectPath, 'Temp', 'UnityLockfile');
+  if (!fs.existsSync(lockfilePath)) {
+    verbose(`No Unity lockfile at ${lockfilePath}`);
+    return null;
+  }
+
+  let buf: Buffer;
+  try {
+    buf = fs.readFileSync(lockfilePath);
+  } catch (err) {
+    verbose(`Failed to read Unity lockfile: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+
+  if (buf.length < 4) {
+    verbose(`Unity lockfile too small (${buf.length} bytes)`);
+    return null;
+  }
+
+  const pid = buf.readUInt32LE(0);
+  if (!Number.isFinite(pid) || pid <= 0) {
+    verbose(`Unity lockfile holds non-positive PID: ${pid}`);
+    return null;
+  }
+  return pid;
+}
+
+/**
+ * Returns true when a process with the given PID is alive.
+ *
+ * Uses signal 0 on POSIX (no actual signal sent — just permission/existence
+ * check) and `tasklist /FI "PID eq <pid>"` on Windows. On any failure the
+ * function errs on the side of "not running" and returns false, which keeps
+ * the wait loop progressing rather than spinning forever on a transient error.
+ */
+export function isProcessAlive(pid: number, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+
+  if (platform === 'win32') {
+    try {
+      const out = execFileSync('tasklist', ['/FI', `PID eq ${pid}`, '/NH', '/FO', 'CSV'], {
+        encoding: 'utf-8',
+        timeout: 3000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      // tasklist prints "INFO: No tasks are running ..." when nothing matches.
+      return out.includes(`"${pid}"`);
+    } catch {
+      return false;
+    }
+  }
+
+  // POSIX: signal 0 returns success if the process exists and we can signal it.
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the process exists but we can't signal it — treat as alive.
+    return code === 'EPERM';
+  }
+}
+
+/**
+ * Send the platform's polite-quit signal to the given PID.
+ *
+ * Returns true on apparent success (the OS accepted the signal); false if the
+ * underlying call threw. The caller still has to poll `isProcessAlive` — the
+ * editor may take seconds to wind down.
+ */
+export function sendGracefulShutdown(pid: number, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  const sig = gracefulShutdownSignal(platform);
+  verbose(`Sending graceful shutdown to PID ${pid} via ${sig}`);
+
+  try {
+    if (sig === 'WM_CLOSE') {
+      execFileSync('taskkill', ['/PID', String(pid)], {
+        timeout: 3000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return true;
+    }
+    process.kill(pid, sig);
+    return true;
+  } catch (err) {
+    verbose(`Graceful shutdown failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
+/**
+ * Hard-kill the given PID. Used only when `--force` is set and the polite
+ * shutdown timed out.
+ */
+export function sendForceKill(pid: number, platform: SupportedPlatform = nodePlatform() as SupportedPlatform): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  const sig = forceKillSignal(platform);
+  verbose(`Force-killing PID ${pid} via ${sig}`);
+
+  try {
+    if (sig === 'TASKKILL_FORCE') {
+      execFileSync('taskkill', ['/F', '/PID', String(pid)], {
+        timeout: 3000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return true;
+    }
+    process.kill(pid, sig);
+    return true;
+  } catch (err) {
+    verbose(`Force kill failed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
+/**
+ * Poll until the given PID disappears or the timeout elapses.
+ *
+ * Returns true if the process exited within `timeoutMs`; false otherwise.
+ * Uses a 250ms poll interval — short enough to give crisp UX on a fast exit
+ * without busy-looping.
+ */
+export async function waitForExit(
+  pid: number,
+  timeoutMs: number,
+  platform: SupportedPlatform = nodePlatform() as SupportedPlatform,
+): Promise<boolean> {
+  const pollIntervalMs = 250;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid, platform)) {
+      return true;
+    }
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+  }
+  return !isProcessAlive(pid, platform);
+}

--- a/cli/tests/close.test.ts
+++ b/cli/tests/close.test.ts
@@ -83,7 +83,7 @@ describe('close command — refusals', () => {
     try {
       const { exitCode, stdout } = runCli(['close', tmpDir]);
       expect(exitCode).toBe(1);
-      expect(stdout).toContain('not a Unity project root');
+      expect(stdout).toContain('Not a Unity project root');
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -364,6 +364,12 @@ liveDescribe('close command — live editor (UMCP_LIVE=1)', () => {
     }
     const { exitCode, stdout } = runCli(['close', liveProject, '--timeout', '60']);
     expect(exitCode).toBe(0);
-    expect(stdout).toMatch(/exited cleanly|no running Editor/);
+    // The whole point of this gated test is to validate the graceful-close
+    // path against a real Editor, so we assert the close-path output
+    // explicitly. The idempotent "no running Editor" branch is NOT acceptable
+    // here — if we hit it the precondition (live editor for liveProject) was
+    // not met and the test must fail loudly rather than silently no-op.
+    expect(stdout).toContain('exited cleanly');
+    expect(stdout).not.toContain('no running Editor');
   }, 90_000);
 });

--- a/cli/tests/close.test.ts
+++ b/cli/tests/close.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  isUnityProjectRoot,
+  parseTimeoutSeconds,
+  resolveCloseProjectPath,
+} from '../src/commands/close.js';
+import {
+  forceKillSignal,
+  gracefulShutdownSignal,
+  isProcessAlive,
+  readLockfilePid,
+  waitForExit,
+} from '../src/utils/unity-shutdown.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
+
+interface RunCliOptions {
+  cwd?: string;
+}
+
+function runCli(args: string[], opts: RunCliOptions = {}): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      timeout: 15000,
+      cwd: opts.cwd,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: (error.stdout ?? '') + (error.stderr ?? ''),
+      exitCode: error.status ?? 1,
+    };
+  }
+}
+
+/** Build a minimal Unity-project-shaped directory so `close` does not refuse it. */
+function makeFakeUnityProject(dir: string): void {
+  fs.mkdirSync(path.join(dir, 'Assets'), { recursive: true });
+  const settingsDir = path.join(dir, 'ProjectSettings');
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(settingsDir, 'ProjectVersion.txt'),
+    'm_EditorVersion: 6000.0.0f1\n',
+  );
+}
+
+// ─── close command — flag parsing, refusals, idempotent no-op ─────────────────
+
+describe('close command — help and flag surface', () => {
+  it('shows help with --help', () => {
+    const { stdout, exitCode } = runCli(['close', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('close');
+    expect(stdout).toContain('[path]');
+    expect(stdout).toContain('--timeout');
+    expect(stdout).toContain('--force');
+  });
+
+  it('lists close in the root --help command list', () => {
+    const { stdout, exitCode } = runCli(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('close');
+  });
+});
+
+describe('close command — refusals', () => {
+  it('fails when project path does not exist', () => {
+    const { exitCode, stdout } = runCli(['close', '/nonexistent/path/abc12345']);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('does not exist');
+  });
+
+  it('refuses to act on a non-Unity-project directory', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-refuse-'));
+    try {
+      const { exitCode, stdout } = runCli(['close', tmpDir]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('not a Unity project root');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a non-positive --timeout value', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-timeout-'));
+    try {
+      makeFakeUnityProject(tmpDir);
+      const { exitCode, stdout } = runCli(['close', tmpDir, '--timeout', '0']);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('Invalid --timeout');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a non-numeric --timeout value', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-timeout-'));
+    try {
+      makeFakeUnityProject(tmpDir);
+      const { exitCode, stdout } = runCli(['close', tmpDir, '--timeout', 'abc']);
+      expect(exitCode).toBe(1);
+      expect(stdout).toContain('Invalid --timeout');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('close command — idempotent no-op when no editor is running', () => {
+  it('exits 0 when the project has no running editor', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-noop-'));
+    try {
+      makeFakeUnityProject(tmpDir);
+      const { exitCode, stdout } = runCli(['close', tmpDir]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('no running Editor');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── path normalisation helpers (pure unit tests) ────────────────────────────
+
+describe('resolveCloseProjectPath', () => {
+  it('returns the positional argument resolved to absolute when provided', () => {
+    const result = resolveCloseProjectPath('some/relative/path', '/fake/cwd');
+    expect(result).toBe(path.resolve('some/relative/path'));
+  });
+
+  it('falls back to cwd when no positional argument is given', () => {
+    const cwd = path.resolve('/fake/cwd');
+    const result = resolveCloseProjectPath(undefined, cwd);
+    expect(result).toBe(cwd);
+  });
+
+  it('strips a trailing path separator via canonicalisation', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-norm-'));
+    try {
+      const withTrailing = tmpDir + path.sep;
+      const result = resolveCloseProjectPath(withTrailing, '/fake/cwd');
+      expect(result).toBe(fs.realpathSync(tmpDir));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('canonicalises a relative path through realpath when the dir exists', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-real-'));
+    try {
+      const subdir = path.join(tmpDir, 'sub');
+      fs.mkdirSync(subdir);
+      const messy = path.join(tmpDir, 'sub', '..', 'sub');
+      const result = resolveCloseProjectPath(messy, '/fake/cwd');
+      expect(result).toBe(fs.realpathSync(subdir));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isUnityProjectRoot', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-isproj-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns false for an empty directory', () => {
+    expect(isUnityProjectRoot(tmpDir)).toBe(false);
+  });
+
+  it('returns false when only Assets/ exists', () => {
+    fs.mkdirSync(path.join(tmpDir, 'Assets'));
+    expect(isUnityProjectRoot(tmpDir)).toBe(false);
+  });
+
+  it('returns true when ProjectSettings/ProjectVersion.txt exists', () => {
+    fs.mkdirSync(path.join(tmpDir, 'ProjectSettings'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'ProjectSettings', 'ProjectVersion.txt'),
+      'm_EditorVersion: 6000.0.0f1\n',
+    );
+    expect(isUnityProjectRoot(tmpDir)).toBe(true);
+  });
+});
+
+describe('parseTimeoutSeconds', () => {
+  it('returns the default when undefined', () => {
+    expect(parseTimeoutSeconds(undefined)).toBe(30);
+  });
+
+  it('parses a positive integer', () => {
+    expect(parseTimeoutSeconds('45')).toBe(45);
+  });
+
+  it('returns null on zero', () => {
+    expect(parseTimeoutSeconds('0')).toBeNull();
+  });
+
+  it('returns null on negative', () => {
+    expect(parseTimeoutSeconds('-5')).toBeNull();
+  });
+
+  it('returns null on non-integer', () => {
+    expect(parseTimeoutSeconds('1.5')).toBeNull();
+  });
+
+  it('returns null on non-numeric', () => {
+    expect(parseTimeoutSeconds('xyz')).toBeNull();
+  });
+});
+
+// ─── shutdown utility unit tests ──────────────────────────────────────────────
+
+describe('gracefulShutdownSignal — cross-platform matrix', () => {
+  it('returns SIGTERM on linux', () => {
+    expect(gracefulShutdownSignal('linux')).toBe('SIGTERM');
+  });
+
+  it('returns SIGTERM on macOS', () => {
+    expect(gracefulShutdownSignal('darwin')).toBe('SIGTERM');
+  });
+
+  it('returns WM_CLOSE sentinel on Windows', () => {
+    expect(gracefulShutdownSignal('win32')).toBe('WM_CLOSE');
+  });
+});
+
+describe('forceKillSignal — cross-platform matrix', () => {
+  it('returns SIGKILL on linux', () => {
+    expect(forceKillSignal('linux')).toBe('SIGKILL');
+  });
+
+  it('returns SIGKILL on macOS', () => {
+    expect(forceKillSignal('darwin')).toBe('SIGKILL');
+  });
+
+  it('returns TASKKILL_FORCE sentinel on Windows', () => {
+    expect(forceKillSignal('win32')).toBe('TASKKILL_FORCE');
+  });
+});
+
+describe('readLockfilePid', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-close-lock-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the lockfile does not exist', () => {
+    expect(readLockfilePid(tmpDir)).toBeNull();
+  });
+
+  it('returns null when the lockfile is too small (<4 bytes)', () => {
+    fs.mkdirSync(path.join(tmpDir, 'Temp'));
+    fs.writeFileSync(path.join(tmpDir, 'Temp', 'UnityLockfile'), Buffer.from([0x01, 0x02]));
+    expect(readLockfilePid(tmpDir)).toBeNull();
+  });
+
+  it('parses a little-endian uint32 from the first 4 bytes', () => {
+    fs.mkdirSync(path.join(tmpDir, 'Temp'));
+    // 0x39300000 LE = 12345 — typical Unity PID range.
+    const buf = Buffer.from([0x39, 0x30, 0x00, 0x00]);
+    fs.writeFileSync(path.join(tmpDir, 'Temp', 'UnityLockfile'), buf);
+    expect(readLockfilePid(tmpDir)).toBe(12345);
+  });
+
+  it('returns null when the lockfile holds zero', () => {
+    fs.mkdirSync(path.join(tmpDir, 'Temp'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'Temp', 'UnityLockfile'),
+      Buffer.from([0x00, 0x00, 0x00, 0x00]),
+    );
+    expect(readLockfilePid(tmpDir)).toBeNull();
+  });
+
+  it('ignores trailing bytes beyond the first 4', () => {
+    fs.mkdirSync(path.join(tmpDir, 'Temp'));
+    // PID 1 + arbitrary trailing payload.
+    const buf = Buffer.concat([
+      Buffer.from([0x01, 0x00, 0x00, 0x00]),
+      Buffer.from([0xAB, 0xCD, 0xEF]),
+    ]);
+    fs.writeFileSync(path.join(tmpDir, 'Temp', 'UnityLockfile'), buf);
+    expect(readLockfilePid(tmpDir)).toBe(1);
+  });
+});
+
+describe('isProcessAlive', () => {
+  it('returns true for the current process pid', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it('returns false for a sentinel non-existent pid', () => {
+    // PID 0 is special on POSIX; using a very large number that is unlikely
+    // to be assigned. The helper rejects non-positive inputs, so 0 returns
+    // false directly without touching the OS.
+    expect(isProcessAlive(0)).toBe(false);
+  });
+
+  it('returns false for a negative pid', () => {
+    expect(isProcessAlive(-1)).toBe(false);
+  });
+
+  it('returns false for a non-finite pid', () => {
+    expect(isProcessAlive(NaN)).toBe(false);
+  });
+});
+
+describe('waitForExit', () => {
+  it('returns true immediately when the pid is already gone', async () => {
+    const start = Date.now();
+    const result = await waitForExit(0, 2000);
+    const elapsed = Date.now() - start;
+    expect(result).toBe(true);
+    // First poll happens before any sleep, so we should return well under
+    // the configured timeout.
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('returns false when the timeout elapses on a live pid', async () => {
+    const start = Date.now();
+    const result = await waitForExit(process.pid, 600);
+    const elapsed = Date.now() - start;
+    expect(result).toBe(false);
+    expect(elapsed).toBeGreaterThanOrEqual(500);
+  });
+});
+
+// ─── live-editor integration smoke test (gated by UMCP_LIVE=1) ───────────────
+//
+// This block is skipped by default so CI does not require Unity. To exercise
+// it locally, run `UMCP_LIVE=1 npm test` inside `Unity-MCP/cli/` after
+// `unity-mcp-cli open <project>` has launched a real editor for
+// `UMCP_LIVE_PROJECT`. The acceptance criterion validated here is the
+// graceful-close path; the timeout and force-kill paths require a wedged
+// editor that scripted setup cannot reliably reproduce.
+
+const liveDescribe = process.env.UMCP_LIVE === '1' ? describe : describe.skip;
+
+liveDescribe('close command — live editor (UMCP_LIVE=1)', () => {
+  const liveProject = process.env.UMCP_LIVE_PROJECT;
+
+  it('terminates a running editor for the project (UMCP_LIVE_PROJECT must point at one)', () => {
+    if (!liveProject) {
+      throw new Error('UMCP_LIVE=1 requires UMCP_LIVE_PROJECT to be set to a Unity project path with a live editor');
+    }
+    const { exitCode, stdout } = runCli(['close', liveProject, '--timeout', '60']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/exited cleanly|no running Editor/);
+  }, 90_000);
+});

--- a/cli/tests/close.test.ts
+++ b/cli/tests/close.test.ts
@@ -22,13 +22,21 @@ const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
 
 interface RunCliOptions {
   cwd?: string;
+  /**
+   * `execFileSync` timeout in ms. Default 15s is fine for the unit-test
+   * paths (refusals, no-op exits). The gated live-editor test passes a
+   * larger value because Unity's polite-quit can legitimately take longer
+   * than 15s and we don't want execFileSync to kill the test runner before
+   * the CLI's own --timeout has had a chance to elapse.
+   */
+  timeoutMs?: number;
 }
 
 function runCli(args: string[], opts: RunCliOptions = {}): { stdout: string; exitCode: number } {
   try {
     const stdout = execFileSync('node', [CLI_PATH, ...args], {
       encoding: 'utf-8',
-      timeout: 15000,
+      timeout: opts.timeoutMs ?? 15000,
       cwd: opts.cwd,
     });
     return { stdout, exitCode: 0 };
@@ -308,10 +316,10 @@ describe('isProcessAlive', () => {
     expect(isProcessAlive(process.pid)).toBe(true);
   });
 
-  it('returns false for a sentinel non-existent pid', () => {
-    // PID 0 is special on POSIX; using a very large number that is unlikely
-    // to be assigned. The helper rejects non-positive inputs, so 0 returns
-    // false directly without touching the OS.
+  it('returns false for PID 0 without touching the OS', () => {
+    // The helper rejects non-positive inputs at the guard, so PID 0 returns
+    // false directly without an OS syscall (which would otherwise be
+    // platform-dependent — POSIX treats 0 as the caller's process group).
     expect(isProcessAlive(0)).toBe(false);
   });
 
@@ -362,7 +370,13 @@ liveDescribe('close command — live editor (UMCP_LIVE=1)', () => {
     if (!liveProject) {
       throw new Error('UMCP_LIVE=1 requires UMCP_LIVE_PROJECT to be set to a Unity project path with a live editor');
     }
-    const { exitCode, stdout } = runCli(['close', liveProject, '--timeout', '60']);
+    // execFileSync timeout must exceed the CLI's own --timeout (60s) plus a
+    // generous buffer for force-kill fallback and process reaping. 80s here
+    // pairs with the 90s Vitest test-level timeout below.
+    const { exitCode, stdout } = runCli(
+      ['close', liveProject, '--timeout', '60'],
+      { timeoutMs: 80_000 },
+    );
     expect(exitCode).toBe(0);
     // The whole point of this gated test is to validate the graceful-close
     // path against a real Editor, so we assert the close-path output


### PR DESCRIPTION
## Summary

- Adds `unity-mcp-cli close <path>` — gracefully terminates the Unity Editor running for a given project. Symmetric counterpart of `open` for scripted bring-up/tear-down lifecycles (CI agents, pipeline executors, integration test fixtures).
- PID resolution: read `<project>/Temp/UnityLockfile` (LE uint32, first 4 bytes), cross-check via process enumeration to handle stale lock files. Cross-platform: `SIGTERM` on Linux/macOS, `taskkill` (no `/F`) on Windows. `--force` falls back to `SIGKILL` / `taskkill /F` after `--timeout` (default 30s).
- Project-scoped — refuses to act on any path that is not a Unity project root (`ProjectSettings/ProjectVersion.txt` must exist). Idempotent: no running editor → exit 0 with `no running Editor for project at <path>`.

## Design notes

The graceful-quit path uses an OS signal rather than a plugin-side `editor-quit` MCP tool. Adding that tool would require touching plugin code currently being refactored under #689 (config-loader priority). `SIGTERM` already triggers Unity's normal exit hooks (autosave, asset-import finalisation, plugin disconnect), which satisfies the issue's acceptance criteria. A plugin-hub graceful path can be added as a follow-up once #689 lands.

## Test plan

- [x] CLI suite (`npm test` in `Unity-MCP/cli/`): 265 passed, 1 skipped (the live-editor smoke test, gated by `UMCP_LIVE=1`).

The new `tests/close.test.ts` adds 38 tests (37 active + 1 gated) covering, by acceptance criterion:

- (a) Graceful close of a running editor — covered by the gated live-editor smoke test (`UMCP_LIVE=1 UMCP_LIVE_PROJECT=<path> npm test`); kept off CI by default so CI does not require Unity.
- (b) Timeout → soft-failure exit without `--force` — covered indirectly by the `waitForExit` unit tests; the live wedged-editor scenario is impractical to reproduce in CI.
- (c) Timeout → hard kill with `--force` — same as (b).
- (d) No-editor-running → exit 0 — direct unit test (`exits 0 when the project has no running editor`).
- (e) Cross-platform path normalisation — direct unit tests on `resolveCloseProjectPath` (relative, trailing-separator, realpath canonicalisation).
- (f) Refusal on non-Unity-project paths — direct unit tests (`refuses to act on a non-Unity-project directory`, `isUnityProjectRoot`).
- Cross-platform shutdown-signal selection — direct unit tests on `gracefulShutdownSignal` / `forceKillSignal` for `linux` / `darwin` / `win32`.
- Lockfile PID parsing — direct unit tests including missing lockfile, too-small file, zero PID, and trailing-byte robustness.
- Flag parsing — direct unit tests on `parseTimeoutSeconds` plus CLI-level help / refusal tests.

Closes #688