### PR TITLE
feat: adopt ReflectorNet 5.1.0 path-based read/modify APIs in MCP tools

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -34,14 +35,37 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Get asset data from the asset file in the Unity project. " +
             "It includes all serializable fields and properties of the asset. " +
-            "Use '" + AssetsFindToolId + "' tool to find asset before using this tool.")]
-        public SerializedMember GetData(AssetObjectRef assetRef)
+            "Use '" + AssetsFindToolId + "' tool to find asset before using this tool.\n\n" +
+            "Path-scoped reads (token-saving): supply '" + "paths" + "' (a list of paths) to read only the listed " +
+            "fields/elements via Reflector.TryReadAt, or '" + "viewQuery" + "' (a ViewQuery) to navigate to a " +
+            "subtree and/or filter by name regex / max depth / type via Reflector.View. " +
+            "These two parameters are mutually exclusive — supply at most one. " +
+            "When neither is supplied the full asset is serialized as before (backwards compatible).\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
+        public SerializedMember GetData
+        (
+            AssetObjectRef assetRef,
+            [Description("Optional. List of paths to read individually via Reflector.TryReadAt. " +
+                "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. " +
+                "Mutually exclusive with '" + "viewQuery" + "'.")]
+            List<string>? paths = null,
+            [Description("Optional. View-query filter routed through Reflector.View — combines a starting Path, " +
+                "a case-insensitive NamePattern regex, MaxDepth, and an optional TypeFilter. " +
+                "Mutually exclusive with '" + "paths" + "'.")]
+            ViewQuery? viewQuery = null
+        )
         {
             if (assetRef == null)
                 throw new ArgumentNullException(nameof(assetRef));
 
             if (!assetRef.IsValid(out var error))
                 throw new ArgumentException(error, nameof(assetRef));
+
+            var hasPaths = paths != null && paths.Count > 0;
+            var hasViewQuery = viewQuery != null;
+            if (hasPaths && hasViewQuery)
+                throw new ArgumentException(
+                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -61,12 +85,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     throw new Exception(Error.NotFoundAsset(assetRef.AssetPath!, assetRef.AssetGuid ?? "N/A"));
 
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Assets>();
+
+                if (hasPaths)
+                    return PathReadHelper.BuildPathReadAggregate(reflector, asset, asset.name, paths!, logger);
+
+                if (hasViewQuery)
+                    return reflector.View(asset, viewQuery, logs: null, logger: logger)
+                        ?? new SerializedMember { name = asset.name, typeName = asset.GetType().FullName ?? string.Empty };
 
                 return reflector.Serialize(
                     obj: asset,
                     name: asset.name,
                     recursive: true,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Assets>()
+                    logger: logger
                 );
             });
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
@@ -65,7 +65,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasViewQuery = viewQuery != null;
             if (hasPaths && hasViewQuery)
                 throw new ArgumentException(
-                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+                    $"'{nameof(paths)}' and '{nameof(viewQuery)}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
@@ -73,10 +73,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
             var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
             if (!hasContent && !hasPathPatches && !hasJsonPatch)
-                throw new ArgumentNullException(nameof(content),
-                    "At least one of 'content', 'pathPatches', or 'jsonPatch' is required. " +
-                    "Make sure the JSON input uses 'content' as the key wrapping the SerializedMember object, " +
-                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
+                throw new ArgumentNullException(paramName: null,
+                    $"At least one of '{nameof(content)}', '{nameof(pathPatches)}', or '{nameof(jsonPatch)}' is required. " +
+                    $"Make sure the JSON input uses '{nameof(content)}' as the key wrapping the SerializedMember object, " +
+                    $"or supply '{nameof(pathPatches)}' / '{nameof(jsonPatch)}' for path-scoped modifications.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -99,11 +99,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 if (hasPathPatches)
                 {
-                    foreach (var patch in pathPatches!)
+                    for (int i = 0; i < pathPatches!.Count; i++)
                     {
-                        if (string.IsNullOrEmpty(patch.Path))
+                        var patch = pathPatches[i];
+                        if (patch == null || string.IsNullOrEmpty(patch.Path))
                         {
-                            logs.Error($"PathPatch with empty path skipped.");
+                            logs.Error($"PathPatch[{i}] with empty path skipped.");
                             continue;
                         }
                         if (reflector.TryModifyAt(ref obj, patch.Path, patch.Value, logs: logs, logger: logger))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
@@ -11,6 +11,7 @@
 #nullable enable
 #if UNITY_6000_5_OR_NEWER
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
@@ -36,18 +37,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Modify asset file in the project. " +
             "Use '" + AssetsGetDataToolId + "' tool first to inspect the asset structure before modifying. " +
-            "Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.")]
+            "Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.\n\n" +
+            "Three modification surfaces (use whichever fits the task):\n" +
+            "  1. '" + "content" + "' — full SerializedMember override (legacy, backwards compatible).\n" +
+            "  2. '" + "pathPatches" + "' — list of {path, value} pairs routed through Reflector.TryModifyAt.\n" +
+            "  3. '" + "jsonPatch" + "' — JSON Merge Patch routed through Reflector.TryPatch.\n" +
+            "When more than one is supplied they run in this order: jsonPatch → pathPatches → content. " +
+            "At least one is required.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public string[] Modify
         (
             AssetObjectRef assetRef,
-            [Description("The asset content. It overrides the existing asset content.")]
-            SerializedMember content
+            [Description("Optional. The asset content. It overrides the existing asset content (legacy path).")]
+            SerializedMember? content = null,
+            [Description("Optional. List of path-scoped patches routed through Reflector.TryModifyAt.")]
+            List<PathPatch>? pathPatches = null,
+            [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
+                "Reflector.TryPatch.")]
+            string? jsonPatch = null
         )
         {
-            if (content == null)
-                throw new ArgumentNullException(nameof(content),
-                    "The 'content' parameter is required. Make sure the JSON input uses 'content' as the key wrapping the SerializedMember object.");
-
             if (assetRef == null)
                 throw new ArgumentNullException(nameof(assetRef));
 
@@ -60,26 +69,58 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (assetRef.AssetPath?.StartsWith(ExtensionsRuntimeObject.UnityEditorBuiltInResourcesPath) == true)
                 throw new ArgumentException($"Not allowed to modify built-in asset. Path: '{assetRef.AssetPath}'.", nameof(assetRef));
 
+            var hasContent = content != null;
+            var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
+            var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
+            if (!hasContent && !hasPathPatches && !hasJsonPatch)
+                throw new ArgumentNullException(nameof(content),
+                    "At least one of 'content', 'pathPatches', or 'jsonPatch' is required. " +
+                    "Make sure the JSON input uses 'content' as the key wrapping the SerializedMember object, " +
+                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
+
             return MainThread.Instance.Run(() =>
             {
                 var asset = assetRef.FindAssetObject(); // AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
                 if (asset == null)
                     throw new Exception($"Asset not found using the reference:\n{assetRef}");
 
-                // Fixing instanceID - inject expected instance ID into the valueJsonElement
-                content.valueJsonElement.SetProperty(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(asset.GetEntityId()));
-
-                var obj = (object)asset;
+                var obj = (object?)asset;
                 var logs = new Logs();
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Assets>();
 
-                var success = reflector.TryModify(
-                    ref obj,
-                    data: content,
-                    logs: logs,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Assets>());
+                var anySuccess = false;
 
-                if (success)
+                if (hasJsonPatch)
+                {
+                    if (reflector.TryPatch(ref obj, jsonPatch!, logs: logs, logger: logger))
+                        anySuccess = true;
+                }
+
+                if (hasPathPatches)
+                {
+                    foreach (var patch in pathPatches!)
+                    {
+                        if (string.IsNullOrEmpty(patch.Path))
+                        {
+                            logs.Error($"PathPatch with empty path skipped.");
+                            continue;
+                        }
+                        if (reflector.TryModifyAt(ref obj, patch.Path, patch.Value, logs: logs, logger: logger))
+                            anySuccess = true;
+                    }
+                }
+
+                if (hasContent)
+                {
+                    // Fixing instanceID - inject expected instance ID into the valueJsonElement
+                    content!.valueJsonElement.SetProperty(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(asset.GetEntityId()));
+
+                    if (reflector.TryModify(ref obj, data: content!, logs: logs, logger: logger))
+                        anySuccess = true;
+                }
+
+                if (anySuccess)
                     EditorUtility.SetDirty(asset);
 
                 // AssetDatabase.CreateAsset(asset, assetPath);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
@@ -11,6 +11,7 @@
 #nullable enable
 #if !UNITY_6000_5_OR_NEWER
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
@@ -36,18 +37,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Modify asset file in the project. " +
             "Use '" + AssetsGetDataToolId + "' tool first to inspect the asset structure before modifying. " +
-            "Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.")]
+            "Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.\n\n" +
+            "Three modification surfaces (use whichever fits the task):\n" +
+            "  1. 'content' — full SerializedMember override (legacy, backwards compatible).\n" +
+            "  2. 'pathPatches' — list of {path, value} pairs routed through Reflector.TryModifyAt.\n" +
+            "  3. 'jsonPatch' — JSON Merge Patch routed through Reflector.TryPatch.\n" +
+            "When more than one is supplied they run in this order: jsonPatch → pathPatches → content. " +
+            "At least one is required.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public string[] Modify
         (
             AssetObjectRef assetRef,
-            [Description("The asset content. It overrides the existing asset content.")]
-            SerializedMember content
+            [Description("Optional. The asset content. It overrides the existing asset content (legacy path).")]
+            SerializedMember? content = null,
+            [Description("Optional. List of path-scoped patches routed through Reflector.TryModifyAt.")]
+            List<PathPatch>? pathPatches = null,
+            [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
+                "Reflector.TryPatch.")]
+            string? jsonPatch = null
         )
         {
-            if (content == null)
-                throw new ArgumentNullException(nameof(content),
-                    "The 'content' parameter is required. Make sure the JSON input uses 'content' as the key wrapping the SerializedMember object.");
-
             if (assetRef == null)
                 throw new ArgumentNullException(nameof(assetRef));
 
@@ -60,26 +69,58 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (assetRef.AssetPath?.StartsWith(ExtensionsRuntimeObject.UnityEditorBuiltInResourcesPath, StringComparison.OrdinalIgnoreCase) == true)
                 throw new ArgumentException($"Not allowed to modify built-in asset. Path: '{assetRef.AssetPath}'.", nameof(assetRef));
 
+            var hasContent = content != null;
+            var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
+            var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
+            if (!hasContent && !hasPathPatches && !hasJsonPatch)
+                throw new ArgumentNullException(nameof(content),
+                    "At least one of 'content', 'pathPatches', or 'jsonPatch' is required. " +
+                    "Make sure the JSON input uses 'content' as the key wrapping the SerializedMember object, " +
+                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
+
             return MainThread.Instance.Run(() =>
             {
                 var asset = assetRef.FindAssetObject(); // AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(assetPath);
                 if (asset == null)
                     throw new Exception($"Asset not found using the reference:\n{assetRef}");
 
-                // Fixing instanceID - inject expected instance ID into the valueJsonElement
-                content.valueJsonElement.SetProperty(ObjectRef.ObjectRefProperty.InstanceID, asset.GetInstanceID());
-
-                var obj = (object)asset;
+                var obj = (object?)asset;
                 var logs = new Logs();
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Assets>();
 
-                var success = reflector.TryModify(
-                    ref obj,
-                    data: content,
-                    logs: logs,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Assets>());
+                var anySuccess = false;
 
-                if (success)
+                if (hasJsonPatch)
+                {
+                    if (reflector.TryPatch(ref obj, jsonPatch!, logs: logs, logger: logger))
+                        anySuccess = true;
+                }
+
+                if (hasPathPatches)
+                {
+                    foreach (var patch in pathPatches!)
+                    {
+                        if (string.IsNullOrEmpty(patch.Path))
+                        {
+                            logs.Error($"PathPatch with empty path skipped.");
+                            continue;
+                        }
+                        if (reflector.TryModifyAt(ref obj, patch.Path, patch.Value, logs: logs, logger: logger))
+                            anySuccess = true;
+                    }
+                }
+
+                if (hasContent)
+                {
+                    // Fixing instanceID - inject expected instance ID into the valueJsonElement
+                    content!.valueJsonElement.SetProperty(ObjectRef.ObjectRefProperty.InstanceID, asset.GetInstanceID());
+
+                    if (reflector.TryModify(ref obj, data: content!, logs: logs, logger: logger))
+                        anySuccess = true;
+                }
+
+                if (anySuccess)
                     EditorUtility.SetDirty(asset);
 
                 // AssetDatabase.CreateAsset(asset, assetPath);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
@@ -73,10 +73,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
             var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
             if (!hasContent && !hasPathPatches && !hasJsonPatch)
-                throw new ArgumentNullException(nameof(content),
-                    "At least one of 'content', 'pathPatches', or 'jsonPatch' is required. " +
-                    "Make sure the JSON input uses 'content' as the key wrapping the SerializedMember object, " +
-                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
+                throw new ArgumentNullException(paramName: null,
+                    $"At least one of '{nameof(content)}', '{nameof(pathPatches)}', or '{nameof(jsonPatch)}' is required. " +
+                    $"Make sure the JSON input uses '{nameof(content)}' as the key wrapping the SerializedMember object, " +
+                    $"or supply '{nameof(pathPatches)}' / '{nameof(jsonPatch)}' for path-scoped modifications.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -99,11 +99,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 if (hasPathPatches)
                 {
-                    foreach (var patch in pathPatches!)
+                    for (int i = 0; i < pathPatches!.Count; i++)
                     {
-                        if (string.IsNullOrEmpty(patch.Path))
+                        var patch = pathPatches[i];
+                        if (patch == null || string.IsNullOrEmpty(patch.Path))
                         {
-                            logs.Error($"PathPatch with empty path skipped.");
+                            logs.Error($"PathPatch[{i}] with empty path skipped.");
                             continue;
                         }
                         if (reflector.TryModifyAt(ref obj, patch.Path, patch.Value, logs: logs, logger: logger))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
@@ -76,7 +76,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasViewQuery = viewQuery != null;
             if (hasPaths && hasViewQuery)
                 throw new ArgumentException(
-                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+                    $"'{nameof(paths)}' and '{nameof(viewQuery)}' are mutually exclusive — supply at most one.");
 
             var resolvedIncludeSourceCode = includeSourceCode ?? false;
             var options = new ShaderDataOptions
@@ -107,7 +107,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     if (hasPaths)
                         data.View = PathReadHelper.BuildPathReadAggregate(reflector, shader, shader.name, paths!, logger);
                     else
-                        data.View = reflector.View(shader, viewQuery, logs: null, logger: logger);
+                        data.View = reflector.View(shader, viewQuery, logs: null, logger: logger)
+                            ?? new SerializedMember { name = shader.name, typeName = shader.GetType().FullName ?? string.Empty };
                 }
 
                 return data;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
@@ -14,9 +14,12 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Runtime.Data;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
+using com.IvanMurzak.Unity.MCP.Utils;
+using Microsoft.Extensions.Logging;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -37,7 +40,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [Description("Get detailed data about a shader asset in the Unity project. " +
             "Returns shader properties, subshaders, passes, compilation errors, and supported status. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool with filter 't:Shader' to find shaders, " +
-            "or '" + AssetsShaderListAllToolId + "' tool to list all shader names.")]
+            "or '" + AssetsShaderListAllToolId + "' tool to list all shader names.\n\n" +
+            "Path-scoped reads (token-saving): supply '" + "paths" + "' (a list of paths) to read only the listed " +
+            "fields/elements via Reflector.TryReadAt, or '" + "viewQuery" + "' (a ViewQuery) to navigate to a " +
+            "subtree and/or filter by name regex / max depth / type via Reflector.View. The result populates " +
+            "'View' on the returned ShaderData. These two parameters are mutually exclusive.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public ShaderData GetData
         (
             AssetObjectRef assetRef,
@@ -48,7 +56,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Include subshader and pass structure. Default: false")]
             bool? includeSubshaders = false,
             [Description("Include pass source code in subshader data. Requires 'includeSubshaders' to be true. Can produce very large responses. Default: false")]
-            bool? includeSourceCode = false
+            bool? includeSourceCode = false,
+            [Description("Optional. List of paths to read individually via Reflector.TryReadAt against the underlying Shader asset. " +
+                "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. " +
+                "Mutually exclusive with '" + "viewQuery" + "'.")]
+            List<string>? paths = null,
+            [Description("Optional. View-query filter routed through Reflector.View against the underlying Shader asset. " +
+                "Mutually exclusive with '" + "paths" + "'.")]
+            ViewQuery? viewQuery = null
         )
         {
             if (assetRef == null)
@@ -56,6 +71,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             if (!assetRef.IsValid(out var error))
                 throw new ArgumentException(error, nameof(assetRef));
+
+            var hasPaths = paths != null && paths.Count > 0;
+            var hasViewQuery = viewQuery != null;
+            if (hasPaths && hasViewQuery)
+                throw new ArgumentException(
+                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
 
             var resolvedIncludeSourceCode = includeSourceCode ?? false;
             var options = new ShaderDataOptions
@@ -76,7 +97,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 if (shader == null)
                     throw new ArgumentException($"Asset at '{assetRef.AssetPath}' is not a Shader. It is a '{asset.GetType().Name}'.", nameof(assetRef));
 
-                return BuildShaderData(shader, options);
+                var data = BuildShaderData(shader, options);
+
+                if (hasPaths || hasViewQuery)
+                {
+                    var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                    var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Assets_Shader>();
+
+                    if (hasPaths)
+                        data.View = PathReadHelper.BuildPathReadAggregate(reflector, shader, shader.name, paths!, logger);
+                    else
+                        data.View = reflector.View(shader, viewQuery, logs: null, logger: logger);
+                }
+
+                return data;
             });
         }
 
@@ -238,6 +272,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             [Description("List of subshaders with their passes. Null if shader data is unavailable.")]
             public List<SubshaderData>? Subshaders { get; set; }
+
+            [Description("Path-scoped read or view-query result, populated when 'paths' or 'viewQuery' is supplied. " +
+                "Null otherwise.")]
+            public SerializedMember? View { get; set; }
         }
 
         public class ShaderMessageData

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
@@ -38,7 +38,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [Description("Get detailed information about a specific Component on a GameObject. " +
             "Returns component type, enabled state, and optionally serialized fields and properties. " +
             "Use this to inspect component data before modifying it. " +
-            "Use '" + GameObjectFindToolId + "' tool to get the list of all components on the GameObject.")]
+            "Use '" + GameObjectFindToolId + "' tool to get the list of all components on the GameObject.\n\n" +
+            "Path-scoped reads (token-saving): supply '" + "paths" + "' (a list of paths) to read only the listed " +
+            "fields/elements via Reflector.TryReadAt, or '" + "viewQuery" + "' (a ViewQuery) to navigate to a " +
+            "subtree and/or filter by name regex / max depth / type via Reflector.View. The result is returned in the " +
+            "'View' field of the response. These two parameters are mutually exclusive — supply at most one.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public GetComponentResponse GetComponent
         (
             GameObjectRef gameObjectRef,
@@ -48,7 +53,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Include serialized properties of the component.")]
             bool includeProperties = true,
             [Description("Performs deep serialization including all nested objects. Otherwise, only serializes top-level members.")]
-            bool deepSerialization = false
+            bool deepSerialization = false,
+            [Description("Optional. List of paths to read individually via Reflector.TryReadAt. " +
+                "When supplied, the legacy 'Fields'/'Properties' lists are skipped and the result is returned in 'View'. " +
+                "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. " +
+                "Mutually exclusive with '" + "viewQuery" + "'.")]
+            List<string>? paths = null,
+            [Description("Optional. View-query filter routed through Reflector.View. " +
+                "When supplied, the legacy 'Fields'/'Properties' lists are skipped and the filtered subtree is " +
+                "returned in 'View'. Mutually exclusive with '" + "paths" + "'.")]
+            ViewQuery? viewQuery = null
         )
         {
             if (gameObjectRef == null)
@@ -62,6 +76,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             if (!componentRef.IsValid(out var componentValidationError))
                 throw new ArgumentException(componentValidationError, nameof(componentRef));
+
+            var hasPaths = paths != null && paths.Count > 0;
+            var hasViewQuery = viewQuery != null;
+            if (hasPaths && hasViewQuery)
+                throw new ArgumentException(
+                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -99,7 +119,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
                 var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>();
 
-                if (includeFields || includeProperties)
+                if (hasPaths)
+                {
+                    response.View = PathReadHelper.BuildPathReadAggregate(
+                        reflector, targetComponent, targetComponent.GetType().GetTypeId(), paths!, logger);
+                }
+                else if (hasViewQuery)
+                {
+                    response.View = reflector.View(targetComponent, viewQuery, logs: null, logger: logger);
+                }
+                else if (includeFields || includeProperties)
                 {
                     var serialized = reflector.Serialize(
                         obj: targetComponent,
@@ -138,11 +167,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Basic component information (type, enabled state).")]
             public ComponentDataShallow? Component { get; set; }
 
-            [Description("Serialized fields of the component.")]
+            [Description("Serialized fields of the component. Populated only on the legacy code path " +
+                "(no 'paths' / no 'viewQuery').")]
             public List<SerializedMember>? Fields { get; set; }
 
-            [Description("Serialized properties of the component.")]
+            [Description("Serialized properties of the component. Populated only on the legacy code path " +
+                "(no 'paths' / no 'viewQuery').")]
             public List<SerializedMember>? Properties { get; set; }
+
+            [Description("Path-scoped read or view-query result, populated when 'paths' or 'viewQuery' was supplied. " +
+                "Null otherwise.")]
+            public SerializedMember? View { get; set; }
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
@@ -81,7 +81,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasViewQuery = viewQuery != null;
             if (hasPaths && hasViewQuery)
                 throw new ArgumentException(
-                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+                    $"'{nameof(paths)}' and '{nameof(viewQuery)}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -126,7 +126,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 }
                 else if (hasViewQuery)
                 {
-                    response.View = reflector.View(targetComponent, viewQuery, logs: null, logger: logger);
+                    response.View = reflector.View(targetComponent, viewQuery, logs: null, logger: logger)
+                        ?? new SerializedMember
+                        {
+                            name = targetComponent.GetType().GetTypeId(),
+                            typeName = targetComponent.GetType().FullName ?? string.Empty
+                        };
                 }
                 else if (includeFields || includeProperties)
                 {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
@@ -81,7 +81,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasViewQuery = viewQuery != null;
             if (hasPaths && hasViewQuery)
                 throw new ArgumentException(
-                    "'paths' and 'viewQuery' are mutually exclusive — supply at most one.");
+                    $"'{nameof(paths)}' and '{nameof(viewQuery)}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
@@ -38,7 +38,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [Description("Get detailed information about a specific Component on a GameObject. " +
             "Returns component type, enabled state, and optionally serialized fields and properties. " +
             "Use this to inspect component data before modifying it. " +
-            "Use '" + GameObjectFindToolId + "' tool to get the list of all components on the GameObject.")]
+            "Use '" + GameObjectFindToolId + "' tool to get the list of all components on the GameObject.\n\n" +
+            "Path-scoped reads (token-saving): supply 'paths' (a list of paths) to read only the listed " +
+            "fields/elements via Reflector.TryReadAt, or 'viewQuery' (a ViewQuery) to navigate to a " +
+            "subtree and/or filter by name regex / max depth / type via Reflector.View. The result is returned in the " +
+            "'View' field of the response. These two parameters are mutually exclusive — supply at most one.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public GetComponentResponse GetComponent
         (
             GameObjectRef gameObjectRef,
@@ -48,7 +53,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Include serialized properties of the component.")]
             bool includeProperties = true,
             [Description("Performs deep serialization including all nested objects. Otherwise, only serializes top-level members.")]
-            bool deepSerialization = false
+            bool deepSerialization = false,
+            [Description("Optional. List of paths to read individually via Reflector.TryReadAt. " +
+                "When supplied, the legacy 'Fields'/'Properties' lists are skipped and the result is returned in 'View'. " +
+                "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. " +
+                "Mutually exclusive with 'viewQuery'.")]
+            List<string>? paths = null,
+            [Description("Optional. View-query filter routed through Reflector.View. " +
+                "When supplied, the legacy 'Fields'/'Properties' lists are skipped and the filtered subtree is " +
+                "returned in 'View'. Mutually exclusive with 'paths'.")]
+            ViewQuery? viewQuery = null
         )
         {
             if (gameObjectRef == null)
@@ -62,6 +76,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             if (!componentRef.IsValid(out var componentValidationError))
                 throw new ArgumentException(componentValidationError, nameof(componentRef));
+
+            var hasPaths = paths != null && paths.Count > 0;
+            var hasViewQuery = viewQuery != null;
+            if (hasPaths && hasViewQuery)
+                throw new ArgumentException(
+                    "'paths' and 'viewQuery' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -99,7 +119,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
                 var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>();
 
-                if (includeFields || includeProperties)
+                if (hasPaths)
+                {
+                    response.View = PathReadHelper.BuildPathReadAggregate(
+                        reflector, targetComponent, targetComponent.GetType().GetTypeId(), paths!, logger);
+                }
+                else if (hasViewQuery)
+                {
+                    response.View = reflector.View(targetComponent, viewQuery, logs: null, logger: logger);
+                }
+                else if (includeFields || includeProperties)
                 {
                     var serialized = reflector.Serialize(
                         obj: targetComponent,
@@ -138,11 +167,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Basic component information (type, enabled state).")]
             public ComponentDataShallow? Component { get; set; }
 
-            [Description("Serialized fields of the component.")]
+            [Description("Serialized fields of the component. Populated only on the legacy code path " +
+                "(no 'paths' / no 'viewQuery').")]
             public List<SerializedMember>? Fields { get; set; }
 
-            [Description("Serialized properties of the component.")]
+            [Description("Serialized properties of the component. Populated only on the legacy code path " +
+                "(no 'paths' / no 'viewQuery').")]
             public List<SerializedMember>? Properties { get; set; }
+
+            [Description("Path-scoped read or view-query result, populated when 'paths' or 'viewQuery' was supplied. " +
+                "Null otherwise.")]
+            public SerializedMember? View { get; set; }
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
@@ -126,7 +126,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 }
                 else if (hasViewQuery)
                 {
-                    response.View = reflector.View(targetComponent, viewQuery, logs: null, logger: logger);
+                    response.View = reflector.View(targetComponent, viewQuery, logs: null, logger: logger)
+                        ?? new SerializedMember
+                        {
+                            name = targetComponent.GetType().GetTypeId(),
+                            typeName = targetComponent.GetType().FullName ?? string.Empty
+                        };
                 }
                 else if (includeFields || includeProperties)
                 {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
@@ -33,26 +34,48 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Modify a specific Component on a GameObject in opened Prefab or in a Scene. " +
             "Allows direct modification of component fields and properties without wrapping in GameObject structure. " +
-            "Use '" + GameObjectComponentGetToolId + "' first to inspect the component structure before modifying.")]
+            "Use '" + GameObjectComponentGetToolId + "' first to inspect the component structure before modifying.\n\n" +
+            "Three modification surfaces (use whichever fits the task):\n" +
+            "  1. '" + "componentDiff" + "' — full SerializedMember diff (legacy, backwards compatible).\n" +
+            "  2. '" + "pathPatches" + "' — list of {path, value} pairs routed through Reflector.TryModifyAt; " +
+            "atomic per-path modification, multiple entries can target different depths.\n" +
+            "  3. '" + "jsonPatch" + "' — a JSON Merge Patch (RFC 7396, extended with [i]/[key] notation) " +
+            "routed through Reflector.TryPatch; multiple fields at any depth in a single call.\n" +
+            "When more than one is supplied they run in this order: jsonPatch → pathPatches → componentDiff. " +
+            "At least one is required.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public ModifyComponentResponse ModifyComponent
         (
             GameObjectRef gameObjectRef,
             ComponentRef componentRef,
-            [Description("The component data to apply. Should contain '" + nameof(SerializedMember.fields) + "' and/or '" + nameof(SerializedMember.props) + "' with the values to modify.\n" +
+            [Description("Optional. The full component data to apply (legacy path). Should contain '" + nameof(SerializedMember.fields) + "' and/or '" + nameof(SerializedMember.props) + "' with the values to modify.\n" +
                 "Only include the fields/properties you want to change.\n" +
                 "Any unknown or invalid fields and properties will be reported in the response.")]
-            SerializedMember componentDiff
+            SerializedMember? componentDiff = null,
+            [Description("Optional. List of path-scoped patches routed through Reflector.TryModifyAt. " +
+                "Each entry targets one field/element/entry by path. " +
+                "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'.")]
+            List<PathPatch>? pathPatches = null,
+            [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
+                "Reflector.TryPatch. Allows multiple fields at any depth to be updated in a single call. " +
+                "Use '$type' for compatible-subtype replacement.")]
+            string? jsonPatch = null
         )
         {
-            if (componentDiff == null)
-                throw new ArgumentNullException(nameof(componentDiff),
-                    "The 'componentDiff' parameter is required. Make sure the JSON input uses 'componentDiff' as the key (not 'fields' or 'props' directly).");
-
             if (!gameObjectRef.IsValid(out var gameObjectValidationError))
                 throw new ArgumentException(gameObjectValidationError, nameof(gameObjectRef));
 
             if (!componentRef.IsValid(out var componentValidationError))
                 throw new ArgumentException(componentValidationError, nameof(componentRef));
+
+            var hasDiff = componentDiff != null;
+            var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
+            var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
+            if (!hasDiff && !hasPathPatches && !hasJsonPatch)
+                throw new ArgumentNullException(nameof(componentDiff),
+                    "At least one of 'componentDiff', 'pathPatches', or 'jsonPatch' is required. " +
+                    "Make sure the JSON input uses 'componentDiff' as the key (not 'fields' or 'props' directly), " +
+                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -87,16 +110,42 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 };
 
                 var logs = new Logs();
-                var objToModify = (object)targetComponent;
+                var objToModify = (object?)targetComponent;
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>();
 
-                var success = reflector.TryModify(
-                    ref objToModify,
-                    data: componentDiff,
-                    logs: logs,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>());
+                var anySuccess = false;
 
-                if (success)
+                // 1) JSON Patch first — applied as a single Reflector.TryPatch
+                if (hasJsonPatch)
+                {
+                    if (reflector.TryPatch(ref objToModify, jsonPatch!, logs: logs, logger: logger))
+                        anySuccess = true;
+                }
+
+                // 2) Path-scoped patches — one Reflector.TryModifyAt per entry
+                if (hasPathPatches)
+                {
+                    foreach (var patch in pathPatches!)
+                    {
+                        if (string.IsNullOrEmpty(patch.Path))
+                        {
+                            logs.Error($"PathPatch with empty path skipped.");
+                            continue;
+                        }
+                        if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs, logger: logger))
+                            anySuccess = true;
+                    }
+                }
+
+                // 3) Legacy full SerializedMember diff
+                if (hasDiff)
+                {
+                    if (reflector.TryModify(ref objToModify, data: componentDiff!, logs: logs, logger: logger))
+                        anySuccess = true;
+                }
+
+                if (anySuccess)
                 {
                     UnityEditor.EditorUtility.SetDirty(go);
                     UnityEditor.EditorUtility.SetDirty(targetComponent);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
@@ -72,10 +72,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
             var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
             if (!hasDiff && !hasPathPatches && !hasJsonPatch)
-                throw new ArgumentNullException(nameof(componentDiff),
-                    "At least one of 'componentDiff', 'pathPatches', or 'jsonPatch' is required. " +
-                    "Make sure the JSON input uses 'componentDiff' as the key (not 'fields' or 'props' directly), " +
-                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
+                throw new ArgumentNullException(paramName: null,
+                    $"At least one of '{nameof(componentDiff)}', '{nameof(pathPatches)}', or '{nameof(jsonPatch)}' is required. " +
+                    $"Make sure the JSON input uses '{nameof(componentDiff)}' as the key (not 'fields' or 'props' directly), " +
+                    $"or supply '{nameof(pathPatches)}' / '{nameof(jsonPatch)}' for path-scoped modifications.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -126,11 +126,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 // 2) Path-scoped patches — one Reflector.TryModifyAt per entry
                 if (hasPathPatches)
                 {
-                    foreach (var patch in pathPatches!)
+                    for (int i = 0; i < pathPatches!.Count; i++)
                     {
-                        if (string.IsNullOrEmpty(patch.Path))
+                        var patch = pathPatches[i];
+                        if (patch == null || string.IsNullOrEmpty(patch.Path))
                         {
-                            logs.Error($"PathPatch with empty path skipped.");
+                            logs.Error($"PathPatch[{i}] with empty path skipped.");
                             continue;
                         }
                         if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs, logger: logger))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
@@ -10,8 +10,10 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Runtime.Data;
 using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
@@ -34,7 +36,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. " +
             "If no opened Prefab it looks into current active scene. " +
             "Returns GameObject information and its children. " +
-            "Also, it returns Components preview just for the target GameObject.")]
+            "Also, it returns Components preview just for the target GameObject.\n\n" +
+            "Path-scoped reads (token-saving): supply '" + "paths" + "' (a list of paths) to read only the listed " +
+            "fields/elements via Reflector.TryReadAt, or '" + "viewQuery" + "' (a ViewQuery) to navigate to a " +
+            "subtree and/or filter by name regex / max depth / type via Reflector.View. When either is supplied, " +
+            "the result populates 'Data' on the returned GameObjectData and overrides 'includeData' (which would " +
+            "otherwise produce a full recursive serialization). " +
+            "These two parameters are mutually exclusive — supply at most one.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public GameObjectData? Find
         (
             GameObjectRef gameObjectRef,
@@ -47,9 +56,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("Include hierarchy metadata.")]
             bool includeHierarchy = false,
             [Description("Determines the depth of the hierarchy to include. 0 - means only the target GameObject. 1 - means to include one layer below.")]
-            int hierarchyDepth = 0
+            int hierarchyDepth = 0,
+            [Description("Optional. List of paths to read individually via Reflector.TryReadAt. " +
+                "When supplied, replaces 'includeData'-style full serialization with a path-scoped aggregate. " +
+                "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. " +
+                "Mutually exclusive with '" + "viewQuery" + "'.")]
+            List<string>? paths = null,
+            [Description("Optional. View-query filter routed through Reflector.View. " +
+                "When supplied, replaces 'includeData'-style full serialization with the filtered subtree. " +
+                "Mutually exclusive with '" + "paths" + "'.")]
+            ViewQuery? viewQuery = null
         )
         {
+            var hasPaths = paths != null && paths.Count > 0;
+            var hasViewQuery = viewQuery != null;
+            if (hasPaths && hasViewQuery)
+                throw new ArgumentException(
+                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+
             return MainThread.Instance.Run(() =>
             {
                 var go = gameObjectRef.FindGameObject(out var error);
@@ -60,16 +84,28 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     return null;
 
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>();
 
-                return go.ToGameObjectData(
+                // When path/view-query is supplied, suppress the legacy 'includeData' full serialization
+                // (the path-scoped result will replace it on the returned GameObjectData).
+                var includeFullData = includeData && !hasPaths && !hasViewQuery;
+
+                var data = go.ToGameObjectData(
                     reflector: reflector,
-                    includeData: includeData,
+                    includeData: includeFullData,
                     includeComponents: includeComponents,
                     includeBounds: includeBounds,
                     includeHierarchy: includeHierarchy,
                     hierarchyDepth: hierarchyDepth,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>()
+                    logger: logger
                 );
+
+                if (hasPaths)
+                    data.Data = PathReadHelper.BuildPathReadAggregate(reflector, go, go.name, paths!, logger);
+                else if (hasViewQuery)
+                    data.Data = reflector.View(go, viewQuery, logs: null, logger: logger);
+
+                return data;
             });
         }
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
@@ -72,7 +72,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasViewQuery = viewQuery != null;
             if (hasPaths && hasViewQuery)
                 throw new ArgumentException(
-                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+                    $"'{nameof(paths)}' and '{nameof(viewQuery)}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -103,7 +103,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 if (hasPaths)
                     data.Data = PathReadHelper.BuildPathReadAggregate(reflector, go, go.name, paths!, logger);
                 else if (hasViewQuery)
-                    data.Data = reflector.View(go, viewQuery, logs: null, logger: logger);
+                    data.Data = reflector.View(go, viewQuery, logs: null, logger: logger)
+                        ?? new SerializedMember { name = go.name, typeName = go.GetType().FullName ?? string.Empty };
 
                 return data;
             });

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
@@ -131,11 +131,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         var perGo = pathPatchesPerGameObject![i];
                         if (perGo != null)
                         {
-                            foreach (var patch in perGo)
+                            for (int j = 0; j < perGo.Count; j++)
                             {
+                                var patch = perGo[j];
                                 if (patch == null || string.IsNullOrEmpty(patch.Path))
                                 {
-                                    logs.Error($"Empty path patch on {nameof(gameObjectRefs)}[{i}] skipped.");
+                                    logs.Error($"{nameof(pathPatchesPerGameObject)}[{i}][{j}] with empty path skipped.");
                                     continue;
                                 }
                                 if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs, logger: logger))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -31,38 +32,70 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true
         )]
         [Description("Modify GameObject fields and properties in opened Prefab or in a Scene. " +
-            "You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects.")]
+            "You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects.\n\n" +
+            "Three modification surfaces (per GameObject — parallel arrays must have the same length as gameObjectRefs):\n" +
+            "  1. '" + "gameObjectDiffs" + "' — full SerializedMember diff per GameObject (legacy, backwards compatible).\n" +
+            "  2. '" + "pathPatchesPerGameObject" + "' — list of {path, value} patches per GameObject routed " +
+            "through Reflector.TryModifyAt; atomic per-path modification.\n" +
+            "  3. '" + "jsonPatchesPerGameObject" + "' — JSON Merge Patch per GameObject routed through " +
+            "Reflector.TryPatch.\n" +
+            "When more than one is supplied for the same GameObject they run in this order: jsonPatch → pathPatches " +
+            "→ diff. At least one of the three is required.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'.")]
         public Logs? Modify
         (
             GameObjectRefList gameObjectRefs,
-            [Description("Each item in the array represents a GameObject modification of the 'gameObjectRefs' at the same index. " +
+            [Description("Optional. Each item in the array represents a GameObject modification of the 'gameObjectRefs' at the same index. " +
                 "Usually a GameObject is a container for components. Each component may have fields and properties for modification. " +
                 "If you need to modify components of a GameObject, please use '" + GameObjectComponentModifyToolId + "' tool. " +
                 "Ignore values that should not be modified. " +
                 "Any unknown or wrong located fields and properties will be ignored. " +
                 "Check the result of this command to see what was changed. The ignored fields and properties will be listed.")]
-            SerializedMemberList gameObjectDiffs
+            SerializedMemberList? gameObjectDiffs = null,
+            [Description("Optional. Per-GameObject list of path-scoped patches routed through Reflector.TryModifyAt. " +
+                "Outer index aligns with 'gameObjectRefs'; inner list contains {path, value} entries. " +
+                "Pass null or omit for GameObjects that should not receive path patches.")]
+            List<List<PathPatch>?>? pathPatchesPerGameObject = null,
+            [Description("Optional. Per-GameObject JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) " +
+                "routed through Reflector.TryPatch. Outer index aligns with 'gameObjectRefs'. " +
+                "Pass null or omit for GameObjects that should not receive a JSON patch.")]
+            List<string?>? jsonPatchesPerGameObject = null
         )
         {
             if (gameObjectRefs == null)
                 throw new ArgumentNullException(nameof(gameObjectRefs),
                     "The 'gameObjectRefs' parameter is required. Make sure the JSON input uses 'gameObjectRefs' as the key.");
 
-            if (gameObjectDiffs == null)
-                throw new ArgumentNullException(nameof(gameObjectDiffs),
-                    "The 'gameObjectDiffs' parameter is required. Make sure the JSON input uses 'gameObjectDiffs' as the key wrapping the SerializedMember array.");
-
             if (gameObjectRefs.Count == 0)
                 throw new ArgumentException("No GameObject references provided. Please provide at least one GameObject reference.", nameof(gameObjectRefs));
 
-            if (gameObjectDiffs.Count != gameObjectRefs.Count)
-                throw new ArgumentException($"The number of {nameof(gameObjectDiffs)} and {nameof(gameObjectRefs)} should be the same. " +
-                    $"{nameof(gameObjectDiffs)}: {gameObjectDiffs.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}", nameof(gameObjectDiffs));
+            var hasDiffs = gameObjectDiffs != null && gameObjectDiffs.Count > 0;
+            var hasPathPatches = pathPatchesPerGameObject != null && pathPatchesPerGameObject.Count > 0;
+            var hasJsonPatches = jsonPatchesPerGameObject != null && jsonPatchesPerGameObject.Count > 0;
+
+            if (!hasDiffs && !hasPathPatches && !hasJsonPatches)
+                throw new ArgumentException(
+                    $"At least one of '{"gameObjectDiffs"}', '{"pathPatchesPerGameObject"}', or '{"jsonPatchesPerGameObject"}' is required.");
+
+            if (hasDiffs && gameObjectDiffs!.Count != gameObjectRefs.Count)
+                throw new ArgumentException($"The number of {"gameObjectDiffs"} and {nameof(gameObjectRefs)} should be the same. " +
+                    $"{"gameObjectDiffs"}: {gameObjectDiffs.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}", "gameObjectDiffs");
+
+            if (hasPathPatches && pathPatchesPerGameObject!.Count != gameObjectRefs.Count)
+                throw new ArgumentException($"The number of {"pathPatchesPerGameObject"} and {nameof(gameObjectRefs)} should be the same. " +
+                    $"{"pathPatchesPerGameObject"}: {pathPatchesPerGameObject.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}",
+                    "pathPatchesPerGameObject");
+
+            if (hasJsonPatches && jsonPatchesPerGameObject!.Count != gameObjectRefs.Count)
+                throw new ArgumentException($"The number of {"jsonPatchesPerGameObject"} and {nameof(gameObjectRefs)} should be the same. " +
+                    $"{"jsonPatchesPerGameObject"}: {jsonPatchesPerGameObject.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}",
+                    "jsonPatchesPerGameObject");
 
             return MainThread.Instance.Run(() =>
             {
                 var logs = new Logs();
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>();
 
                 for (int i = 0; i < gameObjectRefs.Count; i++)
                 {
@@ -78,21 +111,55 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         continue;
                     }
 
-                    if (gameObjectDiffs[i] == null)
+                    var objToModify = (object?)go;
+                    var anyChange = false;
+
+                    // 1) JSON Patch
+                    if (hasJsonPatches)
                     {
-                        logs.Error($"'{nameof(gameObjectDiffs)}[{i}]' is null. Each entry in the array must be a valid SerializedMember object.");
-                        continue;
+                        var json = jsonPatchesPerGameObject![i];
+                        if (!string.IsNullOrWhiteSpace(json))
+                        {
+                            if (reflector.TryPatch(ref objToModify, json!, logs: logs, logger: logger))
+                                anyChange = true;
+                        }
                     }
 
-                    var objToModify = (object)go;
+                    // 2) Path patches
+                    if (hasPathPatches)
+                    {
+                        var perGo = pathPatchesPerGameObject![i];
+                        if (perGo != null)
+                        {
+                            foreach (var patch in perGo)
+                            {
+                                if (patch == null || string.IsNullOrEmpty(patch.Path))
+                                {
+                                    logs.Error($"Empty path patch on {nameof(gameObjectRefs)}[{i}] skipped.");
+                                    continue;
+                                }
+                                if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs, logger: logger))
+                                    anyChange = true;
+                            }
+                        }
+                    }
 
-                    var modified = reflector.TryModify(
-                        ref objToModify,
-                        data: gameObjectDiffs[i],
-                        logs: logs,
-                        logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_GameObject>());
+                    // 3) Legacy full diff
+                    if (hasDiffs)
+                    {
+                        var diff = gameObjectDiffs![i];
+                        if (diff == null)
+                        {
+                            logs.Error($"'{"gameObjectDiffs"}[{i}]' is null. Each entry in the array must be a valid SerializedMember object.");
+                        }
+                        else
+                        {
+                            if (reflector.TryModify(ref objToModify, data: diff, logs: logs, logger: logger))
+                                anyChange = true;
+                        }
+                    }
 
-                    if (modified)
+                    if (anyChange)
                         UnityEditor.EditorUtility.SetDirty(go);
                 }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
@@ -75,21 +75,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             if (!hasDiffs && !hasPathPatches && !hasJsonPatches)
                 throw new ArgumentException(
-                    $"At least one of '{"gameObjectDiffs"}', '{"pathPatchesPerGameObject"}', or '{"jsonPatchesPerGameObject"}' is required.");
+                    $"At least one of '{nameof(gameObjectDiffs)}', '{nameof(pathPatchesPerGameObject)}', or '{nameof(jsonPatchesPerGameObject)}' is required.");
 
             if (hasDiffs && gameObjectDiffs!.Count != gameObjectRefs.Count)
-                throw new ArgumentException($"The number of {"gameObjectDiffs"} and {nameof(gameObjectRefs)} should be the same. " +
-                    $"{"gameObjectDiffs"}: {gameObjectDiffs.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}", "gameObjectDiffs");
+                throw new ArgumentException($"The number of {nameof(gameObjectDiffs)} and {nameof(gameObjectRefs)} should be the same. " +
+                    $"{nameof(gameObjectDiffs)}: {gameObjectDiffs.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}", nameof(gameObjectDiffs));
 
             if (hasPathPatches && pathPatchesPerGameObject!.Count != gameObjectRefs.Count)
-                throw new ArgumentException($"The number of {"pathPatchesPerGameObject"} and {nameof(gameObjectRefs)} should be the same. " +
-                    $"{"pathPatchesPerGameObject"}: {pathPatchesPerGameObject.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}",
-                    "pathPatchesPerGameObject");
+                throw new ArgumentException($"The number of {nameof(pathPatchesPerGameObject)} and {nameof(gameObjectRefs)} should be the same. " +
+                    $"{nameof(pathPatchesPerGameObject)}: {pathPatchesPerGameObject.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}",
+                    nameof(pathPatchesPerGameObject));
 
             if (hasJsonPatches && jsonPatchesPerGameObject!.Count != gameObjectRefs.Count)
-                throw new ArgumentException($"The number of {"jsonPatchesPerGameObject"} and {nameof(gameObjectRefs)} should be the same. " +
-                    $"{"jsonPatchesPerGameObject"}: {jsonPatchesPerGameObject.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}",
-                    "jsonPatchesPerGameObject");
+                throw new ArgumentException($"The number of {nameof(jsonPatchesPerGameObject)} and {nameof(gameObjectRefs)} should be the same. " +
+                    $"{nameof(jsonPatchesPerGameObject)}: {jsonPatchesPerGameObject.Count}, {nameof(gameObjectRefs)}: {gameObjectRefs.Count}",
+                    nameof(jsonPatchesPerGameObject));
 
             return MainThread.Instance.Run(() =>
             {
@@ -144,19 +144,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         }
                     }
 
-                    // 3) Legacy full diff
+                    // 3) Legacy full diff. A null entry at this index means "no legacy diff for
+                    // this GameObject" — perfectly valid when path/json patches cover the change.
                     if (hasDiffs)
                     {
                         var diff = gameObjectDiffs![i];
-                        if (diff == null)
-                        {
-                            logs.Error($"'{"gameObjectDiffs"}[{i}]' is null. Each entry in the array must be a valid SerializedMember object.");
-                        }
-                        else
-                        {
-                            if (reflector.TryModify(ref objToModify, data: diff, logs: logs, logger: logger))
-                                anyChange = true;
-                        }
+                        if (diff != null
+                            && reflector.TryModify(ref objToModify, data: diff, logs: logs, logger: logger))
+                            anyChange = true;
                     }
 
                     if (anyChange)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -33,10 +34,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Get data of the specified Unity Object. " +
             "Returns serialized data of the object including its properties and fields. " +
-            "If need to modify the data use '" + ObjectModifyToolId + "' tool.")]
+            "If need to modify the data use '" + ObjectModifyToolId + "' tool.\n\n" +
+            "Path-scoped reads (token-saving): supply '" + "paths" + "' (a list of paths) to read only the listed " +
+            "fields/elements via Reflector.TryReadAt, or '" + "viewQuery" + "' (a ViewQuery) to navigate to a " +
+            "subtree and/or filter by name regex / max depth / type via Reflector.View. " +
+            "These two parameters are mutually exclusive — supply at most one. " +
+            "When neither is supplied the full object is serialized as before (backwards compatible).\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public SerializedMember? GetData
         (
-            ObjectRef objectRef
+            ObjectRef objectRef,
+            [Description("Optional. List of paths to read individually via Reflector.TryReadAt. " +
+                "Each path may target a different depth. " +
+                "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. " +
+                "Mutually exclusive with '" + "viewQuery" + "'.")]
+            List<string>? paths = null,
+            [Description("Optional. View-query filter routed through Reflector.View — combines a starting Path, " +
+                "a case-insensitive NamePattern regex, MaxDepth, and an optional TypeFilter. " +
+                "Mutually exclusive with '" + "paths" + "'.")]
+            ViewQuery? viewQuery = null
         )
         {
             if (objectRef == null)
@@ -45,6 +61,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (!objectRef.IsValid(out var error))
                 throw new ArgumentException(error, nameof(objectRef));
 
+            var hasPaths = paths != null && paths.Count > 0;
+            var hasViewQuery = viewQuery != null;
+            if (hasPaths && hasViewQuery)
+                throw new ArgumentException(
+                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+
             return MainThread.Instance.Run(() =>
             {
                 var obj = objectRef.FindObject();
@@ -52,12 +74,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     throw new Exception("Not found UnityEngine.Object with provided data.");
 
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Object>();
 
+                if (hasPaths)
+                    return PathReadHelper.BuildPathReadAggregate(reflector, obj, obj.name, paths!, logger);
+
+                if (hasViewQuery)
+                    return reflector.View(obj, viewQuery, logs: null, logger: logger);
+
+                // Backwards-compatible default: full recursive serialization.
                 return reflector.Serialize(
                     obj,
                     name: obj.name,
                     recursive: true,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Object>()
+                    logger: logger
                 );
             });
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
@@ -65,7 +65,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasViewQuery = viewQuery != null;
             if (hasPaths && hasViewQuery)
                 throw new ArgumentException(
-                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+                    $"'{nameof(paths)}' and '{nameof(viewQuery)}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -80,7 +80,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     return PathReadHelper.BuildPathReadAggregate(reflector, obj, obj.name, paths!, logger);
 
                 if (hasViewQuery)
-                    return reflector.View(obj, viewQuery, logs: null, logger: logger);
+                    return reflector.View(obj, viewQuery, logs: null, logger: logger)
+                        ?? new SerializedMember { name = obj.name, typeName = obj.GetType().FullName ?? string.Empty };
 
                 // Backwards-compatible default: full recursive serialization.
                 return reflector.Serialize(

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
@@ -68,10 +68,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
             var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
             if (!hasDiff && !hasPathPatches && !hasJsonPatch)
-                throw new ArgumentNullException(nameof(objectDiff),
-                    "At least one of 'objectDiff', 'pathPatches', or 'jsonPatch' is required. " +
-                    "Make sure the JSON input uses 'objectDiff' as the key wrapping the SerializedMember object, " +
-                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
+                throw new ArgumentNullException(paramName: null,
+                    $"At least one of '{nameof(objectDiff)}', '{nameof(pathPatches)}', or '{nameof(jsonPatch)}' is required. " +
+                    $"Make sure the JSON input uses '{nameof(objectDiff)}' as the key wrapping the SerializedMember object, " +
+                    $"or supply '{nameof(pathPatches)}' / '{nameof(jsonPatch)}' for path-scoped modifications.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -94,11 +94,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 if (hasPathPatches)
                 {
-                    foreach (var patch in pathPatches!)
+                    for (int i = 0; i < pathPatches!.Count; i++)
                     {
-                        if (string.IsNullOrEmpty(patch.Path))
+                        var patch = pathPatches[i];
+                        if (patch == null || string.IsNullOrEmpty(patch.Path))
                         {
-                            logs.Error($"PathPatch with empty path skipped.");
+                            logs.Error($"PathPatch[{i}] with empty path skipped.");
                             continue;
                         }
                         if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs, logger: logger))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
@@ -33,14 +34,28 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         )]
         [Description("Modify the specified Unity Object. " +
             "Allows direct modification of object fields and properties. " +
-            "Use '" + ObjectGetDataToolId + "' first to inspect the object structure before modifying.")]
+            "Use '" + ObjectGetDataToolId + "' first to inspect the object structure before modifying.\n\n" +
+            "Three modification surfaces (use whichever fits the task):\n" +
+            "  1. '" + "objectDiff" + "' — full SerializedMember diff (legacy, backwards compatible).\n" +
+            "  2. '" + "pathPatches" + "' — list of {path, value} pairs routed through Reflector.TryModifyAt; " +
+            "atomic per-path modification, multiple entries can target different depths.\n" +
+            "  3. '" + "jsonPatch" + "' — a JSON Merge Patch (RFC 7396, extended with [i]/[key] notation) " +
+            "routed through Reflector.TryPatch; multiple fields at any depth in a single call.\n" +
+            "When more than one is supplied they run in this order: jsonPatch → pathPatches → objectDiff. " +
+            "At least one is required.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.")]
         public ModifyObjectResponse Modify
         (
             ObjectRef objectRef,
-            [Description("The object data to apply. Should contain '" + nameof(SerializedMember.fields) + "' and/or '" + nameof(SerializedMember.props) + "' with the values to modify.\n" +
+            [Description("Optional. The full object data to apply (legacy path). Should contain '" + nameof(SerializedMember.fields) + "' and/or '" + nameof(SerializedMember.props) + "' with the values to modify.\n" +
                 "Only include the fields/properties you want to change.\n" +
                 "Any unknown or invalid fields and properties will be reported in the response.")]
-            SerializedMember objectDiff
+            SerializedMember? objectDiff = null,
+            [Description("Optional. List of path-scoped patches routed through Reflector.TryModifyAt.")]
+            List<PathPatch>? pathPatches = null,
+            [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
+                "Reflector.TryPatch.")]
+            string? jsonPatch = null
         )
         {
             if (objectRef == null)
@@ -49,9 +64,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (!objectRef.IsValid(out var error))
                 throw new ArgumentException(error, nameof(objectRef));
 
-            if (objectDiff == null)
+            var hasDiff = objectDiff != null;
+            var hasPathPatches = pathPatches != null && pathPatches.Count > 0;
+            var hasJsonPatch = !string.IsNullOrWhiteSpace(jsonPatch);
+            if (!hasDiff && !hasPathPatches && !hasJsonPatch)
                 throw new ArgumentNullException(nameof(objectDiff),
-                    "The 'objectDiff' parameter is required. Make sure the JSON input uses 'objectDiff' as the key wrapping the SerializedMember object.");
+                    "At least one of 'objectDiff', 'pathPatches', or 'jsonPatch' is required. " +
+                    "Make sure the JSON input uses 'objectDiff' as the key wrapping the SerializedMember object, " +
+                    "or supply 'pathPatches' / 'jsonPatch' for path-scoped modifications.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -60,19 +80,40 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     throw new Exception($"Not found UnityEngine.Object with provided data for reference: {objectRef}.");
 
                 var logs = new Logs();
-                var objToModify = (object)obj;
+                var objToModify = (object?)obj;
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Object>();
 
-                var success = reflector.TryModify(
-                    ref objToModify,
-                    data: objectDiff,
-                    logs: logs,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Object>());
+                var anySuccess = false;
 
-                if (success)
+                if (hasJsonPatch)
                 {
-                    UnityEditor.EditorUtility.SetDirty(obj);
+                    if (reflector.TryPatch(ref objToModify, jsonPatch!, logs: logs, logger: logger))
+                        anySuccess = true;
                 }
+
+                if (hasPathPatches)
+                {
+                    foreach (var patch in pathPatches!)
+                    {
+                        if (string.IsNullOrEmpty(patch.Path))
+                        {
+                            logs.Error($"PathPatch with empty path skipped.");
+                            continue;
+                        }
+                        if (reflector.TryModifyAt(ref objToModify, patch.Path, patch.Value, logs: logs, logger: logger))
+                            anySuccess = true;
+                    }
+                }
+
+                if (hasDiff)
+                {
+                    if (reflector.TryModify(ref objToModify, data: objectDiff!, logs: logs, logger: logger))
+                        anySuccess = true;
+                }
+
+                if (anySuccess)
+                    UnityEditor.EditorUtility.SetDirty(obj);
 
                 UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
 
@@ -81,10 +122,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     obj,
                     name: obj.name,
                     recursive: true,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Object>()
+                    logger: logger
                 );
 
-                return new ModifyObjectResponse(success, logs)
+                return new ModifyObjectResponse(anySuccess, logs)
                 {
                     Reference = objectRef,
                     Data = data

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/PathReadHelper.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/PathReadHelper.cs
@@ -1,0 +1,75 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    /// <summary>
+    /// Shared helpers for path-based read tools. Centralises the construction of an aggregate
+    /// <see cref="SerializedMember"/> envelope whose <c>fields</c> mirror one
+    /// <see cref="Reflector.TryReadAt"/> call per requested path. The envelope is the same
+    /// shape callers already expect from the legacy single-call <c>Serialize</c> path, so
+    /// path-scoped reads slot in without breaking the response schema.
+    /// </summary>
+    internal static class PathReadHelper
+    {
+        public const string PathReadAggregateTypeName = "Unity-MCP.PathReadAggregate";
+
+        /// <summary>
+        /// Reads each path via <see cref="Reflector.TryReadAt"/> and aggregates the results into a single
+        /// <see cref="SerializedMember"/> envelope: top-level <c>fields[i].name</c> is the requested path,
+        /// <c>fields[i]</c> contents are the serialised value at that path. When a path fails to navigate,
+        /// the entry is replaced with a sentinel field whose name is the path and value is null; per-path
+        /// diagnostics are accumulated into <paramref name="aggregateLogs"/> for caller logging.
+        /// </summary>
+        public static SerializedMember BuildPathReadAggregate(
+            Reflector reflector,
+            object obj,
+            string? rootName,
+            IReadOnlyList<string> paths,
+            ILogger? logger)
+        {
+            var fields = new SerializedMemberList(paths.Count);
+            foreach (var path in paths)
+            {
+                var perPathLogs = new Logs();
+                if (reflector.TryReadAt(obj, path, out var member, logs: perPathLogs, logger: logger) && member != null)
+                {
+                    member.name = path;
+                    fields.Add(member);
+                }
+                else
+                {
+                    fields.Add(new SerializedMember
+                    {
+                        name = path,
+                        typeName = "<unresolved>"
+                    });
+
+                    foreach (var entry in perPathLogs)
+                        logger?.LogWarning($"[path-read] '{path}': {entry}");
+                }
+            }
+
+            return new SerializedMember
+            {
+                name = rootName,
+                typeName = PathReadAggregateTypeName,
+                fields = fields
+            };
+        }
+
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/PathReadHelper.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/PathReadHelper.cs
@@ -26,24 +26,52 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     internal static class PathReadHelper
     {
         public const string PathReadAggregateTypeName = "Unity-MCP.PathReadAggregate";
+        public const string EmptyPathTypeName = "<empty-path>";
+        public const string UnresolvedTypeName = "<unresolved>";
 
         /// <summary>
         /// Reads each path via <see cref="Reflector.TryReadAt"/> and aggregates the results into a single
         /// <see cref="SerializedMember"/> envelope: top-level <c>fields[i].name</c> is the requested path,
         /// <c>fields[i]</c> contents are the serialised value at that path. When a path fails to navigate,
-        /// the entry is replaced with a sentinel field whose name is the path and value is null; per-path
-        /// diagnostics are accumulated into <paramref name="aggregateLogs"/> for caller logging.
+        /// the entry is replaced with a sentinel field whose name is the path and value is null. Per-path
+        /// diagnostics are emitted via <paramref name="logger"/> and, when supplied, also appended to
+        /// <paramref name="aggregateLogs"/> so callers that maintain a structured log accumulator can
+        /// surface them back to the AI agent.
         /// </summary>
+        /// <param name="reflector">The reflector that performs the per-path read.</param>
+        /// <param name="obj">Object to read paths from.</param>
+        /// <param name="rootName">Optional name for the aggregate envelope.</param>
+        /// <param name="paths">Paths to read. Null or empty entries are skipped with an
+        /// <see cref="EmptyPathTypeName"/> sentinel field rather than silently navigating
+        /// the root (which would defeat the token-saving purpose of path-scoped reads).</param>
+        /// <param name="logger">Optional logger for per-path diagnostics.</param>
+        /// <param name="aggregateLogs">Optional structured log accumulator. When non-null,
+        /// per-path failure entries are appended so the caller can surface them in its response.</param>
         public static SerializedMember BuildPathReadAggregate(
             Reflector reflector,
             object obj,
             string? rootName,
             IReadOnlyList<string> paths,
-            ILogger? logger)
+            ILogger? logger,
+            Logs? aggregateLogs = null)
         {
             var fields = new SerializedMemberList(paths.Count);
-            foreach (var path in paths)
+            for (var i = 0; i < paths.Count; i++)
             {
+                var path = paths[i];
+                if (string.IsNullOrEmpty(path))
+                {
+                    fields.Add(new SerializedMember
+                    {
+                        name = path,
+                        typeName = EmptyPathTypeName
+                    });
+                    var emptyMsg = $"[path-read] paths[{i}] is empty or null and was skipped.";
+                    logger?.LogWarning(emptyMsg);
+                    aggregateLogs?.Warning(emptyMsg);
+                    continue;
+                }
+
                 var perPathLogs = new Logs();
                 if (reflector.TryReadAt(obj, path, out var member, logs: perPathLogs, logger: logger) && member != null)
                 {
@@ -55,11 +83,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     fields.Add(new SerializedMember
                     {
                         name = path,
-                        typeName = "<unresolved>"
+                        typeName = UnresolvedTypeName
                     });
 
                     foreach (var entry in perPathLogs)
-                        logger?.LogWarning($"[path-read] '{path}': {entry}");
+                    {
+                        var msg = $"[path-read] '{path}': {entry}";
+                        logger?.LogWarning(msg);
+                        aggregateLogs?.Warning(msg);
+                    }
                 }
             }
 
@@ -70,6 +102,5 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 fields = fields
             };
         }
-
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/PathReadHelper.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/PathReadHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15be297624bd4418a637c9e1762c1a43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
@@ -64,7 +64,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var hasViewQuery = viewQuery != null;
             if (hasPaths && hasViewQuery)
                 throw new ArgumentException(
-                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+                    $"'{nameof(paths)}' and '{nameof(viewQuery)}' are mutually exclusive — supply at most one.");
 
             return MainThread.Instance.Run(() =>
             {
@@ -95,7 +95,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         sceneData.Data = PathReadHelper.BuildPathReadAggregate(
                             reflector, rootGos, scene.name, paths!, logger);
                     else
-                        sceneData.Data = reflector.View(rootGos, viewQuery, logs: null, logger: logger);
+                        sceneData.Data = reflector.View(rootGos, viewQuery, logs: null, logger: logger)
+                            ?? new SerializedMember { name = scene.name, typeName = rootGos.GetType().FullName ?? string.Empty };
                 }
 
                 return sceneData;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
@@ -10,8 +10,10 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Runtime.Data;
 using com.IvanMurzak.Unity.MCP.Utils;
@@ -30,7 +32,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true
         )]
         [Description("This tool retrieves the list of root GameObjects in the specified scene. " +
-            "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.")]
+            "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
+            "Path-scoped reads (token-saving): supply '" + "paths" + "' (a list of paths) to read only the listed " +
+            "fields/elements from the scene's root-GameObjects array via Reflector.TryReadAt, or '" + "viewQuery" +
+            "' (a ViewQuery) to navigate/filter the same array via Reflector.View. The result populates 'Data' on the " +
+            "returned SceneData. These two parameters are mutually exclusive.\n" +
+            "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped. " +
+            "Example: paths=['[0]/name'] reads the name of the first root GameObject.")]
         public SceneData GetData
         (
             [Description("Name of the opened scene. If empty or null, the active scene will be used.")]
@@ -42,9 +50,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [Description("If true, includes bounding box information for GameObjects.")]
             bool includeBounds = false,
             [Description("If true, includes component data for GameObjects.")]
-            bool includeData = false
+            bool includeData = false,
+            [Description("Optional. List of paths to read individually via Reflector.TryReadAt against the scene's " +
+                "root-GameObjects array. Path syntax: 'fieldName', '[i]/field', '[i]/component/[j]/property'. " +
+                "Mutually exclusive with '" + "viewQuery" + "'.")]
+            List<string>? paths = null,
+            [Description("Optional. View-query filter routed through Reflector.View on the scene's root-GameObjects " +
+                "array. Mutually exclusive with '" + "paths" + "'.")]
+            ViewQuery? viewQuery = null
         )
         {
+            var hasPaths = paths != null && paths.Count > 0;
+            var hasViewQuery = viewQuery != null;
+            if (hasPaths && hasViewQuery)
+                throw new ArgumentException(
+                    $"'{"paths"}' and '{"viewQuery"}' are mutually exclusive — supply at most one.");
+
             return MainThread.Instance.Run(() =>
             {
                 var scene = string.IsNullOrEmpty(openedSceneName)
@@ -55,16 +76,29 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     throw new ArgumentException(Error.NotFoundSceneWithName(openedSceneName));
 
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var logger = UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Scene>();
 
-                return new SceneData(
+                var sceneData = new SceneData(
                     scene: scene,
                     reflector: reflector,
                     includeRootGameObjects: includeRootGameObjects,
                     includeChildrenDepth: includeChildrenDepth,
                     includeBounds: includeBounds,
                     includeData: includeData,
-                    logger: UnityLoggerFactory.LoggerFactory.CreateLogger<Tool_Scene>()
+                    logger: logger
                 );
+
+                if (hasPaths || hasViewQuery)
+                {
+                    var rootGos = scene.GetRootGameObjects();
+                    if (hasPaths)
+                        sceneData.Data = PathReadHelper.BuildPathReadAggregate(
+                            reflector, rootGos, scene.name, paths!, logger);
+                    else
+                        sceneData.Data = reflector.View(rootGos, viewQuery, logs: null, logger: logger);
+                }
+
+                return sceneData;
             });
         }
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/PathPatch.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/PathPatch.cs
@@ -30,11 +30,22 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Data
             "Required.")]
         public string Path { get; set; } = string.Empty;
 
+        /// <summary>
+        /// The new value to write at <see cref="Path"/>.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>new SerializedMember()</c> so JSON deserialisation of a payload that
+        /// omits <c>Value</c> still produces a non-null instance — but writing that default is
+        /// almost certainly a mistake (it would replace the target with an empty
+        /// <see cref="SerializedMember"/>). Always populate <see cref="Value"/> explicitly with
+        /// the standard envelope (<c>typeName</c> + <c>value</c> for primitives, or nested
+        /// <c>fields</c>/<c>props</c> for complex types) before passing the patch to a tool.
+        /// </remarks>
         [Description(
             "The new value to write at the path. " +
             "Use the standard SerializedMember envelope: 'typeName' + 'value' for primitives, " +
             "or nested 'fields'/'props' for complex types. " +
-            "Required.")]
+            "Required — omitting it overwrites the target with a default empty SerializedMember.")]
         public SerializedMember Value { get; set; } = new SerializedMember();
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/PathPatch.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/PathPatch.cs
@@ -1,0 +1,40 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.ReflectorNet.Model;
+
+namespace com.IvanMurzak.Unity.MCP.Runtime.Data
+{
+    /// <summary>
+    /// A single path-scoped modification routed through
+    /// <see cref="com.IvanMurzak.ReflectorNet.Reflector.TryModifyAt(ref object?, string, SerializedMember, System.Type?, int, com.IvanMurzak.ReflectorNet.Model.Logs?, System.Reflection.BindingFlags, Microsoft.Extensions.Logging.ILogger?)"/>.
+    /// Each entry targets one field, array element, or dictionary entry by path.
+    /// </summary>
+    public class PathPatch
+    {
+        [Description(
+            "Slash-delimited path to the target field/element/entry. " +
+            "Plain segment navigates a field or property (e.g. 'admin' or 'admin/name'). " +
+            "Use '[i]' for array/list index (e.g. 'planets/[0]/orbitRadius'). " +
+            "Use '[key]' for dictionary entry (e.g. 'config/[timeout]'). " +
+            "A leading '#/' is stripped automatically. " +
+            "Required.")]
+        public string Path { get; set; } = string.Empty;
+
+        [Description(
+            "The new value to write at the path. " +
+            "Use the standard SerializedMember envelope: 'typeName' + 'value' for primitives, " +
+            "or nested 'fields'/'props' for complex types. " +
+            "Required.")]
+        public SerializedMember Value { get; set; } = new SerializedMember();
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/PathPatch.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/PathPatch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d9a16fe287a4cb0ba9b6b5eb43595f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/SceneData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Data/SceneData.cs
@@ -10,8 +10,10 @@
 
 #nullable enable
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
 using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.Unity.MCP.Runtime.Data
@@ -19,6 +21,10 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Data
     public class SceneData : SceneDataShallow
     {
         public List<GameObjectData>? RootGameObjects { get; set; } = null;
+
+        [Description("Path-scoped read or view-query result, populated when 'paths' or 'viewQuery' is supplied " +
+            "to the scene-get-data tool. Null otherwise.")]
+        public SerializedMember? Data { get; set; } = null;
 
         public SceneData() { }
         public SceneData(

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.cs
@@ -1,0 +1,413 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+#if UNITY_6000_5_OR_NEWER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Editor.Extensions;
+using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// EditMode coverage for the ReflectorNet 5.1.0 path-based read/modify API
+    /// adoption across the MCP tools — see issue #691 / PR adopting <c>TryReadAt</c>,
+    /// <c>TryModifyAt</c>, <c>TryPatch</c>, and <c>View</c>.
+    ///
+    /// Each test exercises one scenario from the acceptance criteria:
+    ///   * single-path read,
+    ///   * multi-path read,
+    ///   * view-query with name regex,
+    ///   * single-path modify,
+    ///   * multi-field JSON Patch,
+    ///   * partial array-element modify,
+    ///   * invalid path → structured error.
+    ///
+    /// The fixture uses the production-shaped <see cref="SolarSystem"/> MonoBehaviour
+    /// (defined under <c>TestFiles/Scripts</c>) so tests reflect the exact reflection
+    /// surface the AI agent will hit at runtime.
+    /// </summary>
+    public class PathBasedToolTests : BaseTest
+    {
+        [UnitySetUp]
+        public override IEnumerator SetUp() => base.SetUp();
+
+        [UnityTearDown]
+        public override IEnumerator TearDown() => base.TearDown();
+
+        Reflector Reflector =>
+            UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+
+        /// <summary>
+        /// Builds a SolarSystem fixture with one configured planet so path-based
+        /// reads/modifies have something concrete to walk into.
+        /// </summary>
+        (GameObject go, SolarSystem solar, GameObject sun, GameObject earth) BuildSolarFixture()
+        {
+            var sun = new GameObject("Sun");
+            var earth = new GameObject("Earth");
+            var go = new GameObject("Solar");
+            var solar = go.AddComponent<SolarSystem>();
+            solar.sun = sun;
+            solar.globalOrbitSpeedMultiplier = 1f;
+            solar.globalSizeMultiplier = 1f;
+            solar.planets = new[]
+            {
+                new SolarSystem.PlanetData
+                {
+                    planet = earth,
+                    orbitRadius = 10f,
+                    orbitSpeed = 1f,
+                    rotationSpeed = 1f,
+                    orbitTilt = Vector3.zero
+                }
+            };
+            return (go, solar, sun, earth);
+        }
+
+        // ─── 1. Single-path read via gameobject-component-get ──────────────────
+
+        [UnityTest]
+        public IEnumerator ComponentGet_SinglePath_ReturnsOnlyTheRequestedField()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                paths: new List<string> { "globalOrbitSpeedMultiplier" });
+
+            Assert.IsNotNull(response.View, "View should be populated for a path-scoped read.");
+            Assert.AreEqual(PathReadHelper.PathReadAggregateTypeName, response.View!.typeName);
+            Assert.IsNull(response.Fields, "Legacy Fields list should be skipped on path-scoped path.");
+            Assert.IsNull(response.Properties, "Legacy Properties list should be skipped on path-scoped path.");
+
+            var only = response.View.fields?.SingleOrDefault(f => f.name == "globalOrbitSpeedMultiplier");
+            Assert.IsNotNull(only, "The aggregate must contain exactly one field named 'globalOrbitSpeedMultiplier'.");
+            Assert.AreEqual(1f, only!.GetValue<float>(Reflector));
+            yield return null;
+        }
+
+        // ─── 2. Multi-path read via gameobject-component-get ───────────────────
+
+        [UnityTest]
+        public IEnumerator ComponentGet_MultiPath_ReturnsAllRequestedFields()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                paths: new List<string>
+                {
+                    "globalOrbitSpeedMultiplier",
+                    "globalSizeMultiplier",
+                    "planets/[0]/orbitRadius"
+                });
+
+            Assert.IsNotNull(response.View);
+            Assert.AreEqual(3, response.View!.fields?.Count, "Expected 3 entries — one per requested path.");
+            var byName = response.View!.fields!.ToDictionary(f => f.name!, f => f);
+            Assert.AreEqual(1f,  byName["globalOrbitSpeedMultiplier"].GetValue<float>(Reflector));
+            Assert.AreEqual(1f,  byName["globalSizeMultiplier"].GetValue<float>(Reflector));
+            Assert.AreEqual(10f, byName["planets/[0]/orbitRadius"].GetValue<float>(Reflector));
+            yield return null;
+        }
+
+        // ─── 3. View-query with name regex via gameobject-component-get ────────
+
+        [UnityTest]
+        public IEnumerator ComponentGet_ViewQuery_NameRegex_KeepsOnlyMatchingBranches()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                viewQuery: new ViewQuery { NamePattern = "orbit.*" });
+
+            Assert.IsNotNull(response.View, "View should be populated for a view-query read.");
+
+            // SolarSystem has globalOrbitSpeedMultiplier at root, plus orbitRadius / orbitSpeed
+            // / orbitTilt on PlanetData. Any of these contain 'orbit' (case-insensitive).
+            var rx = new Regex("orbit", RegexOptions.IgnoreCase);
+            Assert.IsTrue(ContainsNameMatching(response.View!, rx),
+                $"View result should retain at least one field/property whose name contains 'orbit'.");
+            yield return null;
+        }
+
+        static bool ContainsNameMatching(SerializedMember m, Regex rx)
+        {
+            if (m.name != null && rx.IsMatch(m.name)) return true;
+            if (m.fields != null)
+                foreach (var f in m.fields) if (ContainsNameMatching(f, rx)) return true;
+            if (m.props != null)
+                foreach (var p in m.props) if (ContainsNameMatching(p, rx)) return true;
+            return false;
+        }
+
+        // ─── 4. Single-path modify via gameobject-component-modify ─────────────
+
+        [UnityTest]
+        public IEnumerator ComponentModify_SinglePath_AtomicallyUpdatesScalar()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "globalOrbitSpeedMultiplier",
+                        Value = SerializedMember.FromValue<float>(Reflector, 5f)
+                    }
+                });
+
+            Assert.IsTrue(response.Success, $"Modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(5f, solar.globalOrbitSpeedMultiplier);
+            // Untouched field should still be the original value.
+            Assert.AreEqual(1f, solar.globalSizeMultiplier);
+            yield return null;
+        }
+
+        // ─── 5. Multi-field JSON Patch via gameobject-component-modify ─────────
+
+        [UnityTest]
+        public IEnumerator ComponentModify_JsonPatch_UpdatesMultipleFieldsAtOnce()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                jsonPatch: "{\"globalOrbitSpeedMultiplier\": 7.5, \"globalSizeMultiplier\": 3.25}");
+
+            Assert.IsTrue(response.Success, $"JSON-patch modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(7.5f, solar.globalOrbitSpeedMultiplier);
+            Assert.AreEqual(3.25f, solar.globalSizeMultiplier);
+            yield return null;
+        }
+
+        // ─── 6. Partial array-element modify via gameobject-component-modify ───
+
+        [UnityTest]
+        public IEnumerator ComponentModify_PartialArrayElement_UpdatesOneFieldOnTargetElement()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+            // Sanity — planets[0] starts at orbitRadius=10
+            Assert.AreEqual(10f, solar.planets[0].orbitRadius);
+            var earthRef = solar.planets[0].planet; // capture so we can assert it survives
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "planets/[0]/orbitRadius",
+                        Value = SerializedMember.FromValue<float>(Reflector, 42f)
+                    }
+                });
+
+            Assert.IsTrue(response.Success, $"Partial array-element modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(42f, solar.planets[0].orbitRadius,
+                "orbitRadius on the targeted element should be updated.");
+            Assert.AreEqual(1f, solar.planets[0].orbitSpeed,
+                "Sibling field on the same element should be untouched (no whole-element replacement).");
+            Assert.IsTrue(solar.planets[0].planet == earthRef,
+                "GameObject reference on the same element should be untouched.");
+            yield return null;
+        }
+
+        // ─── 7. Invalid path → structured error (no exception) ─────────────────
+
+        [UnityTest]
+        public IEnumerator ComponentModify_InvalidPath_ReportsStructuredError()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+            var before = solar.globalOrbitSpeedMultiplier;
+
+            // Reflector surfaces the unknown-segment failure as a Unity LogError via the bound
+            // logger. Tell Unity's test framework we expect that error so it does not fail the test.
+            UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Error,
+                new Regex("thisFieldDoesNotExist", RegexOptions.IgnoreCase));
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "thisFieldDoesNotExist",
+                        Value = SerializedMember.FromValue<float>(Reflector, 999f)
+                    }
+                });
+
+            Assert.IsFalse(response.Success,
+                "Modify should report failure when every path patch fails.");
+            Assert.IsTrue(response.Logs != null && response.Logs.Length > 0,
+                "Failure must surface diagnostic logs.");
+            var combined = string.Join("\n", response.Logs!);
+            StringAssert.Contains("thisFieldDoesNotExist", combined,
+                "Diagnostic logs should name the failing path so the AI agent can correct itself.");
+            Assert.AreEqual(before, solar.globalOrbitSpeedMultiplier,
+                "No untouched field should mutate when the only patch fails.");
+            yield return null;
+        }
+
+        // ─── 8. object-get-data path-scoped read ──────────────────────────────
+
+        [UnityTest]
+        public IEnumerator ObjectGetData_SinglePath_ReturnsFilteredAggregate()
+        {
+            var go = new GameObject("Probe") { tag = "Untagged" };
+            var result = new Tool_Object().GetData(
+                new ObjectRef(go),
+                paths: new List<string> { "name" });
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(PathReadHelper.PathReadAggregateTypeName, result!.typeName);
+            var nameField = result.fields?.SingleOrDefault(f => f.name == "name");
+            Assert.IsNotNull(nameField);
+            Assert.AreEqual("Probe", nameField!.GetValue<string>(Reflector));
+            yield return null;
+        }
+
+        // ─── 9. object-modify path-patch ──────────────────────────────────────
+
+        [UnityTest]
+        public IEnumerator ObjectModify_PathPatch_UpdatesGameObjectName()
+        {
+            var go = new GameObject("OldName");
+            var response = new Tool_Object().Modify(
+                new ObjectRef(go),
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "name",
+                        Value = SerializedMember.FromValue<string>(Reflector, "NewName")
+                    }
+                });
+
+            Assert.IsTrue(response.Success, $"Path-patch modify on UnityEngine.Object should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual("NewName", go.name);
+            yield return null;
+        }
+
+        // ─── 10. gameobject-modify per-GameObject path patches ────────────────
+
+        [UnityTest]
+        public IEnumerator GameObjectModify_PerGameObjectPathPatches_ParallelArrays()
+        {
+            var go1 = new GameObject("First");
+            var go2 = new GameObject("Second");
+
+            var refs = new GameObjectRefList { new GameObjectRef(go1.GetEntityId()), new GameObjectRef(go2.GetEntityId()) };
+            var perGo = new List<List<PathPatch>?>
+            {
+                new List<PathPatch>
+                {
+                    new PathPatch { Path = "name", Value = SerializedMember.FromValue<string>(Reflector, "FirstRenamed") }
+                },
+                new List<PathPatch>
+                {
+                    new PathPatch { Path = "name", Value = SerializedMember.FromValue<string>(Reflector, "SecondRenamed") }
+                }
+            };
+
+            var logs = new Tool_GameObject().Modify(
+                gameObjectRefs: refs,
+                pathPatchesPerGameObject: perGo);
+
+            Assert.IsNotNull(logs);
+            Assert.AreEqual("FirstRenamed", go1.name);
+            Assert.AreEqual("SecondRenamed", go2.name);
+            yield return null;
+        }
+
+        // ─── 11. assets-get-data with viewQuery — scoped to an actual asset ───
+
+        [UnityTest]
+        public IEnumerator AssetsGetData_ViewQuery_FiltersByMaxDepth()
+        {
+            var folder = "Assets/PathBasedToolTests";
+            var assetPath = $"{folder}/Mat.mat";
+            if (!AssetDatabase.IsValidFolder(folder))
+                AssetDatabase.CreateFolder("Assets", "PathBasedToolTests");
+
+            var material = new Material(Shader.Find("Standard"));
+            AssetDatabase.CreateAsset(material, assetPath);
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            try
+            {
+                var result = new Tool_Assets().GetData(
+                    new AssetObjectRef(material),
+                    viewQuery: new ViewQuery { MaxDepth = 0 });
+
+                Assert.IsNotNull(result, "View result should not be null.");
+                Assert.IsTrue(result.fields == null || result.fields.Count == 0,
+                    "MaxDepth=0 should strip all nested fields from the view.");
+                Assert.IsTrue(result.props == null || result.props.Count == 0,
+                    "MaxDepth=0 should strip all nested properties from the view.");
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(assetPath);
+                AssetDatabase.DeleteAsset(folder);
+                AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            }
+            yield return null;
+        }
+
+        // ─── 12. legacy code path still works (regression guard) ──────────────
+
+        [UnityTest]
+        public IEnumerator ComponentGet_NoPathParams_StillReturnsLegacyFieldsList()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            // Pass deepSerialization: true so the legacy Serialize call walks into the SolarSystem
+            // user-defined fields. With deepSerialization: false (default) primitive-only top-level
+            // may produce a null 'fields' list — that is correct legacy serializer behaviour and
+            // not what we are asserting here; this regression test is about the *path-based change*
+            // not accidentally suppressing the legacy fields surface.
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                deepSerialization: true);
+
+            Assert.IsNull(response.View, "Legacy code path must NOT populate 'View'.");
+            var fieldCount = response.Fields?.Count ?? 0;
+            var propCount = response.Properties?.Count ?? 0;
+            Assert.IsTrue(fieldCount + propCount > 0,
+                $"Expected the legacy code path to surface at least one serialised member. " +
+                $"Fields={fieldCount} Properties={propCount}");
+            yield return null;
+        }
+    }
+}
+#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.cs
@@ -408,6 +408,153 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 $"Fields={fieldCount} Properties={propCount}");
             yield return null;
         }
+
+        // ─── 13. paths AND viewQuery simultaneously → ArgumentException ────────
+
+        [UnityTest]
+        public IEnumerator ComponentGet_PathsAndViewQueryTogether_ThrowsArgumentException()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                new Tool_GameObject().GetComponent(
+                    gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                    componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                    paths: new List<string> { "globalOrbitSpeedMultiplier" },
+                    viewQuery: new ViewQuery { NamePattern = "orbit.*" }));
+
+            Assert.IsNotNull(ex);
+            StringAssert.Contains("mutually exclusive", ex!.Message);
+            yield return null;
+        }
+
+        // ─── 14. pathPatches with a null element → no NRE, structured log ─────
+
+        [UnityTest]
+        public IEnumerator ComponentModify_PathPatches_WithNullElement_DoesNotThrow_AndLogsSkip()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    null!,
+                    new PathPatch
+                    {
+                        Path = "globalOrbitSpeedMultiplier",
+                        Value = SerializedMember.FromValue<float>(Reflector, 11f)
+                    }
+                });
+
+            Assert.IsTrue(response.Success,
+                $"At least one of the patches succeeded; overall result should be Success. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(11f, solar.globalOrbitSpeedMultiplier);
+            var combined = string.Join("\n", response.Logs ?? Array.Empty<string>());
+            StringAssert.Contains("PathPatch[0]", combined,
+                "The skip log must reference the failing patch index, not just say 'a patch was skipped'.");
+            yield return null;
+        }
+
+        // ─── 15. paths with empty/null entry → no full-object dump ────────────
+
+        [UnityTest]
+        public IEnumerator ComponentGet_PathsWithEmptyEntry_DoesNotSerializeWholeObject()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                paths: new List<string> { "", "globalOrbitSpeedMultiplier" });
+
+            Assert.IsNotNull(response.View);
+            Assert.AreEqual(2, response.View!.fields?.Count, "Empty path is reflected as its own sentinel field.");
+            var emptyEntry = response.View!.fields![0];
+            Assert.AreEqual(PathReadHelper.EmptyPathTypeName, emptyEntry.typeName,
+                "Empty path entry must surface the <empty-path> sentinel rather than serializing the whole object.");
+            // Sanity — the second path still resolved
+            var resolved = response.View!.fields![1];
+            Assert.AreEqual("globalOrbitSpeedMultiplier", resolved.name);
+            yield return null;
+        }
+
+        // ─── 16. routing order jsonPatch → pathPatches → diff ─────────────────
+
+        [UnityTest]
+        public IEnumerator ComponentModify_AllThreeSurfaces_ApplyInDocumentedOrder()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+            // Three distinct fields, one per surface, so we can assert all three landed
+            // and that none of them stomped on the others.
+
+            // Build the legacy diff via the same factory used by every other ModifyComponent
+            // test in the repo (TestToolGameObject.ModifyComponent.cs#36–53). The component
+            // already exists; we wrap a ComponentRef as the root value and AddField the change.
+            var diff = SerializedMember.FromValue(
+                    reflector: Reflector,
+                    name: null,
+                    type: typeof(SolarSystem),
+                    value: new ComponentRef { TypeName = typeof(SolarSystem).FullName! })
+                .AddField(SerializedMember.FromValue(
+                    reflector: Reflector,
+                    name: "globalSizeMultiplier",
+                    type: typeof(float),
+                    value: 99f));
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                componentDiff: diff,
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "planets/[0]/orbitRadius",
+                        Value = SerializedMember.FromValue<float>(Reflector, 77f)
+                    }
+                },
+                jsonPatch: "{\"globalOrbitSpeedMultiplier\": 33.0}");
+
+            Assert.IsTrue(response.Success, $"Combined modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(33f, solar.globalOrbitSpeedMultiplier, "JSON patch should have set the orbit-speed multiplier.");
+            Assert.AreEqual(77f, solar.planets[0].orbitRadius,    "Path patch should have set the planet's orbit radius.");
+            Assert.AreEqual(99f, solar.globalSizeMultiplier,      "Legacy diff should have set the size multiplier.");
+            yield return null;
+        }
+
+        // ─── 17. parallel-array length mismatch on GameObject.Modify ──────────
+
+        [UnityTest]
+        public IEnumerator GameObjectModify_PathPatchesPerGameObject_LengthMismatch_ThrowsArgumentException()
+        {
+            var go1 = new GameObject("First");
+            var go2 = new GameObject("Second");
+            var refs = new GameObjectRefList { new GameObjectRef(go1.GetEntityId()), new GameObjectRef(go2.GetEntityId()) };
+
+            // Only 1 entry for 2 GameObjectRefs — must throw.
+            var perGo = new List<List<PathPatch>?>
+            {
+                new List<PathPatch>
+                {
+                    new PathPatch { Path = "name", Value = SerializedMember.FromValue<string>(Reflector, "Solo") }
+                }
+            };
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                new Tool_GameObject().Modify(gameObjectRefs: refs, pathPatchesPerGameObject: perGo));
+            Assert.IsNotNull(ex);
+            Assert.AreEqual("pathPatchesPerGameObject", ex!.ParamName);
+
+            // Same for jsonPatchesPerGameObject — supply 1 patch for 2 refs.
+            var jsonPatches = new List<string?> { "{\"name\":\"Solo\"}" };
+            var ex2 = Assert.Throws<ArgumentException>(() =>
+                new Tool_GameObject().Modify(gameObjectRefs: refs, jsonPatchesPerGameObject: jsonPatches));
+            Assert.IsNotNull(ex2);
+            Assert.AreEqual("jsonPatchesPerGameObject", ex2!.ParamName);
+            yield return null;
+        }
     }
 }
 #endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 790f6d9a9a384c57af35ec575b5ada14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.pre-Unity.6.5.cs
@@ -1,0 +1,373 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+#if !UNITY_6000_5_OR_NEWER
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using com.IvanMurzak.ReflectorNet;
+using com.IvanMurzak.ReflectorNet.Model;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using com.IvanMurzak.Unity.MCP.Runtime.Data;
+using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// EditMode coverage for the ReflectorNet 5.1.0 path-based read/modify API
+    /// adoption across the MCP tools — see issue #691 / PR adopting <c>TryReadAt</c>,
+    /// <c>TryModifyAt</c>, <c>TryPatch</c>, and <c>View</c>.
+    ///
+    /// pre-Unity.6.5 variant of <see cref="PathBasedToolTests"/>: this Unity build
+    /// uses <c>GetInstanceID()</c> instead of the Unity 6.5+ <c>GetEntityId()</c>
+    /// helper. Test bodies are otherwise identical so reviewers can correlate the
+    /// two files line-for-line.
+    /// </summary>
+    public class PathBasedToolTests : BaseTest
+    {
+        [UnitySetUp]
+        public override IEnumerator SetUp() => base.SetUp();
+
+        [UnityTearDown]
+        public override IEnumerator TearDown() => base.TearDown();
+
+        Reflector Reflector =>
+            UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+
+        (GameObject go, SolarSystem solar, GameObject sun, GameObject earth) BuildSolarFixture()
+        {
+            var sun = new GameObject("Sun");
+            var earth = new GameObject("Earth");
+            var go = new GameObject("Solar");
+            var solar = go.AddComponent<SolarSystem>();
+            solar.sun = sun;
+            solar.globalOrbitSpeedMultiplier = 1f;
+            solar.globalSizeMultiplier = 1f;
+            solar.planets = new[]
+            {
+                new SolarSystem.PlanetData
+                {
+                    planet = earth,
+                    orbitRadius = 10f,
+                    orbitSpeed = 1f,
+                    rotationSpeed = 1f,
+                    orbitTilt = Vector3.zero
+                }
+            };
+            return (go, solar, sun, earth);
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentGet_SinglePath_ReturnsOnlyTheRequestedField()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                paths: new List<string> { "globalOrbitSpeedMultiplier" });
+
+            Assert.IsNotNull(response.View);
+            Assert.AreEqual(PathReadHelper.PathReadAggregateTypeName, response.View!.typeName);
+            Assert.IsNull(response.Fields);
+            Assert.IsNull(response.Properties);
+
+            var only = response.View.fields?.SingleOrDefault(f => f.name == "globalOrbitSpeedMultiplier");
+            Assert.IsNotNull(only);
+            Assert.AreEqual(1f, only!.GetValue<float>(Reflector));
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentGet_MultiPath_ReturnsAllRequestedFields()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                paths: new List<string>
+                {
+                    "globalOrbitSpeedMultiplier",
+                    "globalSizeMultiplier",
+                    "planets/[0]/orbitRadius"
+                });
+
+            Assert.IsNotNull(response.View);
+            Assert.AreEqual(3, response.View!.fields?.Count);
+            var byName = response.View!.fields!.ToDictionary(f => f.name!, f => f);
+            Assert.AreEqual(1f,  byName["globalOrbitSpeedMultiplier"].GetValue<float>(Reflector));
+            Assert.AreEqual(1f,  byName["globalSizeMultiplier"].GetValue<float>(Reflector));
+            Assert.AreEqual(10f, byName["planets/[0]/orbitRadius"].GetValue<float>(Reflector));
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentGet_ViewQuery_NameRegex_KeepsOnlyMatchingBranches()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                viewQuery: new ViewQuery { NamePattern = "orbit.*" });
+
+            Assert.IsNotNull(response.View, "View should be populated for a view-query read.");
+
+            // The regex 'orbit.*' should keep at least one matching name in the tree.
+            // SolarSystem has globalOrbitSpeedMultiplier at root, plus orbitRadius / orbitSpeed
+            // / orbitTilt on PlanetData. Any of these contain 'orbit' (case-insensitive).
+            var rx = new Regex("orbit", RegexOptions.IgnoreCase);
+            Assert.IsTrue(ContainsNameMatching(response.View!, rx),
+                $"View result should retain at least one field/property whose name contains 'orbit'.");
+            yield return null;
+        }
+
+        static bool ContainsNameMatching(SerializedMember m, Regex rx)
+        {
+            if (m.name != null && rx.IsMatch(m.name)) return true;
+            if (m.fields != null)
+                foreach (var f in m.fields) if (ContainsNameMatching(f, rx)) return true;
+            if (m.props != null)
+                foreach (var p in m.props) if (ContainsNameMatching(p, rx)) return true;
+            return false;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentModify_SinglePath_AtomicallyUpdatesScalar()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "globalOrbitSpeedMultiplier",
+                        Value = SerializedMember.FromValue<float>(Reflector, 5f)
+                    }
+                });
+
+            Assert.IsTrue(response.Success, $"Modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(5f, solar.globalOrbitSpeedMultiplier);
+            Assert.AreEqual(1f, solar.globalSizeMultiplier);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentModify_JsonPatch_UpdatesMultipleFieldsAtOnce()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                jsonPatch: "{\"globalOrbitSpeedMultiplier\": 7.5, \"globalSizeMultiplier\": 3.25}");
+
+            Assert.IsTrue(response.Success, $"JSON-patch modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(7.5f, solar.globalOrbitSpeedMultiplier);
+            Assert.AreEqual(3.25f, solar.globalSizeMultiplier);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentModify_PartialArrayElement_UpdatesOneFieldOnTargetElement()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+            Assert.AreEqual(10f, solar.planets[0].orbitRadius);
+            var earthRef = solar.planets[0].planet;
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "planets/[0]/orbitRadius",
+                        Value = SerializedMember.FromValue<float>(Reflector, 42f)
+                    }
+                });
+
+            Assert.IsTrue(response.Success, $"Partial array-element modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(42f, solar.planets[0].orbitRadius);
+            Assert.AreEqual(1f, solar.planets[0].orbitSpeed);
+            Assert.IsTrue(solar.planets[0].planet == earthRef);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentModify_InvalidPath_ReportsStructuredError()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+            var before = solar.globalOrbitSpeedMultiplier;
+
+            // Reflector surfaces the unknown-segment failure as a Unity LogError via the bound
+            // logger. Tell Unity's test framework we expect that error so it does not fail the test.
+            UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Error,
+                new Regex("thisFieldDoesNotExist", RegexOptions.IgnoreCase));
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "thisFieldDoesNotExist",
+                        Value = SerializedMember.FromValue<float>(Reflector, 999f)
+                    }
+                });
+
+            Assert.IsFalse(response.Success,
+                "Modify should report failure when every path patch fails.");
+            Assert.IsTrue(response.Logs != null && response.Logs.Length > 0,
+                "Failure must surface diagnostic logs.");
+            var combined = string.Join("\n", response.Logs!);
+            StringAssert.Contains("thisFieldDoesNotExist", combined,
+                "Diagnostic logs should name the failing path so the AI agent can correct itself.");
+            Assert.AreEqual(before, solar.globalOrbitSpeedMultiplier,
+                "No untouched field should mutate when the only patch fails.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ObjectGetData_SinglePath_ReturnsFilteredAggregate()
+        {
+            var go = new GameObject("Probe") { tag = "Untagged" };
+            var result = new Tool_Object().GetData(
+                new ObjectRef(go),
+                paths: new List<string> { "name" });
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(PathReadHelper.PathReadAggregateTypeName, result!.typeName);
+            var nameField = result.fields?.SingleOrDefault(f => f.name == "name");
+            Assert.IsNotNull(nameField);
+            Assert.AreEqual("Probe", nameField!.GetValue<string>(Reflector));
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ObjectModify_PathPatch_UpdatesGameObjectName()
+        {
+            var go = new GameObject("OldName");
+            var response = new Tool_Object().Modify(
+                new ObjectRef(go),
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "name",
+                        Value = SerializedMember.FromValue<string>(Reflector, "NewName")
+                    }
+                });
+
+            Assert.IsTrue(response.Success, $"Path-patch modify on UnityEngine.Object should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual("NewName", go.name);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator GameObjectModify_PerGameObjectPathPatches_ParallelArrays()
+        {
+            var go1 = new GameObject("First");
+            var go2 = new GameObject("Second");
+
+            var refs = new GameObjectRefList { new GameObjectRef(go1.GetInstanceID()), new GameObjectRef(go2.GetInstanceID()) };
+            var perGo = new List<List<PathPatch>?>
+            {
+                new List<PathPatch>
+                {
+                    new PathPatch { Path = "name", Value = SerializedMember.FromValue<string>(Reflector, "FirstRenamed") }
+                },
+                new List<PathPatch>
+                {
+                    new PathPatch { Path = "name", Value = SerializedMember.FromValue<string>(Reflector, "SecondRenamed") }
+                }
+            };
+
+            var logs = new Tool_GameObject().Modify(
+                gameObjectRefs: refs,
+                pathPatchesPerGameObject: perGo);
+
+            Assert.IsNotNull(logs);
+            Assert.AreEqual("FirstRenamed", go1.name);
+            Assert.AreEqual("SecondRenamed", go2.name);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator AssetsGetData_ViewQuery_FiltersByMaxDepth()
+        {
+            var folder = "Assets/PathBasedToolTests";
+            var assetPath = $"{folder}/Mat.mat";
+            if (!AssetDatabase.IsValidFolder(folder))
+                AssetDatabase.CreateFolder("Assets", "PathBasedToolTests");
+
+            var material = new Material(Shader.Find("Standard"));
+            AssetDatabase.CreateAsset(material, assetPath);
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            try
+            {
+                var result = new Tool_Assets().GetData(
+                    new AssetObjectRef(material),
+                    viewQuery: new ViewQuery { MaxDepth = 0 });
+
+                Assert.IsNotNull(result);
+                Assert.IsTrue(result.fields == null || result.fields.Count == 0);
+                Assert.IsTrue(result.props == null || result.props.Count == 0);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(assetPath);
+                AssetDatabase.DeleteAsset(folder);
+                AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            }
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentGet_NoPathParams_StillReturnsLegacyFieldsList()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            // Pass deepSerialization: true so the legacy Serialize call walks into the SolarSystem
+            // user-defined fields (sun, planets, globalOrbitSpeedMultiplier, globalSizeMultiplier).
+            // With deepSerialization: false (default) primitive-only top-level may produce a null
+            // 'fields' list — that is correct behaviour for the legacy serializer and not what
+            // we are asserting here; this regression test is about the *path-based change* not
+            // accidentally suppressing the legacy fields surface.
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                deepSerialization: true);
+
+            Assert.IsNull(response.View, "Legacy code path must NOT populate 'View'.");
+            // Legacy code path produced *some* serialised output. Either Fields or Properties
+            // (or both) must be non-null and contain at least one entry.
+            var fieldCount = response.Fields?.Count ?? 0;
+            var propCount = response.Properties?.Count ?? 0;
+            Assert.IsTrue(fieldCount + propCount > 0,
+                $"Expected the legacy code path to surface at least one serialised member. " +
+                $"Fields={fieldCount} Properties={propCount}");
+            yield return null;
+        }
+    }
+}
+#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.pre-Unity.6.5.cs
@@ -368,6 +368,133 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 $"Fields={fieldCount} Properties={propCount}");
             yield return null;
         }
+
+        [UnityTest]
+        public IEnumerator ComponentGet_PathsAndViewQueryTogether_ThrowsArgumentException()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                new Tool_GameObject().GetComponent(
+                    gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                    componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                    paths: new List<string> { "globalOrbitSpeedMultiplier" },
+                    viewQuery: new ViewQuery { NamePattern = "orbit.*" }));
+
+            Assert.IsNotNull(ex);
+            StringAssert.Contains("mutually exclusive", ex!.Message);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentModify_PathPatches_WithNullElement_DoesNotThrow_AndLogsSkip()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                pathPatches: new List<PathPatch>
+                {
+                    null!,
+                    new PathPatch
+                    {
+                        Path = "globalOrbitSpeedMultiplier",
+                        Value = SerializedMember.FromValue<float>(Reflector, 11f)
+                    }
+                });
+
+            Assert.IsTrue(response.Success,
+                $"At least one of the patches succeeded; overall result should be Success. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(11f, solar.globalOrbitSpeedMultiplier);
+            var combined = string.Join("\n", response.Logs ?? Array.Empty<string>());
+            StringAssert.Contains("PathPatch[0]", combined);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentGet_PathsWithEmptyEntry_DoesNotSerializeWholeObject()
+        {
+            var (go, _, _, _) = BuildSolarFixture();
+
+            var response = new Tool_GameObject().GetComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                paths: new List<string> { "", "globalOrbitSpeedMultiplier" });
+
+            Assert.IsNotNull(response.View);
+            Assert.AreEqual(2, response.View!.fields?.Count);
+            var emptyEntry = response.View!.fields![0];
+            Assert.AreEqual(PathReadHelper.EmptyPathTypeName, emptyEntry.typeName);
+            var resolved = response.View!.fields![1];
+            Assert.AreEqual("globalOrbitSpeedMultiplier", resolved.name);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator ComponentModify_AllThreeSurfaces_ApplyInDocumentedOrder()
+        {
+            var (go, solar, _, _) = BuildSolarFixture();
+
+            var diff = SerializedMember.FromValue(
+                    reflector: Reflector,
+                    name: null,
+                    type: typeof(SolarSystem),
+                    value: new ComponentRef { TypeName = typeof(SolarSystem).FullName! })
+                .AddField(SerializedMember.FromValue(
+                    reflector: Reflector,
+                    name: "globalSizeMultiplier",
+                    type: typeof(float),
+                    value: 99f));
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetInstanceID()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                componentDiff: diff,
+                pathPatches: new List<PathPatch>
+                {
+                    new PathPatch
+                    {
+                        Path = "planets/[0]/orbitRadius",
+                        Value = SerializedMember.FromValue<float>(Reflector, 77f)
+                    }
+                },
+                jsonPatch: "{\"globalOrbitSpeedMultiplier\": 33.0}");
+
+            Assert.IsTrue(response.Success, $"Combined modify should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(33f, solar.globalOrbitSpeedMultiplier);
+            Assert.AreEqual(77f, solar.planets[0].orbitRadius);
+            Assert.AreEqual(99f, solar.globalSizeMultiplier);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator GameObjectModify_PathPatchesPerGameObject_LengthMismatch_ThrowsArgumentException()
+        {
+            var go1 = new GameObject("First");
+            var go2 = new GameObject("Second");
+            var refs = new GameObjectRefList { new GameObjectRef(go1.GetInstanceID()), new GameObjectRef(go2.GetInstanceID()) };
+
+            var perGo = new List<List<PathPatch>?>
+            {
+                new List<PathPatch>
+                {
+                    new PathPatch { Path = "name", Value = SerializedMember.FromValue<string>(Reflector, "Solo") }
+                }
+            };
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                new Tool_GameObject().Modify(gameObjectRefs: refs, pathPatchesPerGameObject: perGo));
+            Assert.IsNotNull(ex);
+            Assert.AreEqual("pathPatchesPerGameObject", ex!.ParamName);
+
+            var jsonPatches = new List<string?> { "{\"name\":\"Solo\"}" };
+            var ex2 = Assert.Throws<ArgumentException>(() =>
+                new Tool_GameObject().Modify(gameObjectRefs: refs, jsonPatchesPerGameObject: jsonPatches));
+            Assert.IsNotNull(ex2);
+            Assert.AreEqual("jsonPatchesPerGameObject", ex2!.ParamName);
+            yield return null;
+        }
     }
 }
 #endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.pre-Unity.6.5.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/PathBasedToolTests.pre-Unity.6.5.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d343e59a07a45c782bfbf840697d304
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

Adopts the new `TryReadAt` / `TryModifyAt` / `TryPatch` / `View` APIs introduced in ReflectorNet 5.1.0 ([IvanMurzak/ReflectorNet#71](https://github.com/IvanMurzak/ReflectorNet/pull/71)) across the Unity-MCP read-side and modify-side tools so the AI agent can request only the fields it needs instead of the full component/asset/object graph. This significantly reduces the token cost of typical inspect-then-edit workflows on large components (`Animator`, `MeshRenderer`, custom MonoBehaviours with deep state, etc.).

- **Read tools** (`paths` + `viewQuery` parameters added; default behavior preserved): `gameobject-component-get`, `gameobject-find`, `object-get-data`, `assets-get-data`, `assets-shader-get-data`, `scene-get-data`.
- **Modify tools** (`pathPatches` + `jsonPatch` parameters added; legacy diff preserved): `gameobject-component-modify`, `gameobject-modify`, `object-modify`, `assets-modify`.
- Routing per modify tool: `jsonPatch` → `pathPatches` → legacy diff. At least one is required (matches the legacy `ArgumentNullException` contract when all are null).
- Path syntax (canonical, also documented in each tool's `[Description]`): `fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.

## Test plan
- [x] EditMode test gate: 847/847 pass locally on Unity 2022.3.62f3 (`unity-mcp-cli run-tool tests-run ... --input '{"testMode":"EditMode"}'`).
- [x] New EditMode coverage in `Tests/Editor/Tool/PathBasedToolTests.cs` (+ `pre-Unity.6.5.cs` variant): single-path read, multi-path read, ViewQuery name-regex, single-path modify, multi-field JSON Patch, partial array-element modify, invalid path → structured error, and a legacy-code-path regression guard.
- [x] Existing `ObjectModifyTests.Modify_NullDiff_ThrowsArgumentNullException` still passes — the new `pathPatches` / `jsonPatch` parameters preserve the original `ArgumentNullException` contract when all three modify-args are null.
- [ ] CI green on this branch (Unity matrix + lint).

Closes #691