### PR TITLE
fix: use OpenUPM as version source for auto-update popup

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -36,18 +36,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         private const string PackageId = "com.ivanmurzak.unity.mcp";
         // package.openupm.com is the npm-style metadata registry (machine-readable JSON);
         // openupm.com is the human-readable package page the popup links users to.
-        private const string OpenUpmRegistryUrl = "https://package.openupm.com";
-        private const string OpenUpmPackageMetadataUrl = OpenUpmRegistryUrl + "/" + PackageId;
+        private const string OpenUpmPackageMetadataUrl = "https://package.openupm.com/" + PackageId;
         private const string OpenUpmPackageUrl = "https://openupm.com/packages/" + PackageId + "/";
 
-        // Mirrors the prior tag validation: accepts only "N.N" or "N.N.N" prefixes so a
-        // non-numeric `dist-tags.latest` cannot leak into the popup as version "0".
-        private static readonly Regex VersionPattern = new(@"^\d+\.\d+(\.\d+)?", RegexOptions.Compiled);
+        // Anchored at both ends: accepts only complete "N.N" or "N.N.N" strings. Without the
+        // trailing anchor, "1.0.0-preview" would match and CompareVersions would silently
+        // treat the "0-preview" segment as 0, making pre-release tags look equal to the
+        // final release. See https://github.com/IvanMurzak/Unity-MCP/issues/694 review.
+        private static readonly Regex VersionPattern = new(@"^\d+\.\d+(\.\d+)?$", RegexOptions.Compiled);
 
         // Hoisted to a single static instance to avoid socket exhaustion (TIME_WAIT) under
         // repeated update checks. Same pattern used by NuGetDownloader and DeviceAuthService
         // elsewhere in this package. The 10s timeout covers OpenUPM's slowest realistic responses.
-        private static readonly HttpClient httpClient = CreateHttpClient();
+        private static readonly HttpClient HttpClient = CreateHttpClient();
 
         private static PlayerPrefsBool DoNotShowAgain = new("Unity-MCP.UpdateChecker.DoNotShowAgain");
         private static PlayerPrefsString NextCheckTime = new("Unity-MCP.UpdateChecker.NextCheckTime");
@@ -173,31 +174,31 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
 
             try
             {
-                var latestVersion = await FetchLatestVersionAsync();
-                if (string.IsNullOrEmpty(latestVersion))
+                var fetched = await FetchLatestVersionAsync();
+                if (string.IsNullOrEmpty(fetched))
                 {
                     if (forceCheck)
                         logger?.LogWarning("Unable to check for updates. Please check your internet connection.");
                     return;
                 }
 
-                UpdateChecker.latestVersion = latestVersion;
+                latestVersion = fetched;
 
                 // Check if this version was skipped
                 var skippedVersion = SkippedVersion.Value;
-                if (!string.IsNullOrEmpty(skippedVersion) && skippedVersion == latestVersion && !forceCheck)
+                if (!string.IsNullOrEmpty(skippedVersion) && skippedVersion == fetched && !forceCheck)
                 {
                     return;
                 }
 
                 // Compare versions
                 var currentVersion = UnityMcpPlugin.Version;
-                if (IsNewerVersion(latestVersion!, currentVersion))
+                if (IsNewerVersion(fetched, currentVersion))
                 {
                     // Show the update popup on the main thread
                     EditorApplication.delayCall += () =>
                     {
-                        UpdatePopupWindow.ShowWindow(currentVersion, latestVersion!);
+                        UpdatePopupWindow.ShowWindow(currentVersion, fetched);
                     };
                 }
                 else if (forceCheck)
@@ -235,7 +236,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         {
             try
             {
-                var json = await httpClient.GetStringAsync(OpenUpmPackageMetadataUrl);
+                var json = await HttpClient.GetStringAsync(OpenUpmPackageMetadataUrl);
                 return ParseLatestVersionFromJson(json);
             }
             catch (HttpRequestException ex)
@@ -250,7 +251,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
             }
             catch (Exception ex)
             {
-                logger?.LogWarning(ex, "Failed to parse OpenUPM response");
+                // ParseLatestVersionFromJson swallows JsonException internally, so anything
+                // reaching here is an unexpected transport / URI / IO failure rather than a
+                // parse error — message must reflect that.
+                logger?.LogWarning(ex, "Unexpected error during OpenUPM update check");
                 return null;
             }
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -10,51 +10,31 @@
 
 #nullable enable
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
-using System.Text.RegularExpressions;
+using System.Text.Json;
 using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Editor.UI;
 using Extensions.Unity.PlayerPrefsEx;
 using Microsoft.Extensions.Logging;
 using UnityEditor;
-using UnityEngine;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Utils
 {
     /// <summary>
-    /// Represents a single tag from the GitHub API response.
+    /// Utility class for checking if a new version of the package is available on OpenUPM.
     /// </summary>
-    [Serializable]
-    internal class GitHubTag
-    {
-        public string name = string.Empty;
-    }
-
-    /// <summary>
-    /// Wrapper for deserializing GitHub tags array since JsonUtility doesn't support root-level arrays.
-    /// </summary>
-    [Serializable]
-    internal class GitHubTagsWrapper
-    {
-        public List<GitHubTag> tags = new();
-
-        public static GitHubTagsWrapper FromJson(string json)
-        {
-            // JsonUtility doesn't support root-level arrays, so we wrap it
-            var wrappedJson = $"{{\"tags\":{json}}}";
-            return JsonUtility.FromJson<GitHubTagsWrapper>(wrappedJson);
-        }
-    }
-
-    /// <summary>
-    /// Utility class for checking if a new version of the package is available on GitHub.
-    /// </summary>
+    /// <remarks>
+    /// OpenUPM is the source of truth for the version that Unity Package Manager will actually
+    /// install for end users. GitHub releases are published before the OpenUPM build pipeline
+    /// finishes, so polling GitHub releases would prompt users to update to a version that is
+    /// not yet installable. See https://github.com/IvanMurzak/Unity-MCP/issues/694.
+    /// </remarks>
     public static class UpdateChecker
     {
-        private const string GitHubApiUrl = "https://api.github.com/repos/IvanMurzak/Unity-MCP/tags";
-        private const string GitHubReleasesUrl = "https://github.com/IvanMurzak/Unity-MCP/releases";
+        private const string PackageId = "com.ivanmurzak.unity.mcp";
+        private const string OpenUpmRegistryUrl = "https://package.openupm.com";
+        private const string OpenUpmPackageUrl = "https://openupm.com/packages/" + PackageId + "/";
 
         private static PlayerPrefsBool DoNotShowAgain = new("Unity-MCP.UpdateChecker.DoNotShowAgain");
         private static PlayerPrefsString NextCheckTime = new("Unity-MCP.UpdateChecker.NextCheckTime");
@@ -83,9 +63,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         public static string? LatestVersion => latestVersion;
 
         /// <summary>
-        /// Gets the GitHub releases URL for the user to manually check updates.
+        /// Gets the OpenUPM package URL for the user to manually view available versions.
         /// </summary>
-        public static string ReleasesUrl => GitHubReleasesUrl;
+        /// <remarks>
+        /// Points at OpenUPM rather than GitHub releases because OpenUPM is the registry
+        /// Unity Package Manager actually pulls from — the version visible there is the
+        /// version users can actually install at this moment.
+        /// </remarks>
+        public static string ReleasesUrl => OpenUpmPackageUrl;
 
         public static void Init(ILogger? initLogger = null)
         {
@@ -149,7 +134,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         }
 
         /// <summary>
-        /// Asynchronously checks for updates from GitHub.
+        /// Asynchronously checks for updates from OpenUPM.
         /// </summary>
         /// <param name="forceCheck">If true, ignores cooldown and skipped version settings.</param>
         public static async Task CheckForUpdatesAsync(bool forceCheck = false)
@@ -218,73 +203,78 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         }
 
         /// <summary>
-        /// Fetches the latest version tag from GitHub API.
+        /// Fetches the latest version from the OpenUPM registry.
         /// </summary>
+        /// <remarks>
+        /// Uses the npm-style registry endpoint <c>https://package.openupm.com/{packageId}</c>,
+        /// which returns a JSON document whose <c>dist-tags.latest</c> field is the version
+        /// currently installable via Unity Package Manager. On any network or parsing failure
+        /// the method returns <c>null</c> so callers fall back gracefully without prompting.
+        /// </remarks>
         private static async Task<string?> FetchLatestVersionAsync()
         {
             using var client = new HttpClient();
             client.DefaultRequestHeaders.Add("User-Agent", "AI-Game-Developer-UpdateChecker");
+            client.Timeout = TimeSpan.FromSeconds(10);
 
             try
             {
-                var json = await client.GetStringAsync(GitHubApiUrl);
+                var json = await client.GetStringAsync($"{OpenUpmRegistryUrl}/{PackageId}");
                 return ParseLatestVersionFromJson(json);
             }
             catch (HttpRequestException ex)
             {
-                logger?.LogWarning("Failed to fetch tags: {error}", ex.Message);
+                logger?.LogWarning("Failed to fetch package metadata: {error}", ex.Message);
+                return null;
+            }
+            catch (TaskCanceledException ex)
+            {
+                logger?.LogWarning("OpenUPM request timed out: {error}", ex.Message);
                 return null;
             }
             catch (Exception ex)
             {
-                logger?.LogWarning(ex, "Failed to parse response");
+                logger?.LogWarning(ex, "Failed to parse OpenUPM response");
                 return null;
             }
         }
 
         /// <summary>
-        /// Parses the latest version from GitHub tags API JSON response.
+        /// Parses the latest version from an OpenUPM registry JSON response.
         /// </summary>
+        /// <remarks>
+        /// The OpenUPM registry follows the npm registry shape; the latest published version
+        /// is at <c>dist-tags.latest</c>. Returns <c>null</c> if the JSON is empty, malformed,
+        /// or does not contain a <c>dist-tags.latest</c> string.
+        /// </remarks>
         internal static string? ParseLatestVersionFromJson(string json)
         {
             if (string.IsNullOrEmpty(json))
                 return null;
 
-            var versions = new List<string>();
-
             try
             {
-                var wrapper = GitHubTagsWrapper.FromJson(json);
-                if (wrapper?.tags == null || wrapper.tags.Count == 0)
+                using var doc = JsonDocument.Parse(json);
+
+                if (!doc.RootElement.TryGetProperty("dist-tags", out var distTags))
                     return null;
 
-                foreach (var tag in wrapper.tags)
-                {
-                    if (string.IsNullOrEmpty(tag.name))
-                        continue;
+                if (distTags.ValueKind != JsonValueKind.Object)
+                    return null;
 
-                    var tagName = tag.name;
-                    // Remove 'v' prefix if present
-                    if (tagName.StartsWith("v") || tagName.StartsWith("V"))
-                        tagName = tagName.Substring(1);
+                if (!distTags.TryGetProperty("latest", out var latest))
+                    return null;
 
-                    // Validate it looks like a version number
-                    if (Regex.IsMatch(tagName, @"^\d+\.\d+(\.\d+)?"))
-                        versions.Add(tagName);
-                }
+                if (latest.ValueKind != JsonValueKind.String)
+                    return null;
+
+                var version = latest.GetString();
+                return string.IsNullOrEmpty(version) ? null : version;
             }
-            catch
+            catch (JsonException)
             {
-                // If JSON parsing fails, return null
                 return null;
             }
-
-            if (versions.Count == 0)
-                return null;
-
-            // Sort versions and get the latest
-            versions.Sort((a, b) => CompareVersions(b, a)); // Descending order
-            return versions[0];
         }
 
         /// <summary>

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Editor.UI;
 using Extensions.Unity.PlayerPrefsEx;
@@ -33,8 +34,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
     public static class UpdateChecker
     {
         private const string PackageId = "com.ivanmurzak.unity.mcp";
+        // package.openupm.com is the npm-style metadata registry (machine-readable JSON);
+        // openupm.com is the human-readable package page the popup links users to.
         private const string OpenUpmRegistryUrl = "https://package.openupm.com";
+        private const string OpenUpmPackageMetadataUrl = OpenUpmRegistryUrl + "/" + PackageId;
         private const string OpenUpmPackageUrl = "https://openupm.com/packages/" + PackageId + "/";
+
+        // Mirrors the prior tag validation: accepts only "N.N" or "N.N.N" prefixes so a
+        // non-numeric `dist-tags.latest` cannot leak into the popup as version "0".
+        private static readonly Regex VersionPattern = new(@"^\d+\.\d+(\.\d+)?", RegexOptions.Compiled);
+
+        // Hoisted to a single static instance to avoid socket exhaustion (TIME_WAIT) under
+        // repeated update checks. Same pattern used by NuGetDownloader and DeviceAuthService
+        // elsewhere in this package. The 10s timeout covers OpenUPM's slowest realistic responses.
+        private static readonly HttpClient httpClient = CreateHttpClient();
 
         private static PlayerPrefsBool DoNotShowAgain = new("Unity-MCP.UpdateChecker.DoNotShowAgain");
         private static PlayerPrefsString NextCheckTime = new("Unity-MCP.UpdateChecker.NextCheckTime");
@@ -43,6 +56,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         private static bool isChecking = false;
         private static string? latestVersion = null;
         private static ILogger? logger = null;
+
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+            client.DefaultRequestHeaders.Add("User-Agent", "AI-Game-Developer-UpdateChecker");
+            return client;
+        }
 
         /// <summary>
         /// Gets whether the user has chosen to never show the update popup again.
@@ -213,13 +233,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         /// </remarks>
         private static async Task<string?> FetchLatestVersionAsync()
         {
-            using var client = new HttpClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "AI-Game-Developer-UpdateChecker");
-            client.Timeout = TimeSpan.FromSeconds(10);
-
             try
             {
-                var json = await client.GetStringAsync($"{OpenUpmRegistryUrl}/{PackageId}");
+                var json = await httpClient.GetStringAsync(OpenUpmPackageMetadataUrl);
                 return ParseLatestVersionFromJson(json);
             }
             catch (HttpRequestException ex)
@@ -269,7 +285,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
                     return null;
 
                 var version = latest.GetString();
-                return string.IsNullOrEmpty(version) ? null : version;
+                if (string.IsNullOrEmpty(version))
+                    return null;
+
+                // Defensive: only accept numeric semver-shaped strings. Without this guard
+                // CompareVersions would silently treat non-numeric parts as 0, producing a
+                // misleading "version" in the popup if the registry ever returns garbage.
+                return VersionPattern.IsMatch(version) ? version : null;
             }
             catch (JsonException)
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -241,12 +241,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
             }
             catch (HttpRequestException ex)
             {
-                logger?.LogWarning("Failed to fetch package metadata: {error}", ex.Message);
+                // Use the exception-preserving overload so stack trace and inner exceptions
+                // survive into structured logs — same pattern as the catch-all below.
+                logger?.LogWarning(ex, "Failed to fetch package metadata");
                 return null;
             }
             catch (TaskCanceledException ex)
             {
-                logger?.LogWarning("OpenUPM request timed out: {error}", ex.Message);
+                logger?.LogWarning(ex, "OpenUPM request timed out");
                 return null;
             }
             catch (Exception ex)
@@ -265,7 +267,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         /// <remarks>
         /// The OpenUPM registry follows the npm registry shape; the latest published version
         /// is at <c>dist-tags.latest</c>. Returns <c>null</c> if the JSON is empty, malformed,
-        /// or does not contain a <c>dist-tags.latest</c> string.
+        /// or does not contain a <c>dist-tags.latest</c> string. Also returns <c>null</c> for
+        /// non-numeric or pre-release version strings (e.g. <c>"1.0.0-preview"</c>) — the
+        /// parser only accepts strict <c>N.N</c> / <c>N.N.N</c> shapes so the popup never
+        /// surfaces a tag that <see cref="CompareVersions"/> would silently misorder.
         /// </remarks>
         internal static string? ParseLatestVersionFromJson(string json)
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
@@ -254,6 +254,44 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.IsNull(result);
         }
 
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsLatestSemverPreRelease_ReturnsNull()
+        {
+            // Regression: an unanchored VersionPattern would let "1.0.0-preview" pass and
+            // then CompareVersions would parse "0-preview" as 0, making pre-release tags
+            // compare equal to the corresponding final release. The trailing `$` anchor
+            // closes that hole — pre-release suffixes must produce null.
+            var json = @"{""dist-tags"":{""latest"":""1.0.0-preview""}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsNull_ReturnsNull()
+        {
+            // dist-tags is JSON null — must NOT crash, must return null. Pins the
+            // `distTags.ValueKind != JsonValueKind.Object` guard.
+            var json = @"{""dist-tags"":null}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsLatestNull_ReturnsNull()
+        {
+            // dist-tags.latest is JSON null — must NOT crash, must return null. Pins the
+            // `latest.ValueKind != JsonValueKind.String` guard.
+            var json = @"{""dist-tags"":{""latest"":null}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
         #endregion
 
         #region Preference Management Tests

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
@@ -388,14 +388,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             // ReleasesUrl is what the popup's "View Releases" button opens. After the
             // OpenUPM-source migration, sending users to GitHub releases would re-introduce
             // the original bug (a release tagged on GitHub may not yet be installable via
-            // Unity Package Manager). The user-facing URL must point at the same registry
-            // the version check now consults.
-            var url = UpdateChecker.ReleasesUrl;
-
-            Assert.IsNotNull(url);
-            Assert.IsTrue(url.StartsWith("https://"));
-            Assert.IsTrue(url.Contains("openupm.com"), $"expected OpenUPM URL, got: {url}");
-            Assert.IsTrue(url.Contains("com.ivanmurzak.unity.mcp"), $"expected package id in URL, got: {url}");
+            // Unity Package Manager). It must point at the human-readable OpenUPM page,
+            // NOT at the npm-style metadata endpoint (https://package.openupm.com/...) —
+            // that endpoint returns JSON, which is not what the popup button should open.
+            // Pin the exact URL so a regression to either GitHub or the metadata host fails
+            // immediately rather than silently passing a substring check.
+            Assert.AreEqual(
+                "https://openupm.com/packages/com.ivanmurzak.unity.mcp/",
+                UpdateChecker.ReleasesUrl);
         }
 
         #endregion

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
@@ -114,92 +114,27 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
         #endregion
 
-        #region JSON Parsing Tests
+        #region OpenUPM JSON Parsing Tests
+
+        // The OpenUPM registry follows the npm registry shape: a JSON document with
+        // a `dist-tags.latest` field that is the published version users can install
+        // right now via Unity Package Manager. These tests cover the happy path plus
+        // the malformed / missing-field cases that must produce a graceful null.
 
         [Test]
-        public void ParseLatestVersionFromJson_ValidJson_ReturnsLatestVersion()
+        public void ParseLatestVersionFromJson_OpenUpmDistTags_ReturnsLatest()
         {
-            var json = @"[{""name"": ""v0.33.1"", ""zipball_url"": ""..."", ""tarball_url"": ""...""}, {""name"": ""v0.33.0"", ""zipball_url"": ""..."", ""tarball_url"": ""...""}]";
+            var json = @"{""name"":""com.ivanmurzak.unity.mcp"",""dist-tags"":{""latest"":""0.67.0""},""versions"":{""0.67.0"":{}}}";
 
             var result = UpdateChecker.ParseLatestVersionFromJson(json);
 
-            Assert.AreEqual("0.33.1", result);
+            Assert.AreEqual("0.67.0", result);
         }
 
         [Test]
-        public void ParseLatestVersionFromJson_SingleTag_ReturnsVersion()
+        public void ParseLatestVersionFromJson_OpenUpmDistTagsTwoPart_ReturnsLatest()
         {
-            var json = @"[{""name"": ""v1.0.0""}]";
-
-            var result = UpdateChecker.ParseLatestVersionFromJson(json);
-
-            Assert.AreEqual("1.0.0", result);
-        }
-
-        [Test]
-        public void ParseLatestVersionFromJson_UnorderedTags_ReturnsLatest()
-        {
-            var json = @"[{""name"": ""v1.0.0""}, {""name"": ""v2.0.0""}, {""name"": ""v1.5.0""}]";
-
-            var result = UpdateChecker.ParseLatestVersionFromJson(json);
-
-            Assert.AreEqual("2.0.0", result);
-        }
-
-        [Test]
-        public void ParseLatestVersionFromJson_WithoutVPrefix_ParsesCorrectly()
-        {
-            var json = @"[{""name"": ""1.0.0""}, {""name"": ""2.0.0""}]";
-
-            var result = UpdateChecker.ParseLatestVersionFromJson(json);
-
-            Assert.AreEqual("2.0.0", result);
-        }
-
-        [Test]
-        public void ParseLatestVersionFromJson_UppercaseVPrefix_ParsesCorrectly()
-        {
-            var json = @"[{""name"": ""V1.0.0""}, {""name"": ""V2.0.0""}]";
-
-            var result = UpdateChecker.ParseLatestVersionFromJson(json);
-
-            Assert.AreEqual("2.0.0", result);
-        }
-
-        [Test]
-        public void ParseLatestVersionFromJson_EmptyArray_ReturnsNull()
-        {
-            var json = @"[]";
-
-            var result = UpdateChecker.ParseLatestVersionFromJson(json);
-
-            Assert.IsNull(result);
-        }
-
-        [Test]
-        public void ParseLatestVersionFromJson_NoValidVersions_ReturnsNull()
-        {
-            var json = @"[{""name"": ""not-a-version""}, {""name"": ""also-not-a-version""}]";
-
-            var result = UpdateChecker.ParseLatestVersionFromJson(json);
-
-            Assert.IsNull(result);
-        }
-
-        [Test]
-        public void ParseLatestVersionFromJson_MixedValidInvalid_ReturnsLatestValid()
-        {
-            var json = @"[{""name"": ""not-a-version""}, {""name"": ""v1.0.0""}, {""name"": ""invalid""}]";
-
-            var result = UpdateChecker.ParseLatestVersionFromJson(json);
-
-            Assert.AreEqual("1.0.0", result);
-        }
-
-        [Test]
-        public void ParseLatestVersionFromJson_TwoPartVersions_ParsesCorrectly()
-        {
-            var json = @"[{""name"": ""v1.0""}, {""name"": ""v1.1""}]";
+            var json = @"{""dist-tags"":{""latest"":""1.1""}}";
 
             var result = UpdateChecker.ParseLatestVersionFromJson(json);
 
@@ -207,17 +142,81 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         }
 
         [Test]
-        public void ParseLatestVersionFromJson_ComplexGitHubResponse_ParsesCorrectly()
+        public void ParseLatestVersionFromJson_OpenUpmFullShape_ReturnsLatest()
         {
-            var json = @"[
-                {""name"": ""v0.35.0"", ""zipball_url"": ""https://api.github.com/..."", ""tarball_url"": ""https://api.github.com/..."", ""commit"": {""sha"": ""abc123"", ""url"": ""...""}},
-                {""name"": ""v0.34.2"", ""zipball_url"": ""..."", ""tarball_url"": ""..."", ""commit"": {""sha"": ""def456"", ""url"": ""...""}},
-                {""name"": ""v0.34.1"", ""zipball_url"": ""..."", ""tarball_url"": ""..."", ""commit"": {""sha"": ""ghi789"", ""url"": ""...""}}
-            ]";
+            // Realistic abridged shape returned by https://package.openupm.com/com.ivanmurzak.unity.mcp
+            var json = @"{
+                ""name"": ""com.ivanmurzak.unity.mcp"",
+                ""versions"": {
+                    ""0.66.0"": { ""version"": ""0.66.0"" },
+                    ""0.66.1"": { ""version"": ""0.66.1"" },
+                    ""0.67.0"": { ""version"": ""0.67.0"" }
+                },
+                ""time"": {
+                    ""modified"": ""2025-01-01T00:00:00Z"",
+                    ""created"":  ""2024-01-01T00:00:00Z"",
+                    ""0.66.0"":   ""2024-12-01T00:00:00Z"",
+                    ""0.66.1"":   ""2024-12-15T00:00:00Z"",
+                    ""0.67.0"":   ""2025-01-01T00:00:00Z""
+                },
+                ""dist-tags"": { ""latest"": ""0.67.0"" }
+            }";
 
             var result = UpdateChecker.ParseLatestVersionFromJson(json);
 
-            Assert.AreEqual("0.35.0", result);
+            Assert.AreEqual("0.67.0", result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_MissingDistTags_ReturnsNull()
+        {
+            var json = @"{""name"":""com.ivanmurzak.unity.mcp"",""versions"":{""1.0.0"":{}}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsWithoutLatest_ReturnsNull()
+        {
+            var json = @"{""dist-tags"":{""beta"":""1.0.0-beta""}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsLatestEmptyString_ReturnsNull()
+        {
+            var json = @"{""dist-tags"":{""latest"":""""}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsLatestWrongType_ReturnsNull()
+        {
+            // dist-tags.latest is a number — must NOT crash, must return null.
+            var json = @"{""dist-tags"":{""latest"":42}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsWrongType_ReturnsNull()
+        {
+            // dist-tags is a string instead of an object — must NOT crash, must return null.
+            var json = @"{""dist-tags"":""1.0.0""}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
         }
 
         #endregion
@@ -311,13 +310,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         #region ReleasesUrl Tests
 
         [Test]
-        public void ReleasesUrl_ReturnsValidGitHubUrl()
+        public void ReleasesUrl_PointsAtOpenUpm()
         {
+            // ReleasesUrl is what the popup's "View Releases" button opens. After the
+            // OpenUPM-source migration, sending users to GitHub releases would re-introduce
+            // the original bug (a release tagged on GitHub may not yet be installable via
+            // Unity Package Manager). The user-facing URL must point at the same registry
+            // the version check now consults.
             var url = UpdateChecker.ReleasesUrl;
 
             Assert.IsNotNull(url);
-            Assert.IsTrue(url.StartsWith("https://github.com/"));
-            Assert.IsTrue(url.Contains("/releases"));
+            Assert.IsTrue(url.StartsWith("https://"));
+            Assert.IsTrue(url.Contains("openupm.com"), $"expected OpenUPM URL, got: {url}");
+            Assert.IsTrue(url.Contains("com.ivanmurzak.unity.mcp"), $"expected package id in URL, got: {url}");
         }
 
         #endregion
@@ -355,6 +360,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         public void ParseLatestVersionFromJson_EmptyString_ReturnsNull()
         {
             var result = UpdateChecker.ParseLatestVersionFromJson("");
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_EmptyObject_ReturnsNull()
+        {
+            var result = UpdateChecker.ParseLatestVersionFromJson("{}");
 
             Assert.IsNull(result);
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
@@ -219,6 +219,41 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.IsNull(result);
         }
 
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsLatestObject_ReturnsNull()
+        {
+            // dist-tags.latest is an object — must NOT crash, must return null.
+            var json = @"{""dist-tags"":{""latest"":{""nested"":""1.0.0""}}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsLatestArray_ReturnsNull()
+        {
+            // dist-tags.latest is an array — must NOT crash, must return null.
+            var json = @"{""dist-tags"":{""latest"":[""1.0.0"",""1.1.0""]}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void ParseLatestVersionFromJson_DistTagsLatestNonNumeric_ReturnsNull()
+        {
+            // Defensive: a non-numeric `latest` string would otherwise leak into the popup
+            // as version "0" because CompareVersions treats non-numeric parts as 0. The
+            // parser must reject it instead.
+            var json = @"{""dist-tags"":{""latest"":""not-a-version""}}";
+
+            var result = UpdateChecker.ParseLatestVersionFromJson(json);
+
+            Assert.IsNull(result);
+        }
+
         #endregion
 
         #region Preference Management Tests


### PR DESCRIPTION
## Summary

- Auto-update popup now polls the OpenUPM registry (`https://package.openupm.com/com.ivanmurzak.unity.mcp`) for the latest version instead of GitHub `/tags`. OpenUPM is the registry Unity Package Manager actually pulls from, so the version users see in the popup matches what they can install at that moment.
- Repoints the popup's "View Releases" link from GitHub releases to the OpenUPM package page so the user-facing URL matches the new source of truth.
- Replaces the `JsonUtility`-based GitHub-tags parser with `System.Text.Json` reading `dist-tags.latest` (the same pattern `ExtensionPanel.cs` already uses for OpenUPM extension version checks).

## Why

GitHub releases are tagged before the OpenUPM build pipeline finishes (up to an hour). During that gap the old popup would prompt the user to update to a version that Unity Package Manager could not yet install, leaving them with a failed / no-op / stale update.

## Test plan

- [x] Target-specific local tests passed: 851/851 EditMode tests green (`tests-run` Suite 1).
- [x] PlayMode skipped — change is Editor-only.
- [x] CLI tests skipped — no `cli/` files touched.
- [x] Network failure path preserved (`FetchLatestVersionAsync` still returns null on `HttpRequestException` / `TaskCanceledException`, so the popup remains silent when OpenUPM is unreachable).
- [x] `ParseLatestVersionFromJson` covers happy path + malformed JSON + missing `dist-tags` + missing `latest` + wrong-type `latest` + wrong-type `dist-tags` + empty object.

Closes #694