### PR TITLE
fix: skip local MCP server auto-start in Cloud mode

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -339,10 +339,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 var versionMatches = IsVersionMatches();
                 var success = binaryExists && versionMatches;
 
-                if (success && previousKeepServerRunning)
+                if (success && previousKeepServerRunning && IsAutoStartAllowedForMode(UnityMcpPluginEditor.ConnectionMode))
                 {
                     if (!StartServer())
                         UnityEngine.Debug.LogError($"Failed to start MCP server after updating binary. Please try starting the server manually.");
+                }
+                else if (success && previousKeepServerRunning)
+                {
+                    _logger.LogDebug("DownloadAndUnpackBinary: Cloud mode active, skipping local server auto-start after binary update");
                 }
 
                 NotificationPopupWindow.Show(
@@ -1129,6 +1133,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         }
 
         /// <summary>
+        /// Returns true when the local MCP server may be auto-started for the given connection mode.
+        /// In Cloud mode the plugin connects to a remote MCP endpoint, so the local server is never
+        /// auto-started on Editor launch or after a binary update; in Custom mode the local server
+        /// is the connection target, so auto-start is allowed (subject to other gates such as
+        /// <see cref="UnityMcpPluginEditor.KeepServerRunning"/>).
+        /// Pure (no Unity API access) so it can be unit-tested in EditMode.
+        /// </summary>
+        public static bool IsAutoStartAllowedForMode(ConnectionMode mode)
+            => mode != ConnectionMode.Cloud;
+
+        /// <summary>
         /// Starts the MCP server if KeepServerRunning is enabled and no external server is detected.
         /// This method is called during Unity Editor startup to auto-start the server based on user preference.
         /// The external server check is performed asynchronously to avoid blocking the main thread.
@@ -1138,7 +1153,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             EditorApplication.update -= StartServerIfNeeded;
 
             // Skip local server auto-start in Cloud mode — Unity connects to the cloud server instead
-            if (UnityMcpPluginEditor.ConnectionMode == ConnectionMode.Cloud)
+            if (!IsAutoStartAllowedForMode(UnityMcpPluginEditor.ConnectionMode))
             {
                 _logger.LogDebug("StartServerIfNeeded: Cloud mode active, skipping local server auto-start");
                 return;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -339,14 +339,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 var versionMatches = IsVersionMatches();
                 var success = binaryExists && versionMatches;
 
-                if (success && previousKeepServerRunning && IsAutoStartAllowedForMode(UnityMcpPluginEditor.ConnectionMode))
+                if (success && previousKeepServerRunning)
                 {
-                    if (!StartServer())
-                        UnityEngine.Debug.LogError($"Failed to start MCP server after updating binary. Please try starting the server manually.");
-                }
-                else if (success && previousKeepServerRunning)
-                {
-                    _logger.LogDebug("DownloadAndUnpackBinary: Cloud mode active, skipping local server auto-start after binary update");
+                    if (IsAutoStartAllowedForMode(UnityMcpPluginEditor.ConnectionMode))
+                    {
+                        if (!StartServer())
+                            UnityEngine.Debug.LogError($"Failed to start MCP server after updating binary. Please try starting the server manually.");
+                    }
+                    else
+                    {
+                        _logger.LogDebug("DownloadAndUnpackBinary: Cloud mode active, skipping local server auto-start after binary update");
+                    }
                 }
 
                 NotificationPopupWindow.Show(
@@ -1134,14 +1137,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         /// <summary>
         /// Returns true when the local MCP server may be auto-started for the given connection mode.
-        /// In Cloud mode the plugin connects to a remote MCP endpoint, so the local server is never
-        /// auto-started on Editor launch or after a binary update; in Custom mode the local server
-        /// is the connection target, so auto-start is allowed (subject to other gates such as
-        /// <see cref="UnityMcpPluginEditor.KeepServerRunning"/>).
+        /// Only Custom mode targets the local server, so auto-start is allowed there (subject to
+        /// other gates such as <see cref="UnityMcpPluginEditor.KeepServerRunning"/>). Every other
+        /// mode (Cloud today, plus any future addition) connects to a remote endpoint and must
+        /// never auto-start the local server on Editor launch or after a binary update.
         /// Pure (no Unity API access) so it can be unit-tested in EditMode.
         /// </summary>
         public static bool IsAutoStartAllowedForMode(ConnectionMode mode)
-            => mode != ConnectionMode.Cloud;
+            => mode == ConnectionMode.Custom;
 
         /// <summary>
         /// Starts the MCP server if KeepServerRunning is enabled and no external server is detected.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerManagerAutoStartTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerManagerAutoStartTests.cs
@@ -1,0 +1,43 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Regression tests for issue #695: the local MCP server must NOT be auto-started on
+    /// Editor launch (or after a binary update) when the connection mode is Cloud.
+    ///
+    /// <see cref="McpServerManager.IsAutoStartAllowedForMode"/> is the pure decision used by
+    /// every auto-start path. User-driven actions (clicking the Start button in the editor
+    /// window) are intentionally not gated by this method.
+    /// </summary>
+    public class McpServerManagerAutoStartTests
+    {
+        [Test]
+        public void IsAutoStartAllowedForMode_Cloud_ReturnsFalse()
+        {
+            Assert.IsFalse(
+                McpServerManager.IsAutoStartAllowedForMode(ConnectionMode.Cloud),
+                "Cloud mode must never auto-start the local MCP server (issue #695).");
+        }
+
+        [Test]
+        public void IsAutoStartAllowedForMode_Custom_ReturnsTrue()
+        {
+            Assert.IsTrue(
+                McpServerManager.IsAutoStartAllowedForMode(ConnectionMode.Custom),
+                "Custom mode targets the local MCP server, so auto-start must be allowed " +
+                "(subject to the other gates inside StartServerIfNeeded).");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerManagerAutoStartTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerManagerAutoStartTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e1388cbec9ffa44aaaf30cb6a6b906e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Local MCP server was being auto-started on Editor launch even when `connectionMode == Cloud`, because the post-binary-update auto-restart in `DownloadAndUnpackBinary` lacked the cloud-mode guard that `StartServerIfNeeded` already had.
- Extracted the decision into a pure static `IsAutoStartAllowedForMode(ConnectionMode)` and reused it from both auto-start callsites; user-driven Start button and runtime mode-switch handlers remain untouched (explicit user intent).
- Added EditMode regression tests for the Cloud / Custom decisions.

## Test plan
- [x] Target-specific local tests passed (Unity EditMode, 854/854).

Closes #695