### PR TITLE
fix(tests): use GetEntityId on Unity 6.5+ in ScriptExecuteTests

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Script/ScriptExecuteTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Script/ScriptExecuteTests.cs
@@ -20,6 +20,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
     {
         const string GO_ABC = "ABC";
 
+#if UNITY_6000_5_OR_NEWER
+        static ulong GetGameObjectInstanceId(GameObject go)
+            => UnityEngine.EntityId.ToULong(go.GetEntityId());
+#else
+        static int GetGameObjectInstanceId(GameObject go)
+            => go.GetInstanceID();
+#endif
+
         [Test]
         public void Script_Execute_DisablesGameObject()
         {
@@ -224,7 +232,7 @@ public class Script
                     toolMethod: typeof(Tool_Script).GetMethod(nameof(Tool_Script.Execute)),
                     jsonProvider: () =>
                     {
-                        var instanceId = gameObjectEx.GameObject!.GetInstanceID();
+                        var instanceId = GetGameObjectInstanceId(gameObjectEx.GameObject!);
                         return $@"{{
                             ""csharpCode"": {JsonEscape(csharpCode)},
                             ""className"": ""Script"",
@@ -269,7 +277,7 @@ if (go != null)
                     toolMethod: typeof(Tool_Script).GetMethod(nameof(Tool_Script.Execute)),
                     jsonProvider: () =>
                     {
-                        var instanceId = gameObjectEx.GameObject!.GetInstanceID();
+                        var instanceId = GetGameObjectInstanceId(gameObjectEx.GameObject!);
                         return $@"{{
                             ""csharpCode"": {JsonEscape(methodBody)},
                             ""className"": ""Script"",
@@ -319,7 +327,7 @@ public class Script
                     toolMethod: typeof(Tool_Script).GetMethod(nameof(Tool_Script.Execute)),
                     jsonProvider: () =>
                     {
-                        var instanceId = gameObjectEx.GameObject!.GetInstanceID();
+                        var instanceId = GetGameObjectInstanceId(gameObjectEx.GameObject!);
                         return $@"{{
                             ""csharpCode"": {JsonEscape(csharpCode)},
                             ""className"": ""Script"",
@@ -360,7 +368,7 @@ Debug.Log(""Disabled: "" + go.name);";
                     toolMethod: typeof(Tool_Script).GetMethod(nameof(Tool_Script.Execute)),
                     jsonProvider: () =>
                     {
-                        var instanceId = gameObjectEx.GameObject!.GetInstanceID();
+                        var instanceId = GetGameObjectInstanceId(gameObjectEx.GameObject!);
                         return $@"{{
                             ""csharpCode"": {JsonEscape(methodBody)},
                             ""className"": ""Script"",


### PR DESCRIPTION
## Problem

Unity 6.5+ marks `Object.GetInstanceID()` as obsolete with `error=true`, producing `CS0619` and breaking compilation:

```
ScriptExecuteTests.cs(227,42): error CS0619: 'Object.GetInstanceID()' is obsolete:
'GetInstanceID is deprecated. Use GetEntityId instead. This will be removed in a future version.'
```

Four tests in `ScriptExecuteTests` (introduced by #524) build a JSON `GameObjectRef` payload using `gameObjectEx.GameObject!.GetInstanceID()`. The compile error blocks Unity 6.5+ users from running the EditMode test suite.

## Fix

Adds a `#if UNITY_6000_5_OR_NEWER`-guarded private helper at the top of the test class:

```csharp
#if UNITY_6000_5_OR_NEWER
static ulong GetGameObjectInstanceId(GameObject go)
    => UnityEngine.EntityId.ToULong(go.GetEntityId());
#else
static int GetGameObjectInstanceId(GameObject go)
    => go.GetInstanceID();
#endif
```

Replaces the four call sites with `GetGameObjectInstanceId(gameObjectEx.GameObject!)`.

## Why this works

`EntityIdConverter.ReadEntityIdValue` already accepts both the legacy int form (from `EntityId.ToString`) and the full raw ulong form (from `EntityId.ToULong`), so the JSON `{ "instanceID": <number> }` payload round-trips on both branches.

## Scope

- Tests only. No production code touched.
- No behavior change on Unity 2022.3 / 2023.2 (still calls `GetInstanceID()`).
- Affected tests:
  - `Script_Execute_BodyOnly_WithGameObjectRef_DisablesGameObject`
  - `Script_Execute_BodyOnly_WithGameObject_DisablesGameObject`
  - `Script_Execute_WithGameObjectRef_DisablesGameObject`
  - `Script_Execute_WithGameObject_DisablesGameObject`

Branched off latest `main` (`ccbd655a`, the merge of #524).