### PR TITLE
fix: disable auto-referencing for DependencyResolver assembly

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/com.IvanMurzak.Unity.MCP.DependencyResolver.asmdef
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/com.IvanMurzak.Unity.MCP.DependencyResolver.asmdef
@@ -9,7 +9,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false


### PR DESCRIPTION
This pull request makes a small configuration change to the assembly definition file for the dependency resolver in the Unity MCP plugin. The change disables automatic referencing of the assembly, which means it will no longer be automatically included in other assemblies unless explicitly referenced.

- Set `"autoReferenced"` to `false` in `com.IvanMurzak.Unity.MCP.DependencyResolver.asmdef`, disabling automatic assembly referencing.