### PR TITLE
fix: clean up stale NuGet package versions at install time

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/DependencyResolver/NuGetPackageInstaller.cs
@@ -38,12 +38,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
 
         /// <summary>
         /// Installs a package and its transitive dependencies.
-        /// Returns true if any new DLLs were extracted (requires domain reload).
-        /// Always reads the dependency graph (from the cached .nupkg) and records the resolved
-        /// (id, version) in <see cref="installedThisSession"/>, even when the package is already
-        /// present on disk — otherwise transitive deps of already-installed packages would be
-        /// missing from the closure, and stale-version directories of those transitives would
-        /// be kept by RemoveUnnecessaryPackages.
+        /// Returns true if any new DLLs were extracted, OR if any stale-version sibling
+        /// directories of this package's Id were removed from the install path (both require
+        /// a domain reload). Always reads the dependency graph (from the cached .nupkg) and
+        /// records the resolved (id, version) in <see cref="installedThisSession"/>, even
+        /// when the package is already present on disk — otherwise transitive deps of
+        /// already-installed packages would be missing from the closure, and stale-version
+        /// directories of those transitives would be kept by RemoveUnnecessaryPackages.
         /// </summary>
         public static bool Install(NuGetPackage package, HashSet<string>? visitedIds = null)
         {
@@ -85,19 +86,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                 foreach (var dep in dependencies)
                     anyInstalled |= Install(dep, visitedIds);
 
-                // If a previous version of the same Id is installed this session (higher-wins path),
-                // remove its directory before extracting the new one. Deletion is a material
-                // Asset change that must trigger a domain reload, so flip anyInstalled here —
-                // otherwise a restore cycle whose only change is cleanup would skip the reload.
-                if (existingVersion != null)
-                {
-                    var oldDir = Path.Combine(NuGetConfig.InstallPath, $"{package.Id}.{existingVersion}");
-                    if (Directory.Exists(oldDir))
-                    {
-                        DeleteDirAndMeta(oldDir);
-                        anyInstalled = true;
-                    }
-                }
+                // Remove any stale-version sibling directories for this package Id BEFORE
+                // extracting the new payload. Covers two distinct cases that the post-pass in
+                // RemoveUnnecessaryPackages cannot reliably catch in time:
+                //   (a) Cross-session upgrade: a prior session installed {Id}.{OldVer}/ from a
+                //       previous version of the parent Unity package; the user updated the
+                //       Unity package, the new dep graph resolves {Id}.{NewVer}, and the old
+                //       dir is still on disk. Without this scan, both versions remain side by
+                //       side and the C# compiler reports duplicate-assembly errors before
+                //       RemoveUnnecessaryPackages gets to run. See Unity-MCP#703.
+                //   (b) Within-session higher-version-wins: a lower version of the same Id was
+                //       already installed earlier in this restore cycle through a different
+                //       chain, and the current chain resolves a higher version. The disk scan
+                //       subsumes the previous installedThisSession-based cleanup branch by
+                //       deleting whatever sibling versions are actually on disk.
+                // Deletion is a material Asset change that must trigger a domain reload, so
+                // flip anyInstalled here — otherwise a restore cycle whose only change is
+                // cleanup would skip the reload.
+                if (RemoveStaleSiblingVersions(NuGetConfig.InstallPath, package.Id, package.Version))
+                    anyInstalled = true;
 
                 // Development-only dependencies (e.g. Roslyn analyzers, source generators,
                 // build-time tooling) ship their payload under analyzers/, build/, tools/ etc.
@@ -225,6 +232,57 @@ namespace com.IvanMurzak.Unity.MCP.Editor.DependencyResolver
                     continue;
 
                 Debug.Log($"{Tag} Removing {dirName} — Unity now provides all of its assemblies.");
+                DeleteDirAndMeta(dir);
+                anyRemoved = true;
+            }
+
+            return anyRemoved;
+        }
+
+        /// <summary>
+        /// Scans <paramref name="installPath"/> for sibling directories of the form
+        /// <c>{packageId}.&lt;otherVersion&gt;/</c> at any version other than
+        /// <paramref name="keepVersion"/> and removes them (plus their <c>.meta</c> files).
+        /// Returns true when at least one directory was removed.
+        ///
+        /// Matching uses <see cref="ExtractPackageIdFromDirName(string)"/> so that package IDs
+        /// containing dots (e.g. "Microsoft.AspNetCore.SignalR.Common") are split correctly.
+        /// Comparison is case-insensitive on both Id and version to mirror the rest of the
+        /// resolver's casing rules.
+        ///
+        /// Called from <see cref="Install(NuGetPackage, HashSet{string})"/> for every package
+        /// (top-level and transitive) so a NuGet bump in any layer of the graph cleans its
+        /// own stale sibling at install time, without depending on a separate post-pass.
+        ///
+        /// <paramref name="installPath"/> is parameterised (instead of reading
+        /// <see cref="NuGetConfig.InstallPath"/> directly) so EditMode tests can drive the
+        /// scan against a temp directory without touching the real Assets/Plugins/NuGet path.
+        /// </summary>
+        internal static bool RemoveStaleSiblingVersions(string installPath, string packageId, string keepVersion)
+        {
+            if (!Directory.Exists(installPath))
+                return false;
+
+            var keepDirName = $"{packageId}.{keepVersion}";
+            var anyRemoved = false;
+
+            foreach (var dir in Directory.GetDirectories(installPath))
+            {
+                var dirName = Path.GetFileName(dir);
+
+                // Same exact version — keep it. The downstream extraction step is responsible
+                // for that directory; deleting it here would force needless re-extraction.
+                if (string.Equals(dirName, keepDirName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var dirPackageId = ExtractPackageIdFromDirName(dirName);
+                if (dirPackageId == null)
+                    continue;
+
+                if (!string.Equals(dirPackageId, packageId, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                Debug.Log($"{Tag} Removing stale {dirName} — superseded by {packageId} {keepVersion}.");
                 DeleteDirAndMeta(dir);
                 anyRemoved = true;
             }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetPackageInstallerStaleVersionCleanupTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetPackageInstallerStaleVersionCleanupTests.cs
@@ -1,0 +1,242 @@
+/*
++------------------------------------------------------------------+
+|  Author: Ivan Murzak (https://github.com/IvanMurzak)             |
+|  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    |
+|  Copyright (c) 2025 Ivan Murzak                                  |
+|  Licensed under the Apache License, Version 2.0.                 |
+|  See the LICENSE file in the project root for more information.  |
++------------------------------------------------------------------+
+*/
+
+#nullable enable
+using System.IO;
+using NUnit.Framework;
+using com.IvanMurzak.Unity.MCP.Editor.DependencyResolver;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests.DependencyResolverTests
+{
+    /// <summary>
+    /// Regression coverage for issue #703: when the resolver installs a package whose
+    /// version was bumped (commonly a transitive like ReflectorNet on a Unity-package
+    /// upgrade), any prior <c>{Id}.&lt;oldVersion&gt;/</c> directory left on disk from a
+    /// previous session must be removed at install time so the C# compiler does not see
+    /// duplicate copies of the same assembly.
+    ///
+    /// <see cref="NuGetPackageInstaller.RemoveStaleSiblingVersions"/> is the helper that
+    /// performs this scan. These tests exercise it directly against a temp directory; the
+    /// actual <c>Install()</c> path wires the real <c>NuGetConfig.InstallPath</c> in.
+    /// </summary>
+    [TestFixture]
+    public class NuGetPackageInstallerStaleVersionCleanupTests
+    {
+        string _installPath = string.Empty;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _installPath = Path.Combine(
+                Path.GetTempPath(),
+                "UnityMcp-NuGetInstaller-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(_installPath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_installPath))
+            {
+                try { Directory.Delete(_installPath, recursive: true); }
+                catch { /* best-effort cleanup */ }
+            }
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_DeletesPriorLowerVersionAndItsMeta()
+        {
+            // Issue #703 scenario: ReflectorNet 5.0.0 installed in a previous session,
+            // user upgraded the Unity package, new dep graph resolves ReflectorNet 5.1.1.
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "5.0.0");
+            // The new directory does not need to exist yet — the helper runs BEFORE
+            // extraction in Install(), so this mirrors the real cross-session upgrade flow.
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsTrue(removed, "Helper must report that it removed something.");
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.5.0.0")),
+                "Stale lower-version directory must be removed.");
+            Assert.IsFalse(File.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.5.0.0.meta")),
+                "Stale .meta sidecar must be removed alongside its directory.");
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_PreservesSameVersionDirectory()
+        {
+            // Idempotency: re-running the resolver on an up-to-date project must NOT delete
+            // the directory at the configured version. Otherwise every restore would force
+            // a needless re-extraction.
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsFalse(removed);
+            Assert.IsTrue(Directory.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.5.1.1")));
+            Assert.IsTrue(File.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.5.1.1.meta")));
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_PreservesOtherPackages()
+        {
+            // The scan must not touch directories belonging to a different package Id.
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "5.0.0");
+            CreateFakePackageDir("System.Text.Json", "8.0.5");
+            CreateFakePackageDir("Microsoft.AspNetCore.SignalR.Client", "8.0.15");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsTrue(removed);
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.5.0.0")));
+            Assert.IsTrue(Directory.Exists(Path.Combine(_installPath, "System.Text.Json.8.0.5")),
+                "Unrelated package must be untouched.");
+            Assert.IsTrue(Directory.Exists(Path.Combine(_installPath, "Microsoft.AspNetCore.SignalR.Client.8.0.15")),
+                "Package with dots in its Id must not be matched against a different package's Id.");
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_HandlesPackageIdsWithDots()
+        {
+            // Bug-shaped regression check: ExtractPackageIdFromDirName must split correctly
+            // for IDs that contain dots, so a stale "Microsoft.AspNetCore.SignalR.Common.10.0.3"
+            // is correctly recognised as belonging to "Microsoft.AspNetCore.SignalR.Common".
+            CreateFakePackageDir("Microsoft.AspNetCore.SignalR.Common", "10.0.3");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "Microsoft.AspNetCore.SignalR.Common", "8.0.15");
+
+            Assert.IsTrue(removed);
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "Microsoft.AspNetCore.SignalR.Common.10.0.3")));
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_DeletesMultipleStaleVersionsAtOnce()
+        {
+            // A user who upgraded across several Unity-MCP releases without ever running
+            // Restore() in the middle could legitimately have two or more stale directories
+            // for the same package Id on disk. The helper must clean ALL of them, not just one.
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "4.9.0");
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "5.0.0");
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "5.1.0");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsTrue(removed);
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.4.9.0")));
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.5.0.0")));
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.5.1.0")));
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_DeletesHigherVersionTooWhenItIsNotTheKeepVersion()
+        {
+            // The cleanup contract is "delete everything that is not the keepVersion", not
+            // "delete only lower versions". A bad partial restore could legitimately leave a
+            // higher-version directory on disk that is NOT the one the current closure
+            // resolves to (e.g. the closure pinned a lower version explicitly to match a
+            // peer dependency), and we need to remove it for the same duplicate-assembly
+            // reason as a stale lower version.
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "6.0.0");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsTrue(removed);
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "com.IvanMurzak.ReflectorNet.6.0.0")));
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_ReturnsFalse_WhenInstallPathDoesNotExist()
+        {
+            // First-ever restore on a brand-new project: the install dir is created lazily
+            // by the restorer. The helper must not crash and must report no work done.
+            var doesNotExist = Path.Combine(_installPath, "does-not-exist");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                doesNotExist, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsFalse(removed);
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_ReturnsFalse_WhenInstallPathHasNoMatchingSiblings()
+        {
+            // Steady-state restore: the install path is full of unrelated packages and the
+            // current package is not on disk at any version yet (it is about to be extracted).
+            // The helper must do nothing and report so.
+            CreateFakePackageDir("System.Text.Json", "8.0.5");
+            CreateFakePackageDir("Microsoft.AspNetCore.SignalR.Client", "8.0.15");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsFalse(removed);
+            Assert.IsTrue(Directory.Exists(Path.Combine(_installPath, "System.Text.Json.8.0.5")));
+            Assert.IsTrue(Directory.Exists(Path.Combine(_installPath, "Microsoft.AspNetCore.SignalR.Client.8.0.15")));
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_MatchesPackageIdCaseInsensitively()
+        {
+            // The rest of the resolver matches package IDs case-insensitively (see
+            // installedThisSession's StringComparer.OrdinalIgnoreCase, RemoveUnnecessaryPackages,
+            // IsSkipped). Real-world directory names typically preserve the canonical casing
+            // of the NuGet ID, but defensive case-insensitivity protects against e.g. a
+            // hand-edited Plugins folder where someone lowered the casing.
+            CreateFakePackageDir("com.ivanmurzak.reflectornet", "5.0.0");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsTrue(removed);
+            Assert.IsFalse(Directory.Exists(Path.Combine(_installPath, "com.ivanmurzak.reflectornet.5.0.0")));
+        }
+
+        [Test]
+        public void RemoveStaleSiblingVersions_IgnoresDirectoriesWithUnparseableNames()
+        {
+            // The install path can contain non-package directories (e.g. an editor-generated
+            // backup folder, a user-dropped file). The helper relies on
+            // ExtractPackageIdFromDirName which returns null for unparseable names; those
+            // directories must be ignored, not crash the scan and not be deleted.
+            Directory.CreateDirectory(Path.Combine(_installPath, "not-a-package"));
+            Directory.CreateDirectory(Path.Combine(_installPath, "ReadMe"));
+            CreateFakePackageDir("com.IvanMurzak.ReflectorNet", "5.0.0");
+
+            var removed = NuGetPackageInstaller.RemoveStaleSiblingVersions(
+                _installPath, "com.IvanMurzak.ReflectorNet", "5.1.1");
+
+            Assert.IsTrue(removed, "The legitimately stale package dir must still be removed.");
+            Assert.IsTrue(Directory.Exists(Path.Combine(_installPath, "not-a-package")),
+                "Non-package directories must not be touched.");
+            Assert.IsTrue(Directory.Exists(Path.Combine(_installPath, "ReadMe")));
+        }
+
+        /// <summary>
+        /// Creates a fake <c>{Id}.{Version}/</c> directory with a single dummy DLL inside,
+        /// plus a sibling <c>.meta</c> file, mirroring the on-disk shape the real resolver
+        /// produces. The DLL content is not parsed by the helper; only the filename / extension
+        /// matter for any downstream checks (and this helper's scan does not even look at file
+        /// contents — it identifies stale siblings purely by directory name).
+        /// </summary>
+        void CreateFakePackageDir(string id, string version)
+        {
+            var dirName = $"{id}.{version}";
+            var dirPath = Path.Combine(_installPath, dirName);
+            Directory.CreateDirectory(dirPath);
+            File.WriteAllText(Path.Combine(dirPath, $"{id}.dll"), "dummy");
+            File.WriteAllText(dirPath + ".meta", "fileFormatVersion: 2\nguid: 00000000000000000000000000000000\n");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetPackageInstallerStaleVersionCleanupTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DependencyResolver/NuGetPackageInstallerStaleVersionCleanupTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee77f38ab567a534386801f6f6846f11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- `NuGetPackageInstaller.Install()` now scans the NuGet install path for any sibling `{Id}.<otherVersion>/` directory before extracting the new payload and removes it together with its `.meta` sidecar. Fixes the duplicate-assembly compile errors that hit users when they upgrade `com.ivanmurzak.unity.mcp` across a transitive bump (e.g. ReflectorNet `5.0.0` → `5.1.1`).
- The cleanup runs for every package the installer processes — top-level and transitive — so a NuGet bump in any layer of the dep graph self-cleans without depending on the separate `RemoveUnnecessaryPackages` post-pass.
- The previous within-session higher-version-wins cleanup branch (keyed on `installedThisSession`) is subsumed by the disk scan and removed; `anyInstalled = true` is set on any cleanup so the caller triggers a domain reload even when the only change in the cycle was deletion.

## Test plan

- [x] Target-specific local tests passed (Unity EditMode, 875/875 — see profile `test.md`).
- [x] New `NuGetPackageInstallerStaleVersionCleanupTests` covers cross-session upgrade (the #703 repro), same-version preservation, unrelated-package preservation, IDs with dots (`Microsoft.AspNetCore.SignalR.Common`), multiple stale siblings, higher-than-keep versions, missing install path, no-op when no siblings match, case-insensitive Id matching, and unparseable directory names.

Closes #703