### PR TITLE
fix: persist update popup version fields across domain reload

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
@@ -36,8 +36,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         protected override string[] WindowUssPaths => _windowUssPaths;
         protected override string WindowTitle => "Update Available";
 
-        private string currentVersion = string.Empty;
-        private string latestVersion = string.Empty;
+        // [SerializeField] so the version strings survive Unity's domain reload (script
+        // recompile). Without this, after a recompile the EditorWindow instance is recreated,
+        // CreateGUI() is invoked again, and BindUI() re-binds button click handlers — but
+        // these private fields revert to empty, so the labels render empty and "Install
+        // Update" attempts to install "{PackageId}@" (empty version), which silently fails.
+        // See https://github.com/IvanMurzak/Unity-MCP/issues/702.
+        [SerializeField] private string currentVersion = string.Empty;
+        [SerializeField] private string latestVersion = string.Empty;
+
+        // Non-serialized: an in-flight Package Manager AddRequest cannot survive a domain
+        // reload (it holds native handles on the C++ side). After reload it goes back to null
+        // and the user can re-click "Install Update" to start a fresh install. Same applies
+        // to the R3 IDisposable subscription — re-clicking re-establishes it.
         private AddRequest? addRequest;
         private IDisposable? _stopSubscription;
 


### PR DESCRIPTION
## Summary

- Add `[SerializeField]` to `UpdatePopupWindow.currentVersion` / `latestVersion` so they survive Unity's domain reload (script recompile). Previously these private fields reverted to empty strings when Unity recreated the EditorWindow after recompile, causing the popup labels to render blank and "Install Update" to attempt installing `com.ivanmurzak.unity.mcp@` (empty version) — making the popup look unresponsive.
- Document inline why `addRequest` (PackageManager native handle) and `_stopSubscription` (R3 IDisposable) intentionally remain non-serialized: they cannot survive a domain reload, but reverting to null is the correct behavior — a fresh click on Install Update starts a clean install.

## Test plan

- [x] EditMode: 865/865 passed locally (`unity-mcp-cli run-tool tests-run --input '{"testMode":"EditMode"}'`).
- [x] Change is Editor-only (`Editor/Scripts/UI/Window/UpdatePopupWindow.cs`); PlayMode and CLI suites correctly skipped per profile conditional rules.
- [ ] CI matrix (test-pull-request) green on every Unity version × platform combo.
- [ ] Manual: trigger update popup via `Tools > AI Game Developer > Debug > Show Update Popup`, force a script recompile (e.g. add a comment to any `.cs` file), confirm the popup labels still show the correct versions and all four buttons (Install Update / View Releases / Skip Version / Don't Show Again) respond.

Closes #702