### PR TITLE
fix: silence CS8604 in UpdateChecker.CheckForUpdatesAsync

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -191,14 +191,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
                     return;
                 }
 
-                // Compare versions
+                // Compare versions. The `!` is required because the Unity Editor C# compiler
+                // does not honor `[NotNullWhen(false)]` on `string.IsNullOrEmpty`, so it does
+                // not narrow `fetched` (declared `string?`) to non-null after the early-return
+                // guard above and would otherwise emit CS8604 here. The runtime check above
+                // already establishes `fetched` is non-null and non-empty at this point.
                 var currentVersion = UnityMcpPlugin.Version;
-                if (IsNewerVersion(fetched, currentVersion))
+                if (IsNewerVersion(fetched!, currentVersion))
                 {
                     // Show the update popup on the main thread
                     EditorApplication.delayCall += () =>
                     {
-                        UpdatePopupWindow.ShowWindow(currentVersion, fetched);
+                        UpdatePopupWindow.ShowWindow(currentVersion, fetched!);
                     };
                 }
                 else if (forceCheck)


### PR DESCRIPTION
## Summary
- Silence CS8604 warning at `UpdateChecker.cs:196`: the Unity Editor C# compiler does not honor `[NotNullWhen(false)]` on `string.IsNullOrEmpty`, so `fetched` (typed `string?` because `FetchLatestVersionAsync` returns `Task<string?>`) is not narrowed to non-null after the early-return guard.
- Add the null-forgiving operator at the `IsNewerVersion(fetched, currentVersion)` call site (and at the deferred `UpdatePopupWindow.ShowWindow(currentVersion, fetched)` invocation inside the lambda, which captures `fetched` and would emit the same warning). The runtime null/empty guard above is unchanged, so behavior is identical.
- Preserved `FetchLatestVersionAsync`'s `Task<string?>` return type — `null` is a meaningful failure signal for the catch blocks.

## Test plan
- [x] Target-specific local tests passed (Unity EditMode, 875/875 passed, 0 failures — see profile test.md)
- [x] Verified no CS8604 emitted in the post-fix Unity recompile (`Editor.log` shows clean rebuild of `com.IvanMurzak.Unity.MCP.Editor.dll`).

Closes #709