### PR TITLE
refactor(cli/lib): introduce discriminated-union result types

### DIFF
--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -97,12 +97,14 @@ export const configureCommand = new Command('configure')
       resources: options.list ? undefined : resourcesAction,
     });
 
-    if (!result.success) {
-      ui.error(result.error?.message ?? 'Unknown error');
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
       process.exit(1);
     }
 
-    if (options.list && result.snapshot) {
+    // Narrowed: result.kind === 'success' below — `snapshot` is
+    // non-optional.
+    if (options.list) {
       ui.heading('Current configuration');
       ui.label('Host', result.snapshot.host ?? 'not set');
       ui.label('Keep Connected', String(result.snapshot.keepConnected ?? false));

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -47,19 +47,19 @@ export const installPluginCommand = new Command('install-plugin')
       },
     });
 
-    if (!result.success) {
+    if (result.kind === 'failure') {
       if (spinner) {
         spinner.error('Failed to resolve plugin version');
         spinner = undefined;
       }
-      ui.error(result.error?.message ?? 'Unknown error');
+      ui.error(result.error.message);
       process.exit(1);
     }
 
+    // Narrowed: result.kind === 'success' below — `installedVersion`
+    // and `manifestPath` are non-optional.
     verbose(`Plugin version: ${result.installedVersion} (explicit: ${!!options.pluginVersion})`);
-    if (result.manifestPath) {
-      verbose(`Manifest path: ${result.manifestPath}`);
-    }
+    verbose(`Manifest path: ${result.manifestPath}`);
     ui.info(`Installing Unity-MCP plugin v${result.installedVersion} into: ${projectPath}`);
 
     for (const warning of result.warnings) {

--- a/cli/src/commands/remove-plugin.ts
+++ b/cli/src/commands/remove-plugin.ts
@@ -20,14 +20,14 @@ export const removePluginCommand = new Command('remove-plugin')
 
     const result = await removePlugin({ unityProjectPath: projectPath });
 
-    if (!result.success) {
-      ui.error(result.error?.message ?? 'Unknown error');
+    if (result.kind === 'failure') {
+      ui.error(result.error.message);
       process.exit(1);
     }
 
-    if (result.manifestPath) {
-      verbose(`Manifest path: ${result.manifestPath}`);
-    }
+    // Narrowed: result.kind === 'success' below — `manifestPath` is
+    // non-optional and `removed` is a definite boolean.
+    verbose(`Manifest path: ${result.manifestPath}`);
 
     if (result.removed) {
       ui.success(`Removed com.ivanmurzak.unity.mcp from ${result.manifestPath}`);

--- a/cli/src/commands/setup-mcp.ts
+++ b/cli/src/commands/setup-mcp.ts
@@ -76,24 +76,24 @@ export const setupMcpCommand = new Command('setup-mcp')
         token: options.token,
       });
 
-      if (!result.success) {
+      if (result.kind === 'failure') {
         spinner.error('Failed to write config');
-        ui.error(result.error?.message ?? 'Unknown error');
+        ui.error(result.error.message);
         process.exit(1);
       }
 
+      // Narrowed: result.kind === 'success' below — `configPath` and
+      // `transport` are non-optional.
       if (positionalPath) {
         verbose(`Project path: ${positionalPath}`);
       }
-      if (result.configPath) {
-        verbose(`Config file: ${result.configPath}`);
-      }
+      verbose(`Config file: ${result.configPath}`);
 
       spinner.success(`${agent.name} configured successfully`);
 
       console.log('');
-      if (result.configPath) ui.label('Config file', result.configPath);
-      if (result.transport) ui.label('Transport', result.transport);
+      ui.label('Config file', result.configPath);
+      ui.label('Transport', result.transport);
       ui.label('Server name', MCP_SERVER_NAME);
 
       for (const warning of result.warnings) {

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -4,8 +4,8 @@
 // - NO top-level side effects. Importing this file must not open
 //   sockets, spin up spinners, write to stdout/stderr, or parse argv.
 // - NO `commander` import reachable from this file.
-// - Errors are returned in `{ success: false, error }` results — never
-//   thrown past the public boundary.
+// - Errors are returned in `{ kind: 'failure', success: false, error }`
+//   results — never thrown past the public boundary.
 // - Progress is surfaced via an optional `onProgress` callback, not
 //   globals or singletons.
 //
@@ -21,19 +21,29 @@ export type {
   // Shared
   ProgressEvent,
   ProgressCallback,
+  ResultKind,
   // install-plugin
   InstallPluginOptions,
   InstallResult,
+  InstallSuccess,
+  InstallFailure,
   // remove-plugin
   RemovePluginOptions,
   RemoveResult,
+  RemoveSuccess,
+  RemoveFailure,
   // configure
   ConfigureOptions,
   ConfigureResult,
+  ConfigureSuccess,
+  ConfigureFailure,
+  ConfigureSnapshot,
   FeatureAction,
   McpFeatureSnapshot,
   // setup-mcp
   SetupMcpOptions,
   SetupMcpResult,
+  SetupMcpSuccess,
+  SetupMcpFailure,
   McpTransport,
 } from './lib/types.js';

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -4,8 +4,12 @@
 // - NO top-level side effects. Importing this file must not open
 //   sockets, spin up spinners, write to stdout/stderr, or parse argv.
 // - NO `commander` import reachable from this file.
-// - Errors are returned in `{ kind: 'failure', success: false, error }`
-//   results — never thrown past the public boundary.
+// - Every result is a discriminated union keyed on `kind`. Successes are
+//   `{ kind: 'success', success: true, ...variant fields }`; failures are
+//   `{ kind: 'failure', success: false, error }`. Errors are never thrown
+//   past the public boundary. Narrow on `kind` for type-safe access to
+//   variant-specific fields; the boolean `success` mirror is preserved
+//   for wire compatibility (`success === (kind === 'success')`).
 // - Progress is surfaced via an optional `onProgress` callback, not
 //   globals or singletons.
 //

--- a/cli/src/lib/configure.ts
+++ b/cli/src/lib/configure.ts
@@ -45,6 +45,10 @@ function snapshotFeatures(config: UnityConnectionConfig, key: 'tools' | 'prompts
  * If none of `tools`/`prompts`/`resources` are supplied, the call is a
  * read-only "create-if-missing and return snapshot" — mirrors the CLI's
  * `--list` behaviour minus the rendering.
+ *
+ * The returned `ConfigureResult` is a discriminated union — narrow with
+ * `result.kind === 'success'` to access `configPath` / `snapshot`, or
+ * `result.kind === 'failure'` to access `error`.
  */
 export async function configure(opts: ConfigureOptions): Promise<ConfigureResult> {
   const warnings: string[] = [];
@@ -52,7 +56,7 @@ export async function configure(opts: ConfigureOptions): Promise<ConfigureResult
   try {
     const validated = requireExistingPath(opts?.unityProjectPath);
     if (!validated.ok) {
-      return { success: false, warnings, error: validated.error };
+      return { kind: 'failure', success: false, warnings, error: validated.error };
     }
     const { projectPath } = validated;
 
@@ -88,6 +92,7 @@ export async function configure(opts: ConfigureOptions): Promise<ConfigureResult
     emitProgress(opts.onProgress, { phase: 'done', message: 'Configure complete.' });
 
     return {
+      kind: 'success',
       success: true,
       configPath,
       snapshot: {
@@ -103,6 +108,7 @@ export async function configure(opts: ConfigureOptions): Promise<ConfigureResult
     };
   } catch (err: unknown) {
     return {
+      kind: 'failure',
       success: false,
       warnings,
       error: err instanceof Error ? err : new Error(String(err)),

--- a/cli/src/lib/install-plugin.ts
+++ b/cli/src/lib/install-plugin.ts
@@ -8,7 +8,11 @@ import type { InstallPluginOptions, InstallResult } from './types.js';
  * Install the Unity-MCP plugin into a Unity project. Library-safe:
  * never calls `process.exit`, never prints to stdout / stderr, never
  * throws past the public boundary — errors are returned in
- * `{ success: false, error }`.
+ * `{ kind: 'failure', success: false, error }`.
+ *
+ * The returned `InstallResult` is a discriminated union — narrow with
+ * `result.kind === 'success'` to access `installedVersion` /
+ * `manifestPath`, or `result.kind === 'failure'` to access `error`.
  */
 export async function installPlugin(opts: InstallPluginOptions): Promise<InstallResult> {
   const warnings: string[] = [];
@@ -18,6 +22,7 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     const validated = requireUnityProject(opts?.unityProjectPath);
     if (!validated.ok) {
       return {
+        kind: 'failure',
         success: false,
         manifestPath: validated.manifestPath,
         warnings,
@@ -62,6 +67,7 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     emitProgress(opts.onProgress, { phase: 'done', message: 'Install complete.' });
 
     return {
+      kind: 'success',
       success: true,
       installedVersion: result.resolvedVersion,
       manifestPath: result.manifestPath,
@@ -70,6 +76,7 @@ export async function installPlugin(opts: InstallPluginOptions): Promise<Install
     };
   } catch (err: unknown) {
     return {
+      kind: 'failure',
       success: false,
       warnings,
       nextSteps,

--- a/cli/src/lib/remove-plugin.ts
+++ b/cli/src/lib/remove-plugin.ts
@@ -8,6 +8,10 @@ import type { RemovePluginOptions, RemoveResult } from './types.js';
  * Remove the Unity-MCP plugin from a Unity project. Library-safe:
  * never calls `process.exit`, never prints to stdout / stderr, never
  * throws past the public boundary.
+ *
+ * The returned `RemoveResult` is a discriminated union — narrow with
+ * `result.kind === 'success'` to access `removed` / `manifestPath`, or
+ * `result.kind === 'failure'` to access `error`.
  */
 export async function removePlugin(opts: RemovePluginOptions): Promise<RemoveResult> {
   const warnings: string[] = [];
@@ -16,6 +20,7 @@ export async function removePlugin(opts: RemovePluginOptions): Promise<RemoveRes
     const validated = requireUnityProject(opts?.unityProjectPath);
     if (!validated.ok) {
       return {
+        kind: 'failure',
         success: false,
         manifestPath: validated.manifestPath,
         warnings,
@@ -43,6 +48,7 @@ export async function removePlugin(opts: RemovePluginOptions): Promise<RemoveRes
     emitProgress(opts.onProgress, { phase: 'done', message: 'Remove complete.' });
 
     return {
+      kind: 'success',
       success: true,
       removed: result.removed,
       manifestPath: result.manifestPath,
@@ -50,6 +56,7 @@ export async function removePlugin(opts: RemovePluginOptions): Promise<RemoveRes
     };
   } catch (err: unknown) {
     return {
+      kind: 'failure',
       success: false,
       warnings,
       error: err instanceof Error ? err : new Error(String(err)),

--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -39,6 +39,10 @@ function portFromHost(host: string | undefined, projectPath: string): number {
  * Write MCP configuration for the given AI agent, so it can talk to
  * Unity-MCP. Library-safe: no stdout noise, no process.exit, no throws
  * past the public boundary.
+ *
+ * The returned `SetupMcpResult` is a discriminated union — narrow with
+ * `result.kind === 'success'` to access `agentId` / `configPath` /
+ * `transport`, or `result.kind === 'failure'` to access `error`.
  */
 export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
   const warnings: string[] = [];
@@ -47,6 +51,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
   try {
     if (!opts || typeof opts.agentId !== 'string' || opts.agentId.length === 0) {
       return {
+        kind: 'failure',
         success: false,
         warnings,
         nextSteps,
@@ -59,6 +64,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     const agent = getAgentById(opts.agentId);
     if (!agent) {
       return {
+        kind: 'failure',
         success: false,
         warnings,
         nextSteps,
@@ -71,6 +77,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     const transport: McpTransport = opts.transport ?? 'http';
     if (!isValidTransport(transport)) {
       return {
+        kind: 'failure',
         success: false,
         warnings,
         nextSteps,
@@ -84,7 +91,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     if (opts.unityProjectPath) {
       const validated = requireExistingPath(opts.unityProjectPath);
       if (!validated.ok) {
-        return { success: false, warnings, nextSteps, error: validated.error };
+        return { kind: 'failure', success: false, warnings, nextSteps, error: validated.error };
       }
       projectPath = validated.projectPath;
     } else {
@@ -148,6 +155,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     emitProgress(opts.onProgress, { phase: 'done', message: `${agent.name} configured successfully.` });
 
     return {
+      kind: 'success',
       success: true,
       agentId: agent.id,
       configPath,
@@ -157,6 +165,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
     };
   } catch (err: unknown) {
     return {
+      kind: 'failure',
       success: false,
       warnings,
       nextSteps,

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -24,6 +24,21 @@ export type ProgressEvent =
 export type ProgressCallback = (event: ProgressEvent) => void;
 
 // ---------------------------------------------------------------------------
+// Result discriminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminator literal for every library result type. Consumers should
+ * narrow on `result.kind === 'success'` (or `=== 'failure'`) to access
+ * variant-specific fields with full TypeScript type safety.
+ *
+ * Wire-compatible note: every result object also carries a `success`
+ * boolean that satisfies `success === (kind === 'success')` so existing
+ * consumers reading `result.success` continue to work without changes.
+ */
+export type ResultKind = 'success' | 'failure';
+
+// ---------------------------------------------------------------------------
 // install-plugin
 // ---------------------------------------------------------------------------
 
@@ -43,20 +58,37 @@ export interface InstallPluginOptions {
   onProgress?: ProgressCallback;
 }
 
-export interface InstallResult {
-  /** `true` when the manifest was updated (or already correct); `false` on error. */
-  success: boolean;
-  /** Final plugin version in the manifest. Populated on success. */
-  installedVersion?: string;
+/** Successful `installPlugin` outcome. Narrow with `kind === 'success'`. */
+export interface InstallSuccess {
+  kind: 'success';
+  /** Always `true` for the success variant. Wire-compatible alias for `kind === 'success'`. */
+  success: true;
+  /** Final plugin version in the manifest. */
+  installedVersion: string;
   /** Absolute path to the manifest.json that was inspected / written. */
-  manifestPath?: string;
+  manifestPath: string;
   /** Non-fatal warnings collected during the run (e.g. skipped downgrade). */
   warnings: string[];
   /** Suggested next steps for the caller to surface to a human user. */
   nextSteps: string[];
-  /** Populated when `success === false`. Never thrown past this boundary. */
-  error?: Error;
 }
+
+/** Failed `installPlugin` outcome. Narrow with `kind === 'failure'`. */
+export interface InstallFailure {
+  kind: 'failure';
+  /** Always `false` for the failure variant. Wire-compatible alias for `kind === 'failure'`. */
+  success: false;
+  /** Manifest path may be known even on failure (e.g. when validation reaches the manifest). */
+  manifestPath?: string;
+  /** Non-fatal warnings collected before the failure. */
+  warnings: string[];
+  /** Suggested next steps the caller may surface to a human user. */
+  nextSteps: string[];
+  /** The captured error. Never thrown past this boundary. */
+  error: Error;
+}
+
+export type InstallResult = InstallSuccess | InstallFailure;
 
 // ---------------------------------------------------------------------------
 // remove-plugin
@@ -67,14 +99,24 @@ export interface RemovePluginOptions {
   onProgress?: ProgressCallback;
 }
 
-export interface RemoveResult {
-  success: boolean;
+export interface RemoveSuccess {
+  kind: 'success';
+  success: true;
   /** `true` when the plugin dependency was present and has been removed. */
-  removed?: boolean;
+  removed: boolean;
+  manifestPath: string;
+  warnings: string[];
+}
+
+export interface RemoveFailure {
+  kind: 'failure';
+  success: false;
   manifestPath?: string;
   warnings: string[];
-  error?: Error;
+  error: Error;
 }
+
+export type RemoveResult = RemoveSuccess | RemoveFailure;
 
 // ---------------------------------------------------------------------------
 // configure
@@ -106,23 +148,34 @@ export interface McpFeatureSnapshot {
   enabled: boolean;
 }
 
-export interface ConfigureResult {
-  success: boolean;
-  /** Absolute path to the `AI-Game-Developer-Config.json` that was written. */
-  configPath?: string;
-  /** A read-only snapshot of the post-write config. */
-  snapshot?: {
-    host?: string;
-    keepConnected?: boolean;
-    transportMethod?: string;
-    authOption?: string;
-    tools: McpFeatureSnapshot[];
-    prompts: McpFeatureSnapshot[];
-    resources: McpFeatureSnapshot[];
-  };
-  warnings: string[];
-  error?: Error;
+export interface ConfigureSnapshot {
+  host?: string;
+  keepConnected?: boolean;
+  transportMethod?: string;
+  authOption?: string;
+  tools: McpFeatureSnapshot[];
+  prompts: McpFeatureSnapshot[];
+  resources: McpFeatureSnapshot[];
 }
+
+export interface ConfigureSuccess {
+  kind: 'success';
+  success: true;
+  /** Absolute path to the `AI-Game-Developer-Config.json` that was written. */
+  configPath: string;
+  /** A read-only snapshot of the post-write config. */
+  snapshot: ConfigureSnapshot;
+  warnings: string[];
+}
+
+export interface ConfigureFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  error: Error;
+}
+
+export type ConfigureResult = ConfigureSuccess | ConfigureFailure;
 
 // ---------------------------------------------------------------------------
 // setup-mcp
@@ -147,15 +200,25 @@ export interface SetupMcpOptions {
   onProgress?: ProgressCallback;
 }
 
-export interface SetupMcpResult {
-  success: boolean;
-  /** The agent whose config file was written (undefined on error). */
-  agentId?: string;
+export interface SetupMcpSuccess {
+  kind: 'success';
+  success: true;
+  /** The agent whose config file was written. */
+  agentId: string;
   /** Absolute path to the agent config file that was written. */
-  configPath?: string;
+  configPath: string;
   /** Transport actually written. */
-  transport?: McpTransport;
+  transport: McpTransport;
   warnings: string[];
   nextSteps: string[];
-  error?: Error;
 }
+
+export interface SetupMcpFailure {
+  kind: 'failure';
+  success: false;
+  warnings: string[];
+  nextSteps: string[];
+  error: Error;
+}
+
+export type SetupMcpResult = SetupMcpSuccess | SetupMcpFailure;

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -35,6 +35,12 @@ export type ProgressCallback = (event: ProgressEvent) => void;
  * Wire-compatible note: every result object also carries a `success`
  * boolean that satisfies `success === (kind === 'success')` so existing
  * consumers reading `result.success` continue to work without changes.
+ *
+ * Exported for consumer ergonomics (e.g. mapping a `ResultKind` to a UI
+ * label). DO NOT use as a field type on a result variant — every variant
+ * MUST inline the literal (`kind: 'success'` / `kind: 'failure'`) so
+ * TypeScript's discriminated-union narrowing works. Declaring
+ * `kind: ResultKind` on a variant silently collapses narrowing.
  */
 export type ResultKind = 'success' | 'failure';
 

--- a/cli/tests/lib.test.ts
+++ b/cli/tests/lib.test.ts
@@ -106,7 +106,6 @@ describe('installPlugin', () => {
     });
 
     expect(result.kind).toBe('success');
-    expect(result.success).toBe(true);
     if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.installedVersion).toBe(TEST_VERSION);
     expect(result.warnings).toEqual([]);
@@ -123,9 +122,7 @@ describe('installPlugin', () => {
   it('returns kind:"failure" with an Error when unityProjectPath is missing', async () => {
     const result = await installPlugin({ unityProjectPath: '' });
     expect(result.kind).toBe('failure');
-    expect(result.success).toBe(false);
     if (result.kind !== 'failure') throw new Error('expected failure kind');
-    expect(result.error).toBeInstanceOf(Error);
     expect(result.error.message).toContain('unityProjectPath is required');
   });
 
@@ -137,7 +134,6 @@ describe('installPlugin', () => {
         version: TEST_VERSION,
       });
       expect(result.kind).toBe('failure');
-      expect(result.success).toBe(false);
       if (result.kind !== 'failure') throw new Error('expected failure kind');
       expect(result.error.message).toContain('Not a valid Unity project');
     } finally {
@@ -265,7 +261,6 @@ describe('removePlugin', () => {
 
     const result = await removePlugin({ unityProjectPath: tmpDir });
     expect(result.kind).toBe('success');
-    expect(result.success).toBe(true);
     if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.removed).toBe(true);
     expect(result.warnings).toEqual([]);
@@ -302,6 +297,14 @@ describe('removePlugin', () => {
     expect(result.kind).toBe('failure');
     if (result.kind !== 'failure') throw new Error('expected failure kind');
     expect(result.error.message).toContain('unityProjectPath is required');
+  });
+
+  it('wire-compatible: result.success mirrors result.kind === "success"', async () => {
+    const ok = await removePlugin({ unityProjectPath: tmpDir });
+    expect(ok.success).toBe(ok.kind === 'success');
+
+    const fail = await removePlugin({ unityProjectPath: '' });
+    expect(fail.success).toBe(fail.kind === 'success');
   });
 });
 
@@ -390,6 +393,14 @@ describe('configure', () => {
     expect(result.snapshot.resources).toContainEqual({ name: 'r1', enabled: false });
     expect(result.snapshot.tools).toEqual([]);
   });
+
+  it('wire-compatible: result.success mirrors result.kind === "success"', async () => {
+    const ok = await configure({ unityProjectPath: tmpDir });
+    expect(ok.success).toBe(ok.kind === 'success');
+
+    const fail = await configure({ unityProjectPath: '' });
+    expect(fail.success).toBe(fail.kind === 'success');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -422,7 +433,6 @@ describe('setupMcp', () => {
     if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.agentId).toBe(agentId);
     expect(result.transport).toBe('http');
-    expect(result.configPath).toBeDefined();
     expect(fs.existsSync(result.configPath)).toBe(true);
   });
 
@@ -466,5 +476,17 @@ describe('setupMcp', () => {
     expect(result.kind).toBe('failure');
     if (result.kind !== 'failure') throw new Error('expected failure kind');
     expect(result.error.message).toContain('Invalid transport');
+  });
+
+  it('wire-compatible: result.success mirrors result.kind === "success"', async () => {
+    const ok = await setupMcp({
+      agentId: listAgentIds()[0],
+      unityProjectPath: tmpDir,
+      transport: 'http',
+    });
+    expect(ok.success).toBe(ok.kind === 'success');
+
+    const fail = await setupMcp({ agentId: '', unityProjectPath: tmpDir });
+    expect(fail.success).toBe(fail.kind === 'success');
   });
 });

--- a/cli/tests/lib.test.ts
+++ b/cli/tests/lib.test.ts
@@ -105,11 +105,12 @@ describe('installPlugin', () => {
       version: TEST_VERSION,
     });
 
+    expect(result.kind).toBe('success');
     expect(result.success).toBe(true);
+    if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.installedVersion).toBe(TEST_VERSION);
     expect(result.warnings).toEqual([]);
     expect(result.nextSteps.length).toBeGreaterThan(0);
-    expect(result.error).toBeUndefined();
     expect(result.manifestPath).toContain('manifest.json');
 
     const manifest = JSON.parse(
@@ -119,22 +120,26 @@ describe('installPlugin', () => {
     expect(manifest.scopedRegistries[0].name).toBe('package.openupm.com');
   });
 
-  it('returns success:false with an Error when unityProjectPath is missing', async () => {
+  it('returns kind:"failure" with an Error when unityProjectPath is missing', async () => {
     const result = await installPlugin({ unityProjectPath: '' });
+    expect(result.kind).toBe('failure');
     expect(result.success).toBe(false);
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
     expect(result.error).toBeInstanceOf(Error);
-    expect(result.error?.message).toContain('unityProjectPath is required');
+    expect(result.error.message).toContain('unityProjectPath is required');
   });
 
-  it('returns success:false when manifest.json is missing', async () => {
+  it('returns kind:"failure" when manifest.json is missing', async () => {
     const emptyDir = mkEmptyDir();
     try {
       const result = await installPlugin({
         unityProjectPath: emptyDir,
         version: TEST_VERSION,
       });
+      expect(result.kind).toBe('failure');
       expect(result.success).toBe(false);
-      expect(result.error?.message).toContain('Not a valid Unity project');
+      if (result.kind !== 'failure') throw new Error('expected failure kind');
+      expect(result.error.message).toContain('Not a valid Unity project');
     } finally {
       fs.rmSync(emptyDir, { recursive: true, force: true });
     }
@@ -150,7 +155,7 @@ describe('installPlugin', () => {
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.kind).toBe('success');
 
     const phases = events.map((e) => e.phase);
     expect(phases).toContain('start');
@@ -176,7 +181,8 @@ describe('installPlugin', () => {
       version: '99.0.0',
     });
 
-    expect(result.success).toBe(true);
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.installedVersion).toBe('99.0.0');
     expect(result.warnings).toEqual([]);
   });
@@ -190,7 +196,8 @@ describe('installPlugin', () => {
       },
     });
 
-    expect(result.success).toBe(true);
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.installedVersion).toBe(TEST_VERSION);
   });
 
@@ -205,7 +212,7 @@ describe('installPlugin', () => {
       version: TEST_VERSION,
     });
 
-    expect(result.success).toBe(true);
+    expect(result.kind).toBe('success');
     expect(log).not.toHaveBeenCalled();
     expect(errFn).not.toHaveBeenCalled();
     expect(stdout).not.toHaveBeenCalled();
@@ -215,6 +222,14 @@ describe('installPlugin', () => {
     errFn.mockRestore();
     stdout.mockRestore();
     stderr.mockRestore();
+  });
+
+  it('wire-compatible: result.success mirrors result.kind === "success"', async () => {
+    const ok = await installPlugin({ unityProjectPath: tmpDir, version: TEST_VERSION });
+    expect(ok.success).toBe(ok.kind === 'success');
+
+    const fail = await installPlugin({ unityProjectPath: '' });
+    expect(fail.success).toBe(fail.kind === 'success');
   });
 });
 
@@ -249,7 +264,9 @@ describe('removePlugin', () => {
     );
 
     const result = await removePlugin({ unityProjectPath: tmpDir });
+    expect(result.kind).toBe('success');
     expect(result.success).toBe(true);
+    if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.removed).toBe(true);
     expect(result.warnings).toEqual([]);
 
@@ -260,19 +277,21 @@ describe('removePlugin', () => {
     expect(manifest.dependencies['com.unity.ugui']).toBe('1.0.0');
   });
 
-  it('returns success:true with removed=false when plugin is not installed', async () => {
+  it('returns kind:"success" with removed=false when plugin is not installed', async () => {
     const result = await removePlugin({ unityProjectPath: tmpDir });
-    expect(result.success).toBe(true);
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.removed).toBe(false);
     expect(result.warnings.length).toBeGreaterThan(0);
   });
 
-  it('returns success:false with an Error when manifest is missing', async () => {
+  it('returns kind:"failure" with an Error when manifest is missing', async () => {
     const emptyDir = mkEmptyDir();
     try {
       const result = await removePlugin({ unityProjectPath: emptyDir });
-      expect(result.success).toBe(false);
-      expect(result.error?.message).toContain('Not a valid Unity project');
+      expect(result.kind).toBe('failure');
+      if (result.kind !== 'failure') throw new Error('expected failure kind');
+      expect(result.error.message).toContain('Not a valid Unity project');
     } finally {
       fs.rmSync(emptyDir, { recursive: true, force: true });
     }
@@ -280,8 +299,9 @@ describe('removePlugin', () => {
 
   it('validates unityProjectPath', async () => {
     const result = await removePlugin({ unityProjectPath: '' });
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain('unityProjectPath is required');
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.error.message).toContain('unityProjectPath is required');
   });
 });
 
@@ -303,13 +323,13 @@ describe('configure', () => {
   it('creates a default config when none exists and returns a snapshot', async () => {
     const result = await configure({ unityProjectPath: tmpDir });
 
-    expect(result.success).toBe(true);
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.configPath).toContain('AI-Game-Developer-Config.json');
-    expect(result.snapshot).toBeDefined();
-    expect(result.snapshot?.host).toContain('localhost');
-    expect(result.snapshot?.tools).toEqual([]);
-    expect(result.snapshot?.prompts).toEqual([]);
-    expect(result.snapshot?.resources).toEqual([]);
+    expect(result.snapshot.host).toContain('localhost');
+    expect(result.snapshot.tools).toEqual([]);
+    expect(result.snapshot.prompts).toEqual([]);
+    expect(result.snapshot.resources).toEqual([]);
   });
 
   it('enables specific tools', async () => {
@@ -318,8 +338,9 @@ describe('configure', () => {
       tools: { enableNames: ['tool-a', 'tool-b'] },
     });
 
-    expect(result.success).toBe(true);
-    const tools = result.snapshot?.tools ?? [];
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
+    const tools = result.snapshot.tools;
     expect(tools).toContainEqual({ name: 'tool-a', enabled: true });
     expect(tools).toContainEqual({ name: 'tool-b', enabled: true });
   });
@@ -334,23 +355,27 @@ describe('configure', () => {
       tools: { disableNames: ['tool-a'] },
     });
 
-    const tools = result.snapshot?.tools ?? [];
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
+    const tools = result.snapshot.tools;
     expect(tools).toContainEqual({ name: 'tool-a', enabled: false });
     expect(tools).toContainEqual({ name: 'tool-b', enabled: true });
   });
 
-  it('returns success:false when the project path does not exist', async () => {
+  it('returns kind:"failure" when the project path does not exist', async () => {
     const result = await configure({
       unityProjectPath: path.join(tmpDir, 'does-not-exist'),
     });
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain('does not exist');
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.error.message).toContain('does not exist');
   });
 
   it('validates unityProjectPath', async () => {
     const result = await configure({ unityProjectPath: '' });
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain('unityProjectPath is required');
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.error.message).toContain('unityProjectPath is required');
   });
 
   it('supports prompts and resources independently', async () => {
@@ -359,10 +384,11 @@ describe('configure', () => {
       prompts: { enableNames: ['p1'] },
       resources: { disableNames: ['r1'] },
     });
-    expect(result.success).toBe(true);
-    expect(result.snapshot?.prompts).toContainEqual({ name: 'p1', enabled: true });
-    expect(result.snapshot?.resources).toContainEqual({ name: 'r1', enabled: false });
-    expect(result.snapshot?.tools).toEqual([]);
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
+    expect(result.snapshot.prompts).toContainEqual({ name: 'p1', enabled: true });
+    expect(result.snapshot.resources).toContainEqual({ name: 'r1', enabled: false });
+    expect(result.snapshot.tools).toEqual([]);
   });
 });
 
@@ -392,11 +418,12 @@ describe('setupMcp', () => {
       transport: 'http',
     });
 
-    expect(result.success).toBe(true);
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('expected success kind');
     expect(result.agentId).toBe(agentId);
     expect(result.transport).toBe('http');
     expect(result.configPath).toBeDefined();
-    expect(fs.existsSync(result.configPath!)).toBe(true);
+    expect(fs.existsSync(result.configPath)).toBe(true);
   });
 
   it('fails with a descriptive error when the agent is unknown', async () => {
@@ -405,8 +432,9 @@ describe('setupMcp', () => {
       unityProjectPath: tmpDir,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain('Unknown agent');
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.error.message).toContain('Unknown agent');
   });
 
   it('fails when agentId is empty', async () => {
@@ -414,8 +442,9 @@ describe('setupMcp', () => {
       agentId: '',
       unityProjectPath: tmpDir,
     });
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain('agentId is required');
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.error.message).toContain('agentId is required');
   });
 
   it('fails when the supplied project path does not exist', async () => {
@@ -423,8 +452,9 @@ describe('setupMcp', () => {
       agentId: listAgentIds()[0],
       unityProjectPath: path.join(tmpDir, 'does-not-exist'),
     });
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain('does not exist');
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.error.message).toContain('does not exist');
   });
 
   it('rejects an invalid transport', async () => {
@@ -433,7 +463,8 @@ describe('setupMcp', () => {
       unityProjectPath: tmpDir,
       transport: 'ftp' as unknown as 'stdio' | 'http',
     });
-    expect(result.success).toBe(false);
-    expect(result.error?.message).toContain('Invalid transport');
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.error.message).toContain('Invalid transport');
   });
 });


### PR DESCRIPTION
## Summary

- Convert `InstallResult`, `RemoveResult`, `ConfigureResult`, and `SetupMcpResult` into discriminated unions keyed on a `kind` literal (`'success'` | `'failure'`); each variant gets its own interface (`InstallSuccess` / `InstallFailure`, etc.) so consumers narrow with `result.kind === 'success'` and access variant-specific fields with full type safety.
- Wire-compatible: every variant retains a `success` boolean satisfying `success === (kind === 'success')`, so existing consumers reading `result.success` keep working unchanged. Promote previously-optional success-path fields (`installedVersion`, `manifestPath`, `configPath`, `snapshot`, `agentId`, `transport`) to non-optional on the success variant.
- Update the four CLI command wrappers (`install-plugin`, `remove-plugin`, `configure`, `setup-mcp`) to narrow on `result.kind === 'failure'` before reading `result.error`, removing the prior `??` / `?.` fallback patterns; update `tests/lib.test.ts` to assert on `result.kind` as the canonical narrowing path and add a wire-compatibility test verifying the `success`/`kind` invariant.

## Test plan

- [x] `npm test` in `cli/` — 266 passed (1 pre-existing skip), `tsc` build clean.
- [x] Unity EditMode test gate — 875 passed, 0 failed (Unity 2022.3.62f3, run via `unity-mcp-cli run-tool tests-run` against the worktree's local MCP endpoint).
- [x] CLI wrappers compile under `tsc` with `strict` mode against the new union shape.

## Notes

- No version bump in this PR (per workspace invariant: versions are owned by the release pipeline).
- Per the issue, this is the wire-compatible minor-bump path: a future PR can drop the legacy `success` boolean if downstream consumers (e.g. `@ai-game-dev/core`) migrate fully to `kind`.

Closes #681