### PR TITLE
feat: add screenshot-isolated MCP tool

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -1,0 +1,650 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.ReflectorNet.Utils;
+using AIGD;
+using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Screenshot
+    {
+        public const string ScreenshotIsolatedToolId = "screenshot-isolated";
+
+        // Layer 31 is Unity's last user-defined layer; we reserve it transiently for
+        // isolation rendering. The layer swap is restored in finally before any other
+        // code observes the scene, so the choice is invisible to the user.
+        private const int IsolationLayer = 31;
+        private const int MinResolution = 1;
+        private const int MaxResolution = 8192;
+
+        public enum CameraView
+        {
+            [Description("Camera faces the object's forward side (-Z). Standard front view.")]
+            Front,
+            [Description("Camera faces the object's rear side (+Z).")]
+            Back,
+            [Description("Camera faces the object's left side (-X).")]
+            Left,
+            [Description("Camera faces the object's right side (+X).")]
+            Right,
+            [Description("Camera looks down at the object from above (+Y).")]
+            Top,
+            [Description("Camera looks up at the object from below (-Y).")]
+            Bottom,
+            [Description("Produces a single 2x2 grid image with Front, Right, Back, and Top views. "
+                       + "Each sub-view uses the specified resolution, so final image is resolution*2 x resolution*2.")]
+            Composite
+        }
+
+        public enum BackgroundMode
+        {
+            [Description("Flat color defined by backgroundColor. Camera clearFlags = SolidColor.")]
+            SolidColor,
+            [Description("Uses the scene's current skybox material. Camera clearFlags = Skybox.")]
+            Skybox,
+            [Description("Alpha-zero background for compositing. RenderTexture format must support alpha (ARGB32).")]
+            Transparent
+        }
+
+        public class IsolatedLightConfig
+        {
+            [JsonPropertyName("type")] public string? Type { get; set; }
+            [JsonPropertyName("color")] public string? Color { get; set; }
+            [JsonPropertyName("intensity")] public float? Intensity { get; set; }
+            [JsonPropertyName("rotation")] public float[]? Rotation { get; set; }
+            [JsonPropertyName("position")] public float[]? Position { get; set; }
+            [JsonPropertyName("range")] public float? Range { get; set; }
+            [JsonPropertyName("spotAngle")] public float? SpotAngle { get; set; }
+            [JsonPropertyName("innerSpotAngle")] public float? InnerSpotAngle { get; set; }
+            [JsonPropertyName("shadows")] public string? Shadows { get; set; }
+            [JsonPropertyName("shadowStrength")] public float? ShadowStrength { get; set; }
+            [JsonPropertyName("bounceIntensity")] public float? BounceIntensity { get; set; }
+            [JsonPropertyName("colorTemperature")] public float? ColorTemperature { get; set; }
+            [JsonPropertyName("cookieSize")] public float? CookieSize { get; set; }
+            [JsonPropertyName("cullingMask")] public int? CullingMask { get; set; }
+            [JsonPropertyName("renderMode")] public string? RenderMode { get; set; }
+        }
+
+        [McpPluginTool
+        (
+            ScreenshotIsolatedToolId,
+            Title = "Screenshot / Isolated GameObject",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [Description("Renders a screenshot of a target GameObject with configurable isolation, background, "
+                   + "camera angle, and lighting — without modifying the scene. When isolated=true (default), "
+                   + "only the target object is visible via layer-based culling. Supports custom multi-light "
+                   + "setups via JSON. Returns a base64-encoded PNG.")]
+        public ResponseCallTool ScreenshotIsolated
+        (
+            [Description("Reference to the target GameObject (by instanceId, path, or name).")]
+            GameObjectRef gameObjectRef,
+            [Description("Include child GameObjects in the render. Default: true.")]
+            bool? includeChildren = true,
+            [Description("When true, renders only the target object using layer-based culling. "
+                       + "When false, renders the full scene from the computed camera position. Default: true.")]
+            bool? isolated = true,
+            [Description("Background mode. Default: SolidColor.")]
+            BackgroundMode? backgroundMode = BackgroundMode.SolidColor,
+            [Description("Hex background color (e.g. '#404040'). Only used when backgroundMode is SolidColor.")]
+            string? backgroundColor = "#404040",
+            [Description("Camera angle relative to the target object's bounding box. Default: Front.")]
+            CameraView? cameraView = CameraView.Front,
+            [Description("Camera vertical field of view in degrees. Default: 60.")]
+            float? fieldOfView = 60f,
+            [Description("Camera near clip plane distance. Default: 0.01.")]
+            float? nearClipPlane = 0.01f,
+            [Description("Camera far clip plane distance. Default: 1000.")]
+            float? farClipPlane = 1000f,
+            [Description("Framing multiplier around the object. 1.0 = tight fit, 1.5 = 50% extra space. Default: 1.2.")]
+            float? padding = 1.2f,
+            [Description("JSON array of light configurations. Each object defines type, color, intensity, "
+                       + "rotation, position, range, spotAngle, shadows, etc. "
+                       + "When null, a default white directional light at rotation (50,-30,0) is used. "
+                       + "Example: [{\"type\":\"Directional\",\"color\":\"#FFF4E5\",\"intensity\":1.2,\"rotation\":[45,-45,0]}]")]
+            string? lights = null,
+            [Description("Output image resolution in pixels (width = height). Default: 512.")]
+            int? resolution = 512
+        )
+        {
+            var resolvedResolution = resolution ?? 512;
+            if (resolvedResolution < MinResolution || resolvedResolution > MaxResolution)
+                return ResponseCallTool.Error(
+                    $"Resolution must be between {MinResolution} and {MaxResolution} pixels. Got {resolvedResolution}.");
+
+            if (gameObjectRef == null)
+                return ResponseCallTool.Error("[Error] gameObjectRef is required.");
+
+            var resolvedIncludeChildren = includeChildren ?? true;
+            var resolvedIsolated = isolated ?? true;
+            var resolvedBackgroundMode = backgroundMode ?? BackgroundMode.SolidColor;
+            var resolvedBackgroundColor = backgroundColor ?? "#404040";
+            var resolvedCameraView = cameraView ?? CameraView.Front;
+            var resolvedFov = fieldOfView ?? 60f;
+            var resolvedNear = nearClipPlane ?? 0.01f;
+            var resolvedFar = farClipPlane ?? 1000f;
+            var resolvedPadding = padding ?? 1.2f;
+
+            List<IsolatedLightConfig> lightConfigs;
+            try
+            {
+                lightConfigs = ParseLights(lights);
+            }
+            catch (JsonException ex)
+            {
+                return ResponseCallTool.Error($"[Error] Failed to parse lights JSON: {ex.Message}");
+            }
+
+            if (!ColorUtility.TryParseHtmlString(resolvedBackgroundColor, out var clearColor))
+                return ResponseCallTool.Error($"[Error] Invalid backgroundColor '{resolvedBackgroundColor}'. Expected hex format like '#404040'.");
+
+            return MainThread.Instance.Run(() =>
+            {
+                var target = gameObjectRef.FindGameObject(out var findError);
+                if (target == null)
+                {
+                    return ResponseCallTool.Error(string.IsNullOrEmpty(findError)
+                        ? "[Error] GameObject not found for the given reference."
+                        : $"[Error] GameObject not found: {findError}");
+                }
+
+                var renderers = CollectRenderers(target, resolvedIncludeChildren);
+                if (renderers.Count == 0)
+                    return ResponseCallTool.Error("[Error] No Renderers found on target GameObject. Cannot compute bounds.");
+
+                var bounds = ComputeBounds(renderers);
+
+                var targetGameObjects = resolvedIncludeChildren
+                    ? CollectAllGameObjects(target)
+                    : new List<GameObject> { target };
+
+                var originalLayers = new Dictionary<GameObject, int>(targetGameObjects.Count);
+                var originalActiveSelf = new Dictionary<GameObject, bool>(targetGameObjects.Count);
+                var temporaryObjects = new List<GameObject>();
+                RenderTexture? renderTexture = null;
+                Texture2D? readbackTexture = null;
+                var prevActiveRT = RenderTexture.active;
+
+                try
+                {
+                    foreach (var go in targetGameObjects)
+                    {
+                        originalLayers[go] = go.layer;
+                        originalActiveSelf[go] = go.activeSelf;
+                        if (!go.activeSelf)
+                            go.SetActive(true);
+                        if (resolvedIsolated)
+                            go.layer = IsolationLayer;
+                    }
+
+                    var rtFormat = resolvedBackgroundMode == BackgroundMode.Transparent
+                        ? RenderTextureFormat.ARGB32
+                        : RenderTextureFormat.ARGB32;
+
+                    byte[] pngBytes;
+                    if (resolvedCameraView == CameraView.Composite)
+                    {
+                        pngBytes = RenderComposite(
+                            bounds,
+                            resolvedResolution,
+                            resolvedIsolated,
+                            resolvedBackgroundMode,
+                            clearColor,
+                            resolvedFov,
+                            resolvedNear,
+                            resolvedFar,
+                            resolvedPadding,
+                            lightConfigs,
+                            temporaryObjects,
+                            rtFormat);
+                    }
+                    else
+                    {
+                        renderTexture = new RenderTexture(resolvedResolution, resolvedResolution, 24, rtFormat);
+                        renderTexture.Create();
+
+                        SetUpLights(lightConfigs, bounds, resolvedIsolated, temporaryObjects);
+
+                        pngBytes = RenderSingleView(
+                            resolvedCameraView,
+                            bounds,
+                            resolvedIsolated,
+                            resolvedBackgroundMode,
+                            clearColor,
+                            resolvedFov,
+                            resolvedNear,
+                            resolvedFar,
+                            resolvedPadding,
+                            renderTexture,
+                            temporaryObjects,
+                            out readbackTexture);
+                    }
+
+                    return ResponseCallTool.Image(pngBytes, McpPlugin.Common.Consts.MimeType.ImagePng,
+                        $"Isolated screenshot of '{target.name}' ({resolvedCameraView}, {resolvedResolution}x{resolvedResolution})");
+                }
+                finally
+                {
+                    foreach (var kvp in originalLayers)
+                    {
+                        if (kvp.Key != null)
+                            kvp.Key.layer = kvp.Value;
+                    }
+                    foreach (var kvp in originalActiveSelf)
+                    {
+                        if (kvp.Key != null && kvp.Key.activeSelf != kvp.Value)
+                            kvp.Key.SetActive(kvp.Value);
+                    }
+                    foreach (var go in temporaryObjects)
+                    {
+                        if (go != null)
+                            UnityEngine.Object.DestroyImmediate(go);
+                    }
+                    RenderTexture.active = prevActiveRT;
+                    if (readbackTexture != null)
+                        UnityEngine.Object.DestroyImmediate(readbackTexture);
+                    if (renderTexture != null)
+                    {
+                        renderTexture.Release();
+                        UnityEngine.Object.DestroyImmediate(renderTexture);
+                    }
+                }
+            });
+        }
+
+        private static List<IsolatedLightConfig> ParseLights(string? lights)
+        {
+            if (string.IsNullOrWhiteSpace(lights))
+            {
+                return new List<IsolatedLightConfig>
+                {
+                    new IsolatedLightConfig
+                    {
+                        Type = "Directional",
+                        Color = "#FFFFFF",
+                        Intensity = 1.0f,
+                        Rotation = new[] { 50f, -30f, 0f }
+                    }
+                };
+            }
+
+            var parsed = System.Text.Json.JsonSerializer.Deserialize<List<IsolatedLightConfig>>(lights!);
+            if (parsed == null || parsed.Count == 0)
+            {
+                return new List<IsolatedLightConfig>
+                {
+                    new IsolatedLightConfig
+                    {
+                        Type = "Directional",
+                        Color = "#FFFFFF",
+                        Intensity = 1.0f,
+                        Rotation = new[] { 50f, -30f, 0f }
+                    }
+                };
+            }
+            return parsed;
+        }
+
+        private static List<Renderer> CollectRenderers(GameObject target, bool includeChildren)
+        {
+            var list = new List<Renderer>();
+            if (includeChildren)
+            {
+                list.AddRange(target.GetComponentsInChildren<Renderer>(includeInactive: true));
+            }
+            else
+            {
+                var ownRenderers = target.GetComponents<Renderer>();
+                if (ownRenderers != null)
+                    list.AddRange(ownRenderers);
+            }
+            return list;
+        }
+
+        private static List<GameObject> CollectAllGameObjects(GameObject target)
+        {
+            var list = new List<GameObject> { target };
+            foreach (Transform child in target.GetComponentsInChildren<Transform>(includeInactive: true))
+            {
+                if (child != null && child.gameObject != target)
+                    list.Add(child.gameObject);
+            }
+            return list;
+        }
+
+        private static Bounds ComputeBounds(List<Renderer> renderers)
+        {
+            var initialised = false;
+            var bounds = new Bounds();
+            foreach (var r in renderers)
+            {
+                if (r == null) continue;
+                if (!initialised)
+                {
+                    bounds = r.bounds;
+                    initialised = true;
+                }
+                else
+                {
+                    bounds.Encapsulate(r.bounds);
+                }
+            }
+
+            if (!initialised || bounds.size == Vector3.zero)
+                bounds = new Bounds(bounds.center, Vector3.one * 0.1f);
+
+            return bounds;
+        }
+
+        private static (Vector3 direction, Vector3 up) GetViewDirectionAndUp(CameraView view)
+        {
+            switch (view)
+            {
+                case CameraView.Front:  return (new Vector3(0, 0, -1), Vector3.up);
+                case CameraView.Back:   return (new Vector3(0, 0, 1),  Vector3.up);
+                case CameraView.Left:   return (new Vector3(-1, 0, 0), Vector3.up);
+                case CameraView.Right:  return (new Vector3(1, 0, 0),  Vector3.up);
+                case CameraView.Top:    return (new Vector3(0, 1, 0),  Vector3.forward);
+                case CameraView.Bottom: return (new Vector3(0, -1, 0), Vector3.forward);
+                default:                return (new Vector3(0, 0, -1), Vector3.up);
+            }
+        }
+
+        private static Camera CreateTemporaryCamera(
+            CameraView view,
+            Bounds bounds,
+            bool isolated,
+            BackgroundMode backgroundMode,
+            Color clearColor,
+            float fov,
+            float near,
+            float far,
+            float padding,
+            RenderTexture target,
+            List<GameObject> temporaryObjects)
+        {
+            var cameraGo = new GameObject("__TempIsolationCamera");
+            cameraGo.hideFlags = HideFlags.HideAndDontSave;
+            temporaryObjects.Add(cameraGo);
+
+            var cam = cameraGo.AddComponent<Camera>();
+            cam.fieldOfView = fov;
+            cam.nearClipPlane = near;
+            cam.farClipPlane = far;
+            cam.targetTexture = target;
+            cam.allowHDR = false;
+            cam.allowMSAA = false;
+
+            switch (backgroundMode)
+            {
+                case BackgroundMode.SolidColor:
+                    cam.clearFlags = CameraClearFlags.SolidColor;
+                    cam.backgroundColor = clearColor;
+                    break;
+                case BackgroundMode.Skybox:
+                    cam.clearFlags = CameraClearFlags.Skybox;
+                    break;
+                case BackgroundMode.Transparent:
+                    cam.clearFlags = CameraClearFlags.SolidColor;
+                    cam.backgroundColor = new Color(0f, 0f, 0f, 0f);
+                    break;
+            }
+
+            cam.cullingMask = isolated ? (1 << IsolationLayer) : ~0;
+
+            var radius = bounds.extents.magnitude;
+            if (radius < 0.0001f)
+                radius = 0.05f;
+
+            var fovRad = Mathf.Max(fov, 1f) * 0.5f * Mathf.Deg2Rad;
+            var distance = (radius * Mathf.Max(padding, 0.01f)) / Mathf.Sin(fovRad);
+
+            var (dir, up) = GetViewDirectionAndUp(view);
+            cameraGo.transform.position = bounds.center + dir * distance;
+            cameraGo.transform.LookAt(bounds.center, up);
+
+            return cam;
+        }
+
+        private static void SetUpLights(
+            List<IsolatedLightConfig> configs,
+            Bounds bounds,
+            bool isolated,
+            List<GameObject> temporaryObjects)
+        {
+            var index = 0;
+            foreach (var cfg in configs)
+            {
+                var lightGo = new GameObject($"__TempIsolationLight_{index++}");
+                lightGo.hideFlags = HideFlags.HideAndDontSave;
+                temporaryObjects.Add(lightGo);
+
+                var light = lightGo.AddComponent<Light>();
+                ApplyLightConfig(light, lightGo.transform, cfg, bounds);
+
+                if (cfg.CullingMask.HasValue)
+                {
+                    light.cullingMask = cfg.CullingMask.Value;
+                }
+                else
+                {
+                    light.cullingMask = isolated ? (1 << IsolationLayer) : ~0;
+                }
+            }
+        }
+
+        private static void ApplyLightConfig(Light light, Transform xform, IsolatedLightConfig cfg, Bounds bounds)
+        {
+            light.type = ParseLightType(cfg.Type);
+            light.intensity = cfg.Intensity ?? 1.0f;
+
+            var colorHex = cfg.Color ?? "#FFFFFF";
+            light.color = ColorUtility.TryParseHtmlString(colorHex, out var c) ? c : Color.white;
+
+            var rot = cfg.Rotation;
+            xform.rotation = (rot != null && rot.Length >= 3)
+                ? Quaternion.Euler(rot[0], rot[1], rot[2])
+                : Quaternion.Euler(50f, -30f, 0f);
+
+            if (cfg.Position != null && cfg.Position.Length >= 3)
+            {
+                xform.position = new Vector3(cfg.Position[0], cfg.Position[1], cfg.Position[2]);
+            }
+            else if (light.type == LightType.Point || light.type == LightType.Spot)
+            {
+                xform.position = bounds.center - xform.forward * Mathf.Max(bounds.extents.magnitude * 2f, 1f);
+            }
+
+            if (cfg.Range.HasValue)
+                light.range = cfg.Range.Value;
+            if (cfg.SpotAngle.HasValue)
+                light.spotAngle = cfg.SpotAngle.Value;
+            if (cfg.InnerSpotAngle.HasValue)
+                light.innerSpotAngle = cfg.InnerSpotAngle.Value;
+            if (cfg.BounceIntensity.HasValue)
+                light.bounceIntensity = cfg.BounceIntensity.Value;
+            if (cfg.ColorTemperature.HasValue)
+            {
+                light.useColorTemperature = true;
+                light.colorTemperature = cfg.ColorTemperature.Value;
+            }
+            if (cfg.CookieSize.HasValue)
+                light.cookieSize = cfg.CookieSize.Value;
+
+            light.shadows = ParseShadows(cfg.Shadows);
+            if (cfg.ShadowStrength.HasValue)
+                light.shadowStrength = Mathf.Clamp01(cfg.ShadowStrength.Value);
+
+            light.renderMode = ParseRenderMode(cfg.RenderMode);
+        }
+
+        private static LightType ParseLightType(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return LightType.Directional;
+            return Enum.TryParse<LightType>(value, ignoreCase: true, out var parsed) ? parsed : LightType.Directional;
+        }
+
+        private static LightShadows ParseShadows(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return LightShadows.None;
+            return Enum.TryParse<LightShadows>(value, ignoreCase: true, out var parsed) ? parsed : LightShadows.None;
+        }
+
+        private static LightRenderMode ParseRenderMode(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return LightRenderMode.Auto;
+            return Enum.TryParse<LightRenderMode>(value, ignoreCase: true, out var parsed) ? parsed : LightRenderMode.Auto;
+        }
+
+        private static byte[] RenderSingleView(
+            CameraView view,
+            Bounds bounds,
+            bool isolated,
+            BackgroundMode backgroundMode,
+            Color clearColor,
+            float fov,
+            float near,
+            float far,
+            float padding,
+            RenderTexture target,
+            List<GameObject> temporaryObjects,
+            out Texture2D readbackTexture)
+        {
+            var cam = CreateTemporaryCamera(view, bounds, isolated, backgroundMode, clearColor, fov, near, far, padding, target, temporaryObjects);
+            cam.Render();
+
+            var prev = RenderTexture.active;
+            RenderTexture.active = target;
+            var format = backgroundMode == BackgroundMode.Transparent ? TextureFormat.ARGB32 : TextureFormat.RGB24;
+            readbackTexture = new Texture2D(target.width, target.height, format, false);
+            try
+            {
+                readbackTexture.ReadPixels(new Rect(0, 0, target.width, target.height), 0, 0);
+                readbackTexture.Apply();
+                return readbackTexture.EncodeToPNG();
+            }
+            finally
+            {
+                RenderTexture.active = prev;
+            }
+        }
+
+        private static byte[] RenderComposite(
+            Bounds bounds,
+            int subResolution,
+            bool isolated,
+            BackgroundMode backgroundMode,
+            Color clearColor,
+            float fov,
+            float near,
+            float far,
+            float padding,
+            List<IsolatedLightConfig> lightConfigs,
+            List<GameObject> temporaryObjects,
+            RenderTextureFormat rtFormat)
+        {
+            var quadrantViews = new[] { CameraView.Front, CameraView.Right, CameraView.Back, CameraView.Top };
+            var compositeSize = subResolution * 2;
+            var format = backgroundMode == BackgroundMode.Transparent ? TextureFormat.ARGB32 : TextureFormat.RGB24;
+
+            SetUpLights(lightConfigs, bounds, isolated, temporaryObjects);
+
+            var compositeTex = new Texture2D(compositeSize, compositeSize, format, false);
+            try
+            {
+                var clearPixels = new Color32[compositeSize * compositeSize];
+                var fill = backgroundMode == BackgroundMode.Transparent ? new Color32(0, 0, 0, 0) : (Color32)clearColor;
+                for (var i = 0; i < clearPixels.Length; i++) clearPixels[i] = fill;
+                compositeTex.SetPixels32(clearPixels);
+
+                for (var i = 0; i < quadrantViews.Length; i++)
+                {
+                    var quadrantView = quadrantViews[i];
+                    RenderTexture? rt = null;
+                    Texture2D? subTex = null;
+                    try
+                    {
+                        rt = new RenderTexture(subResolution, subResolution, 24, rtFormat);
+                        rt.Create();
+
+                        var localTemps = new List<GameObject>();
+                        var cam = CreateTemporaryCamera(quadrantView, bounds, isolated, backgroundMode, clearColor, fov, near, far, padding, rt, localTemps);
+                        cam.Render();
+
+                        var prev = RenderTexture.active;
+                        RenderTexture.active = rt;
+                        subTex = new Texture2D(subResolution, subResolution, format, false);
+                        try
+                        {
+                            subTex.ReadPixels(new Rect(0, 0, subResolution, subResolution), 0, 0);
+                            subTex.Apply();
+                        }
+                        finally
+                        {
+                            RenderTexture.active = prev;
+                        }
+
+                        var (dstX, dstY) = QuadrantOffset(i, subResolution);
+                        var srcPixels = subTex.GetPixels32();
+                        compositeTex.SetPixels32(dstX, dstY, subResolution, subResolution, srcPixels);
+
+                        foreach (var go in localTemps)
+                            if (go != null) UnityEngine.Object.DestroyImmediate(go);
+                    }
+                    finally
+                    {
+                        if (subTex != null)
+                            UnityEngine.Object.DestroyImmediate(subTex);
+                        if (rt != null)
+                        {
+                            rt.Release();
+                            UnityEngine.Object.DestroyImmediate(rt);
+                        }
+                    }
+                }
+
+                compositeTex.Apply();
+                return compositeTex.EncodeToPNG();
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(compositeTex);
+            }
+        }
+
+        private static (int x, int y) QuadrantOffset(int index, int sub)
+        {
+            // Layout (Unity texture origin = bottom-left):
+            //   top-left = Front,   top-right = Right
+            //   bot-left = Back,    bot-right = Top
+            switch (index)
+            {
+                case 0: return (0, sub);       // Front -> top-left
+                case 1: return (sub, sub);     // Right -> top-right
+                case 2: return (0, 0);         // Back  -> bottom-left
+                case 3: return (sub, 0);       // Top   -> bottom-right
+                default: return (0, 0);
+            }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -34,6 +34,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         private const int IsolationLayer = 31;
         private const int MinResolution = 1;
         private const int MaxResolution = 8192;
+        private const float MinFieldOfView = 1f;
+        private const float MaxFieldOfView = 179f;
+        private const float MinPadding = 0.01f;
+        private const float MaxPadding = 100f;
 
         public enum CameraView
         {
@@ -145,6 +149,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var resolvedFar = farClipPlane ?? 1000f;
             var resolvedPadding = padding ?? 1.2f;
 
+            if (!float.IsFinite(resolvedFov) || resolvedFov < MinFieldOfView || resolvedFov > MaxFieldOfView)
+                return ResponseCallTool.Error(
+                    $"fieldOfView must be finite and between {MinFieldOfView} and {MaxFieldOfView} degrees. Got {resolvedFov}.");
+
+            if (!float.IsFinite(resolvedPadding) || resolvedPadding < MinPadding || resolvedPadding > MaxPadding)
+                return ResponseCallTool.Error(
+                    $"padding must be finite and between {MinPadding} and {MaxPadding}. Got {resolvedPadding}.");
+
+            if (!float.IsFinite(resolvedNear) || resolvedNear <= 0f)
+                return ResponseCallTool.Error(
+                    $"nearClipPlane must be finite and > 0. Got {resolvedNear}.");
+
+            if (!float.IsFinite(resolvedFar) || resolvedFar <= resolvedNear)
+                return ResponseCallTool.Error(
+                    $"farClipPlane must be finite and > nearClipPlane ({resolvedNear}). Got {resolvedFar}.");
+
             List<IsolatedLightConfig> lightConfigs;
             try
             {
@@ -170,13 +190,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 var renderers = CollectRenderers(target, resolvedIncludeChildren);
                 if (renderers.Count == 0)
-                    return ResponseCallTool.Error("[Error] No Renderers found on target GameObject. Cannot compute bounds.");
+                    return ResponseCallTool.Error(resolvedIncludeChildren
+                        ? "[Error] No Renderers found on target GameObject or its children. Cannot compute bounds."
+                        : "[Error] No Renderers found on target GameObject (includeChildren=false). Set includeChildren=true if renderers live on child objects.");
 
                 var bounds = ComputeBounds(renderers);
 
-                var targetGameObjects = resolvedIncludeChildren
-                    ? CollectAllGameObjects(target)
-                    : new List<GameObject> { target };
+                var targetGameObjects = CollectAllGameObjects(target, resolvedIncludeChildren);
 
                 var originalLayers = new Dictionary<GameObject, int>(targetGameObjects.Count);
                 var originalActiveSelf = new Dictionary<GameObject, bool>(targetGameObjects.Count);
@@ -197,9 +217,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                             go.layer = IsolationLayer;
                     }
 
-                    var rtFormat = resolvedBackgroundMode == BackgroundMode.Transparent
-                        ? RenderTextureFormat.ARGB32
-                        : RenderTextureFormat.ARGB32;
+                    // ARGB32 is required for Transparent (alpha channel) and is acceptable for the
+                    // other modes; alpha is simply ignored when clearFlags fills it opaque.
+                    var rtFormat = RenderTextureFormat.ARGB32;
 
                     byte[] pngBytes;
                     if (resolvedCameraView == CameraView.Composite)
@@ -241,7 +261,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     }
 
                     return ResponseCallTool.Image(pngBytes, McpPlugin.Common.Consts.MimeType.ImagePng,
-                        $"Isolated screenshot of '{target.name}' ({resolvedCameraView}, {resolvedResolution}x{resolvedResolution})");
+                        $"Isolated screenshot of '{target.name}' ({resolvedCameraView}, {resolvedResolution}x{resolvedResolution}, isolated={resolvedIsolated}, backgroundMode={resolvedBackgroundMode})");
                 }
                 finally
                 {
@@ -274,36 +294,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
         private static List<IsolatedLightConfig> ParseLights(string? lights)
         {
+            // Null / whitespace → caller did not specify lights → use default.
+            // Empty array `[]` → caller explicitly disabled extra lights → return empty list.
             if (string.IsNullOrWhiteSpace(lights))
-            {
-                return new List<IsolatedLightConfig>
-                {
-                    new IsolatedLightConfig
-                    {
-                        Type = "Directional",
-                        Color = "#FFFFFF",
-                        Intensity = 1.0f,
-                        Rotation = new[] { 50f, -30f, 0f }
-                    }
-                };
-            }
+                return DefaultLights();
 
             var parsed = System.Text.Json.JsonSerializer.Deserialize<List<IsolatedLightConfig>>(lights!);
-            if (parsed == null || parsed.Count == 0)
-            {
-                return new List<IsolatedLightConfig>
-                {
-                    new IsolatedLightConfig
-                    {
-                        Type = "Directional",
-                        Color = "#FFFFFF",
-                        Intensity = 1.0f,
-                        Rotation = new[] { 50f, -30f, 0f }
-                    }
-                };
-            }
-            return parsed;
+            return parsed ?? DefaultLights();
         }
+
+        private static List<IsolatedLightConfig> DefaultLights() => new List<IsolatedLightConfig>
+        {
+            new IsolatedLightConfig
+            {
+                Type = "Directional",
+                Color = "#FFFFFF",
+                Intensity = 1.0f,
+                Rotation = new[] { 50f, -30f, 0f }
+            }
+        };
 
         private static List<Renderer> CollectRenderers(GameObject target, bool includeChildren)
         {
@@ -321,9 +330,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             return list;
         }
 
-        private static List<GameObject> CollectAllGameObjects(GameObject target)
+        private static List<GameObject> CollectAllGameObjects(GameObject target, bool includeChildren)
         {
             var list = new List<GameObject> { target };
+            if (!includeChildren)
+                return list;
+
             foreach (Transform child in target.GetComponentsInChildren<Transform>(includeInactive: true))
             {
                 if (child != null && child.gameObject != target)
@@ -587,8 +599,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         rt = new RenderTexture(subResolution, subResolution, 24, rtFormat);
                         rt.Create();
 
-                        var localTemps = new List<GameObject>();
-                        var cam = CreateTemporaryCamera(quadrantView, bounds, isolated, backgroundMode, clearColor, fov, near, far, padding, rt, localTemps);
+                        // Per-quadrant temp camera is appended to the outer temporaryObjects so
+                        // the caller's finally is the single source of truth for camera cleanup
+                        // even if anything below throws.
+                        var cam = CreateTemporaryCamera(quadrantView, bounds, isolated, backgroundMode, clearColor, fov, near, far, padding, rt, temporaryObjects);
                         cam.Render();
 
                         var prev = RenderTexture.active;
@@ -607,9 +621,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         var (dstX, dstY) = QuadrantOffset(i, subResolution);
                         var srcPixels = subTex.GetPixels32();
                         compositeTex.SetPixels32(dstX, dstY, subResolution, subResolution, srcPixels);
-
-                        foreach (var go in localTemps)
-                            if (go != null) UnityEngine.Object.DestroyImmediate(go);
                     }
                     finally
                     {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -38,6 +38,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         private const float MaxFieldOfView = 179f;
         private const float MinPadding = 0.01f;
         private const float MaxPadding = 100f;
+        private const float MaxNearClip = 1000f;
+        private const float MaxFarClip = 1e6f;
 
         public enum CameraView
         {
@@ -96,13 +98,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Enabled = false
         )]
         [Description("Renders a screenshot of a target GameObject with configurable isolation, background, "
-                   + "camera angle, and lighting — without modifying the scene. When isolated=true (default), "
-                   + "only the target object is visible via layer-based culling. Supports custom multi-light "
-                   + "setups via JSON. Returns a base64-encoded PNG.")]
+                   + "camera angle, and lighting. When isolated=true (default), only the target object is "
+                   + "visible via layer-based culling and inactive children of the target are temporarily "
+                   + "activated for the render (their OnEnable callbacks may fire — restored in finally, but "
+                   + "side effects like audio/network/animation events are not undoable). When isolated=false, "
+                   + "the existing scene state is rendered as-is without activating inactive objects. Supports "
+                   + "custom multi-light setups via JSON. Returns a base64-encoded PNG.")]
         public ResponseCallTool ScreenshotIsolated
         (
             [Description("Reference to the target GameObject (by instanceId, path, or name).")]
-            GameObjectRef gameObjectRef,
+            GameObjectRef? gameObjectRef,
             [Description("Include child GameObjects in the render. Default: true.")]
             bool? includeChildren = true,
             [Description("When true, renders only the target object using layer-based culling. "
@@ -157,13 +162,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 return ResponseCallTool.Error(
                     $"padding must be finite and between {MinPadding} and {MaxPadding}. Got {resolvedPadding}.");
 
-            if (!float.IsFinite(resolvedNear) || resolvedNear <= 0f)
+            if (!float.IsFinite(resolvedNear) || resolvedNear <= 0f || resolvedNear > MaxNearClip)
                 return ResponseCallTool.Error(
-                    $"nearClipPlane must be finite and > 0. Got {resolvedNear}.");
+                    $"nearClipPlane must be finite and in (0, {MaxNearClip}]. Got {resolvedNear}.");
 
-            if (!float.IsFinite(resolvedFar) || resolvedFar <= resolvedNear)
+            if (!float.IsFinite(resolvedFar) || resolvedFar <= resolvedNear || resolvedFar > MaxFarClip)
                 return ResponseCallTool.Error(
-                    $"farClipPlane must be finite and > nearClipPlane ({resolvedNear}). Got {resolvedFar}.");
+                    $"farClipPlane must be finite, > nearClipPlane ({resolvedNear}), and <= {MaxFarClip}. Got {resolvedFar}.");
 
             List<IsolatedLightConfig> lightConfigs;
             try
@@ -176,7 +181,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             }
 
             if (!ColorUtility.TryParseHtmlString(resolvedBackgroundColor, out var clearColor))
-                return ResponseCallTool.Error($"[Error] Invalid backgroundColor '{resolvedBackgroundColor}'. Expected hex format like '#404040'.");
+                return ResponseCallTool.Error($"[Error] Invalid backgroundColor '{resolvedBackgroundColor}'. Expected '#RRGGBB', '#RRGGBBAA', or a Unity color name (e.g. 'red').");
 
             return MainThread.Instance.Run(() =>
             {
@@ -211,10 +216,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     {
                         originalLayers[go] = go.layer;
                         originalActiveSelf[go] = go.activeSelf;
-                        if (!go.activeSelf)
-                            go.SetActive(true);
                         if (resolvedIsolated)
+                        {
+                            // Isolation requires the renderer's GameObject (and its hierarchy) to be active so
+                            // its renderer participates in the cull. When isolated=false, leave activeSelf alone
+                            // so we don't fire OnEnable on user scripts that the restore can't undo.
+                            if (!go.activeSelf)
+                                go.SetActive(true);
                             go.layer = IsolationLayer;
+                        }
                     }
 
                     // ARGB32 is required for Transparent (alpha channel) and is acceptable for the
@@ -420,6 +430,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     cam.clearFlags = CameraClearFlags.SolidColor;
                     cam.backgroundColor = new Color(0f, 0f, 0f, 0f);
                     break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(backgroundMode), backgroundMode, "Unsupported BackgroundMode.");
             }
 
             cam.cullingMask = isolated ? (1 << IsolationLayer) : ~0;
@@ -428,8 +440,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (radius < 0.0001f)
                 radius = 0.05f;
 
-            var fovRad = Mathf.Max(fov, 1f) * 0.5f * Mathf.Deg2Rad;
-            var distance = (radius * Mathf.Max(padding, 0.01f)) / Mathf.Sin(fovRad);
+            // Upfront validation in ScreenshotIsolated guarantees fov >= MinFieldOfView and padding >= MinPadding,
+            // so no defensive clamp is needed here.
+            var fovRad = fov * 0.5f * Mathf.Deg2Rad;
+            var distance = (radius * padding) / Mathf.Sin(fovRad);
 
             var (dir, up) = GetViewDirectionAndUp(view);
             cameraGo.transform.position = bounds.center + dir * distance;
@@ -654,7 +668,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 case 1: return (sub, sub);     // Right -> top-right
                 case 2: return (0, 0);         // Back  -> bottom-left
                 case 3: return (sub, 0);       // Top   -> bottom-right
-                default: return (0, 0);
+                default: throw new ArgumentOutOfRangeException(nameof(index), index, "Quadrant index must be 0..3.");
             }
         }
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b9eb09712b186945a94e9be2e51b1ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
@@ -1,0 +1,262 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+#if UNITY_6000_5_OR_NEWER
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using AIGD;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public class ScreenshotIsolatedTests : BaseTest
+    {
+        static GameObject CreateTargetCube(string name = "IsolatedTarget")
+        {
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = name;
+            return go;
+        }
+
+        [Test]
+        public void ScreenshotIsolated_NullGameObjectRef_ReturnsError()
+        {
+            var result = new Tool_Screenshot().ScreenshotIsolated(gameObjectRef: null!);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ResponseStatus.Error, result.Status, "Should error on null gameObjectRef");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_UnresolvableRef_ReturnsError()
+        {
+            var orphanRef = new GameObjectRef { Name = "__never_exists_in_scene__" };
+            var result = new Tool_Screenshot().ScreenshotIsolated(gameObjectRef: orphanRef);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ResponseStatus.Error, result.Status, "Should error when target cannot be resolved");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_NoRenderers_ReturnsError()
+        {
+            var go = new GameObject("EmptyTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+            var result = new Tool_Screenshot().ScreenshotIsolated(gameObjectRef: goRef, includeChildren: false);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ResponseStatus.Error, result.Status, "Should error when target has no renderers");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_DefaultIsolated_RestoresLayer()
+        {
+            var go = CreateTargetCube("LayerRestoreTarget");
+            const int OriginalLayer = 5;
+            go.layer = OriginalLayer;
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                resolution: 64);
+
+            Assert.IsNotNull(result);
+            Assert.AreNotEqual(ResponseStatus.Error, result.Status, "Should succeed with a primitive target");
+            Assert.AreEqual(OriginalLayer, go.layer, "Original layer must be restored after isolated screenshot");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_RestoresInactiveSelf()
+        {
+            var go = CreateTargetCube("InactiveTarget");
+            go.SetActive(false);
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                resolution: 64);
+
+            Assert.IsNotNull(result);
+            Assert.IsFalse(go.activeSelf, "activeSelf must be restored to false after the capture");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_NotIsolated_DoesNotChangeLayer()
+        {
+            var go = CreateTargetCube("NotIsolatedTarget");
+            const int OriginalLayer = 7;
+            go.layer = OriginalLayer;
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                isolated: false,
+                resolution: 64);
+
+            Assert.IsNotNull(result);
+            Assert.AreNotEqual(ResponseStatus.Error, result.Status);
+            Assert.AreEqual(OriginalLayer, go.layer, "Layer must remain untouched when isolated=false");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_AllSingleViews_Succeed()
+        {
+            var go = CreateTargetCube("ViewSweepTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var views = new[]
+            {
+                Tool_Screenshot.CameraView.Front,
+                Tool_Screenshot.CameraView.Back,
+                Tool_Screenshot.CameraView.Left,
+                Tool_Screenshot.CameraView.Right,
+                Tool_Screenshot.CameraView.Top,
+                Tool_Screenshot.CameraView.Bottom
+            };
+
+            foreach (var view in views)
+            {
+                var result = new Tool_Screenshot().ScreenshotIsolated(
+                    gameObjectRef: goRef,
+                    cameraView: view,
+                    resolution: 32);
+                Assert.IsNotNull(result, $"View {view} returned null");
+                Assert.AreNotEqual(ResponseStatus.Error, result.Status, $"View {view} should succeed");
+            }
+        }
+
+        [Test]
+        public void ScreenshotIsolated_CompositeView_Succeeds()
+        {
+            var go = CreateTargetCube("CompositeTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                cameraView: Tool_Screenshot.CameraView.Composite,
+                resolution: 32);
+
+            Assert.IsNotNull(result);
+            Assert.AreNotEqual(ResponseStatus.Error, result.Status, "Composite view should succeed");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_AllBackgroundModes_Succeed()
+        {
+            var go = CreateTargetCube("BackgroundSweepTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var modes = new[]
+            {
+                Tool_Screenshot.BackgroundMode.SolidColor,
+                Tool_Screenshot.BackgroundMode.Skybox,
+                Tool_Screenshot.BackgroundMode.Transparent
+            };
+
+            foreach (var mode in modes)
+            {
+                var result = new Tool_Screenshot().ScreenshotIsolated(
+                    gameObjectRef: goRef,
+                    backgroundMode: mode,
+                    resolution: 32);
+                Assert.IsNotNull(result, $"Background {mode} returned null");
+                Assert.AreNotEqual(ResponseStatus.Error, result.Status, $"Background {mode} should succeed");
+            }
+        }
+
+        [Test]
+        public void ScreenshotIsolated_CustomLightsJson_Parsed()
+        {
+            var go = CreateTargetCube("LightedTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            const string lightsJson = @"[
+                {""type"":""Directional"",""color"":""#FFF4E5"",""intensity"":1.2,""rotation"":[45,-45,0]},
+                {""type"":""Point"",""color"":""#4466FF"",""intensity"":0.5,""position"":[-3,2,2],""range"":15}
+            ]";
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                lights: lightsJson,
+                resolution: 32);
+
+            Assert.IsNotNull(result);
+            Assert.AreNotEqual(ResponseStatus.Error, result.Status, "Custom multi-light JSON should be accepted");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_InvalidLightsJson_ReturnsError()
+        {
+            var go = CreateTargetCube("BadLightsTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                lights: "{ this is not json",
+                resolution: 32);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ResponseStatus.Error, result.Status, "Invalid JSON should produce an error response");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_InvalidBackgroundColor_ReturnsError()
+        {
+            var go = CreateTargetCube("BadColorTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                backgroundColor: "not-a-color",
+                resolution: 32);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ResponseStatus.Error, result.Status, "Invalid background color hex should error");
+        }
+
+        [Test]
+        public void ScreenshotIsolated_OutOfRangeResolution_ReturnsError()
+        {
+            var go = CreateTargetCube("BadResolutionTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var result = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                resolution: 0);
+            Assert.AreEqual(ResponseStatus.Error, result.Status);
+
+            var result2 = new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                resolution: 100000);
+            Assert.AreEqual(ResponseStatus.Error, result2.Status);
+        }
+
+        [Test]
+        public void ScreenshotIsolated_NoTemporaryGameObjectsLeftBehind()
+        {
+            var go = CreateTargetCube("CleanupTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var beforeCount = Object.FindObjectsOfType<Camera>().Length;
+
+            new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                resolution: 32);
+
+            var afterCount = Object.FindObjectsOfType<Camera>().Length;
+            Assert.AreEqual(beforeCount, afterCount, "All temporary cameras must be destroyed in finally");
+
+            var leftoverLights = new List<Light>(Object.FindObjectsOfType<Light>()).FindAll(l =>
+                l != null && l.name != null && l.name.StartsWith("__TempIsolation"));
+            Assert.AreEqual(0, leftoverLights.Count, "All temporary lights must be destroyed in finally");
+        }
+    }
+}
+#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
@@ -257,6 +257,35 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 l != null && l.name != null && l.name.StartsWith("__TempIsolation"));
             Assert.AreEqual(0, leftoverLights.Count, "All temporary lights must be destroyed in finally");
         }
+
+        [Test]
+        public void ScreenshotIsolated_Composite_NoTemporaryGameObjectsLeftBehind()
+        {
+            var go = CreateTargetCube("CompositeCleanupTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var beforeCameras = Object.FindObjectsOfType<Camera>().Length;
+            var beforeLights = Object.FindObjectsOfType<Light>().Length;
+
+            new Tool_Screenshot().ScreenshotIsolated(
+                gameObjectRef: goRef,
+                cameraView: Tool_Screenshot.CameraView.Composite,
+                resolution: 32);
+
+            var afterCameras = Object.FindObjectsOfType<Camera>().Length;
+            Assert.AreEqual(beforeCameras, afterCameras, "All composite-quadrant temporary cameras must be destroyed in finally");
+
+            var leftoverIsolation = new List<GameObject>();
+            foreach (var camera in Object.FindObjectsOfType<Camera>())
+            {
+                if (camera != null && camera.name != null && camera.name.StartsWith("__TempIsolation"))
+                    leftoverIsolation.Add(camera.gameObject);
+            }
+            Assert.AreEqual(0, leftoverIsolation.Count, "No __TempIsolationCamera GameObjects must survive a composite render");
+
+            var afterLights = Object.FindObjectsOfType<Light>().Length;
+            Assert.AreEqual(beforeLights, afterLights, "All composite-quadrant temporary lights must be destroyed in finally");
+        }
     }
 }
 #endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
@@ -31,7 +31,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         [Test]
         public void ScreenshotIsolated_NullGameObjectRef_ReturnsError()
         {
-            var result = new Tool_Screenshot().ScreenshotIsolated(gameObjectRef: null!);
+            var result = new Tool_Screenshot().ScreenshotIsolated(gameObjectRef: null);
             Assert.IsNotNull(result);
             Assert.AreEqual(ResponseStatus.Error, result.Status, "Should error on null gameObjectRef");
         }
@@ -244,16 +244,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var go = CreateTargetCube("CleanupTarget");
             var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
 
-            var beforeCount = Object.FindObjectsOfType<Camera>().Length;
+            var beforeCount = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
 
             new Tool_Screenshot().ScreenshotIsolated(
                 gameObjectRef: goRef,
                 resolution: 32);
 
-            var afterCount = Object.FindObjectsOfType<Camera>().Length;
+            var afterCount = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
             Assert.AreEqual(beforeCount, afterCount, "All temporary cameras must be destroyed in finally");
 
-            var leftoverLights = new List<Light>(Object.FindObjectsOfType<Light>()).FindAll(l =>
+            var leftoverLights = new List<Light>(Object.FindObjectsByType<Light>(FindObjectsSortMode.None)).FindAll(l =>
                 l != null && l.name != null && l.name.StartsWith("__TempIsolation"));
             Assert.AreEqual(0, leftoverLights.Count, "All temporary lights must be destroyed in finally");
         }
@@ -264,26 +264,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var go = CreateTargetCube("CompositeCleanupTarget");
             var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
 
-            var beforeCameras = Object.FindObjectsOfType<Camera>().Length;
-            var beforeLights = Object.FindObjectsOfType<Light>().Length;
+            var beforeCameras = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
+            var beforeLights = Object.FindObjectsByType<Light>(FindObjectsSortMode.None).Length;
 
             new Tool_Screenshot().ScreenshotIsolated(
                 gameObjectRef: goRef,
                 cameraView: Tool_Screenshot.CameraView.Composite,
                 resolution: 32);
 
-            var afterCameras = Object.FindObjectsOfType<Camera>().Length;
+            var afterCameras = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
             Assert.AreEqual(beforeCameras, afterCameras, "All composite-quadrant temporary cameras must be destroyed in finally");
 
             var leftoverIsolation = new List<GameObject>();
-            foreach (var camera in Object.FindObjectsOfType<Camera>())
+            foreach (var camera in Object.FindObjectsByType<Camera>(FindObjectsSortMode.None))
             {
                 if (camera != null && camera.name != null && camera.name.StartsWith("__TempIsolation"))
                     leftoverIsolation.Add(camera.gameObject);
             }
             Assert.AreEqual(0, leftoverIsolation.Count, "No __TempIsolationCamera GameObjects must survive a composite render");
 
-            var afterLights = Object.FindObjectsOfType<Light>().Length;
+            var afterLights = Object.FindObjectsByType<Light>(FindObjectsSortMode.None).Length;
             Assert.AreEqual(beforeLights, afterLights, "All composite-quadrant temporary lights must be destroyed in finally");
         }
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c49b98fe085445349a84e0491e2be72e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Add `screenshot-isolated`, a new MCP tool that renders a target GameObject with full control over isolation, background, camera angle, and lighting — without mutating scene, assets, undo history, or editor state.
- Implements the non-destructive isolation strategy from the issue: transient layer-31 swap (when `isolated=true`), temporary camera + render texture + configurable lights, all torn down in `finally` so original layer values, `activeSelf`, and scene hierarchy are always restored — even on exception paths.
- Supports 7 camera views (Front/Back/Left/Right/Top/Bottom/Composite), 3 background modes (SolidColor/Skybox/Transparent), and JSON-configured multi-light setups (directional/point/spot with color, intensity, rotation, position, range, shadows, etc.). Returns a base64-encoded PNG.

## Test plan

- [x] Target-specific local tests passed (Unity EditMode, 875/875)
- [x] New `ScreenshotIsolatedTests` suite under `Tests/Editor/Tool/Screenshot/` covers all 6 single views + Composite, all 3 background modes, isolation on/off layer restoration, JSON light parsing (valid + invalid), error paths (null ref, unresolvable ref, no renderers, bad hex color, out-of-range resolution), and post-run cleanup of temporary cameras/lights.

Closes #619