### PR TITLE
fix: detach camera targetTexture before releasing per-quadrant RT in composite

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -95,7 +95,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Screenshot / Isolated GameObject",
             ReadOnlyHint = true,
             IdempotentHint = true,
-            Enabled = false
+            Enabled = true
         )]
         [Description("Renders a screenshot of a target GameObject with configurable isolation, background, "
                    + "camera angle, and lighting. When isolated=true (default), only the target object is "
@@ -608,6 +608,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     var quadrantView = quadrantViews[i];
                     RenderTexture? rt = null;
                     Texture2D? subTex = null;
+                    Camera? cam = null;
                     try
                     {
                         rt = new RenderTexture(subResolution, subResolution, 24, rtFormat);
@@ -616,7 +617,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         // Per-quadrant temp camera is appended to the outer temporaryObjects so
                         // the caller's finally is the single source of truth for camera cleanup
                         // even if anything below throws.
-                        var cam = CreateTemporaryCamera(quadrantView, bounds, isolated, backgroundMode, clearColor, fov, near, far, padding, rt, temporaryObjects);
+                        cam = CreateTemporaryCamera(quadrantView, bounds, isolated, backgroundMode, clearColor, fov, near, far, padding, rt, temporaryObjects);
                         cam.Render();
 
                         var prev = RenderTexture.active;
@@ -638,6 +639,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     }
                     finally
                     {
+                        // Detach the camera's targetTexture before releasing rt — Unity logs
+                        // "Releasing render texture that is set as Camera.targetTexture!" otherwise.
+                        // The camera GameObject itself is destroyed later in the outer finally
+                        // (it lives in temporaryObjects).
+                        if (cam != null)
+                            cam.targetTexture = null;
                         if (subTex != null)
                             UnityEngine.Object.DestroyImmediate(subTex);
                         if (rt != null)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
@@ -286,6 +286,40 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var afterLights = Object.FindObjectsByType<Light>(FindObjectsSortMode.None).Length;
             Assert.AreEqual(beforeLights, afterLights, "All composite-quadrant temporary lights must be destroyed in finally");
         }
+
+        [Test]
+        public void ScreenshotIsolated_Composite_NoRenderTextureReleaseWarning()
+        {
+            // Regression for: per-quadrant RenderTexture was being destroyed in the inner
+            // finally while the temp camera still had it as `targetTexture`, producing
+            // "Releasing render texture that is set as Camera.targetTexture!" warnings.
+            var go = CreateTargetCube("CompositeNoWarningTarget");
+            var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
+
+            var capturedWarnings = new List<string>();
+            Application.LogCallback handler = (condition, stackTrace, type) =>
+            {
+                if (type == LogType.Warning && condition.Contains("Releasing render texture"))
+                    capturedWarnings.Add(condition);
+            };
+
+            Application.logMessageReceived += handler;
+            try
+            {
+                new Tool_Screenshot().ScreenshotIsolated(
+                    gameObjectRef: goRef,
+                    cameraView: Tool_Screenshot.CameraView.Composite,
+                    resolution: 32);
+            }
+            finally
+            {
+                Application.logMessageReceived -= handler;
+            }
+
+            Assert.AreEqual(0, capturedWarnings.Count,
+                "Composite render must not emit 'Releasing render texture that is set as Camera.targetTexture!' warnings. "
+                + "Captured: " + string.Join("; ", capturedWarnings));
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary

Follow-up to #714. While manually visual-testing the new `screenshot-isolated` tool, found that composite mode was producing one `Releasing render texture that is set as Camera.targetTexture!` warning per quadrant in the editor Console.

**Root cause** (Tool_Screenshot.cs:646): per-quadrant RenderTexture was being released and destroyed in the inner `finally` while the temporary Camera (which lives in the outer `temporaryObjects` list and is destroyed later) still had the RT assigned as its `targetTexture`. Unity emits the warning, then auto-detaches when the Camera is destroyed in the outer `finally` — non-fatal, but noisy.

**Fix**: hoist `Camera? cam` outside the per-quadrant try block and explicitly set `cam.targetTexture = null` in the inner `finally` before releasing the RT.

Also: flip `Enabled = true` on `screenshot-isolated` so it is discoverable as an MCP tool out of the box. The original PR shipped `Enabled = false` to match the precedent set by the other screenshot tools, but this tool's value to LLMs is high enough that it should be enabled by default.

## Manual verification

Reproduced on Unity 2022.3.62f3 via the `unity-mcp-cli run-tool screenshot-isolated` path:

- **Pre-fix**: 1 composite invocation → 4 `Releasing render texture` warnings in `Editor.log` (one per quadrant), each with a stack trace pointing at `Screenshot.Isolated.cs:646`.
- **Post-fix**: 8 varied invocations (5 composites at 64/128/256/512, plus single-views with skybox/transparent/Top, isolated=false, child-only paths) → 0 new bytes appended to `Editor.log` over the run.

Composite output is byte-identical pre- vs post-fix (17,815 bytes for the 256×256 case).

## Regression test

`ScreenshotIsolated_Composite_NoRenderTextureReleaseWarning` subscribes to `Application.logMessageReceived` during a composite render and asserts no `Releasing render texture` warnings are emitted. Gated `#if UNITY_6000_5_OR_NEWER` like the rest of the file; runs on the Unity 6.5+ CI matrix jobs.

## Test plan

- [x] Local Unity 2022.3 EditMode suite: 875/0 (unchanged — ScreenshotIsolated tests are gated for Unity 6.5+ and don't execute on 2022)
- [x] Manual: 8 varied screenshot invocations, zero log warnings/errors
- [ ] CI Unity 6.5+ matrix exercises the new regression test