### PR TITLE
fix: reset stale install state on domain reload in UpdatePopupWindow

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
@@ -45,10 +45,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         [SerializeField] private string currentVersion = string.Empty;
         [SerializeField] private string latestVersion = string.Empty;
 
-        // Non-serialized: an in-flight Package Manager AddRequest cannot survive a domain
-        // reload (it holds native handles on the C++ side). After reload it goes back to null
-        // and the user can re-click "Install Update" to start a fresh install. Same applies
-        // to the R3 IDisposable subscription — re-clicking re-establishes it.
+        // The AddRequest holds a native Package Manager handle and the R3 subscription holds
+        // a reactive pipeline; neither survives a domain reload. Unity does, however, carry
+        // these private references over the reload boundary even without [SerializeField], so
+        // OnInstallUpdateClicked's "already in progress" guard would permanently lock the
+        // button. ResetInstallState() (called from OnEnable + OnDestroy) keeps the contract.
         private AddRequest? addRequest;
         private IDisposable? _stopSubscription;
 
@@ -75,6 +76,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             window.Focus();
 
             return window;
+        }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            ResetInstallState();
         }
 
         protected override void BindUI(VisualElement root)
@@ -226,11 +233,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             Close();
         }
 
-        void OnDestroy()
+        void OnDestroy() => ResetInstallState();
+
+        private void ResetInstallState()
         {
             EditorApplication.update -= OnPackageInstallProgress;
             _stopSubscription?.Dispose();
             _stopSubscription = null;
+            addRequest = null;
         }
     }
 }


### PR DESCRIPTION
## Summary

The **Install Update** button in `UpdatePopupWindow` stops responding after a Unity domain reload. The popup's other three buttons (View Releases / Skip Version / Do Not Show Again) continue to work — only the install button is dead.

## Root cause

`OnInstallUpdateClicked` has an "already in progress" guard:

```csharp
if (addRequest != null || _stopSubscription != null)
    return; // Already in progress
```

Both `addRequest` and `_stopSubscription` are private fields **without** `[SerializeField]`, and the prior code comment claimed Unity nulls them out at every domain reload. Empirically that is **false**: Unity carries these private references across the reload boundary via the managed-reference path. Once either is non-null, the guard early-returns on every subsequent click.

This was confirmed at runtime: after a NuGet-driven reload the click handler does fire (`OnInstallUpdateClicked` is logged), but the guard immediately returns. The other three handlers have no such guard and behave normally — which is exactly the symptom we observed.

## Fix

Extract `ResetInstallState()` and call it from:

- `OnEnable` — defensive reset after every reload, so the guard's contract holds across the AppDomain boundary.
- `OnDestroy` — existing teardown path.

Also adds the missing `addRequest = null` to that cleanup; the old `OnDestroy` only cleared `_stopSubscription`.

The `EditorApplication.update -= OnPackageInstallProgress` call inside `ResetInstallState()` is a no-op when nothing was subscribed (delegate registrations don't survive reload either), so it's safe to call unconditionally on every `OnEnable`.

## Why this is a follow-up to #706 / closes #702

#706 fixed the *first* class of stale state — empty version strings — by adding `[SerializeField]` to `currentVersion` / `latestVersion`. That made the install command have a valid version to install, but the install attempt was still being blocked at the guard above by the *second* class of stale state. #702's symptom ("popup becomes unfunctional after recompile") wasn't fully resolved until both are addressed.

## Diff

`UpdatePopupWindow.cs` only — +15 / -5 lines. No behavioural change for the in-session non-reload path; the guard semantics are preserved.

## Test plan

- [ ] Open `UpdatePopupWindow` (e.g. via `Tools/AI Game Developer/Check For Updates` after clearing the cooldown, or via the existing dev menu that force-shows it).
- [ ] Trigger a domain reload while the popup is open (any compile, package upgrade, or NuGet resolver swap will do).
- [ ] After the reload completes, click **Install Update** — the package install flow should kick off normally instead of silently no-op'ing.
- [ ] Click **View Releases**, **Skip Version**, **Do Not Show Again** — should continue to work as they did before.
- [ ] Confirm an in-session double-click on **Install Update** still no-ops (the guard's original purpose) — start an install, click again, second click should not start a parallel `Client.Add`.

Closes #702.