### PR TITLE
fix: update GUID in Console.meta to match new asset reference

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Console.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Console.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a1b2c3d4e5f6789012345678901234ab
+guid: ac4bc2cd169047408ed61eb6ca852612
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}


### PR DESCRIPTION
This pull request includes a minor update to the `.meta` file for the `Console` folder in the Editor tests. The change updates the `guid` value, which helps Unity track the asset's identity internally.

- Updated the `guid` in `Console.meta` to ensure proper asset tracking in Unity.