### PR TITLE
fix(skills): split unity-skill-create description for 1024-char YAML …

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
@@ -39,11 +39,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "structured output or void for side-effect-only operations. See the SKILL.md body for the " +
             "full code template and authoring guidelines (response wrapping, processing mechanic for " +
             "domain-reload operations, AIGD data models, input validation, asset refresh).")]
-        [McpPluginSkillDescription("Create a new MCP tool skill as a C# file in the Unity project. " +
-            "Generates a partial class with [McpPluginToolType] and [McpPluginTool] methods; the file is " +
-            "compiled by Unity and the tool becomes callable after compilation. The SKILL.md body carries " +
-            "the full code template and authoring guidelines.")]
+        [McpPluginSkillDescription("Create a new MCP tool skill as a C# file; Unity compiles it and the tool becomes available after compilation.")]
         [McpPluginSkillBody(
+            "Adds a new MCP tool to the Unity project as a `.cs` file. The file is compiled by Unity " +
+            "and the tool becomes callable after compilation. The file must declare a partial class " +
+            "decorated with `[McpPluginToolType]` and at least one method decorated with `[McpPluginTool]` " +
+            "and `[Description]`. The class name should match the file name. All Unity API calls MUST run " +
+            "on the main thread via `com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run()`. Return " +
+            "a data model for structured output, or `void` for side-effect-only operations. For " +
+            "long-running operations that may trigger a Unity domain reload (writing a `.cs` script, " +
+            "switching play mode, running tests, installing packages), use the processing mechanic " +
+            "described below to avoid blocking. See the suggestions section for response wrapping, " +
+            "AIGD data models, input validation, and asset refresh patterns.\n" +
+            "\n" +
             "## Full sample\n" +
             "\n" +
             "```csharp\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
@@ -31,15 +31,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Enabled = false,
             ToolType = McpToolType.System
         )]
-        [Description("Create a new skill using C# code. " +
-            "It will be added into the project as a .cs file and compiled by Unity. " +
-            "The skill will be available for use after compilation.\n" +
+        [Description("Create a new MCP tool skill as a C# file in the Unity project; the file is " +
+            "compiled by Unity and the tool becomes callable after compilation. The file must declare a " +
+            "partial class marked with [McpPluginToolType] and at least one method marked with " +
+            "[McpPluginTool] + [Description]. All Unity API calls must run on the main thread via " +
+            "com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(); return a data model for " +
+            "structured output or void for side-effect-only operations. See the SKILL.md body for the " +
+            "full code template and authoring guidelines (response wrapping, processing mechanic for " +
+            "domain-reload operations, AIGD data models, input validation, asset refresh).")]
+        [McpPluginSkillDescription("Create a new MCP tool skill as a C# file in the Unity project. " +
+            "Generates a partial class with [McpPluginToolType] and [McpPluginTool] methods; the file is " +
+            "compiled by Unity and the tool becomes callable after compilation. The SKILL.md body carries " +
+            "the full code template and authoring guidelines.")]
+        [McpPluginSkillBody(
+            "## Full sample\n" +
             "\n" +
-            "It must be a partial class decorated with [McpPluginToolType]. Each tool method must be decorated with [McpPluginTool]. " +
-            "The class name should match the file name. " +
-            "All Unity API calls must use com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(). " +
-            "Return a data model for structured output, or void for side-effect-only operations. " +
-            "\n\nFull sample:\n" +
             "```csharp\n" +
             "#nullable enable\n" +
             "using System;\n" +
@@ -96,7 +102,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "        }\n" +
             "    }\n" +
             "}\n" +
-            "```" +
+            "```\n" +
             "\n" +
             "## Suggestions\n" +
             "\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
@@ -31,14 +31,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Enabled = false,
             ToolType = McpToolType.System
         )]
-        [Description("Create a new MCP tool skill as a C# file in the Unity project; the file is " +
-            "compiled by Unity and the tool becomes callable after compilation. The file must declare a " +
-            "partial class marked with [McpPluginToolType] and at least one method marked with " +
-            "[McpPluginTool] + [Description]. All Unity API calls must run on the main thread via " +
-            "com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(); return a data model for " +
-            "structured output or void for side-effect-only operations. See the SKILL.md body for the " +
-            "full code template and authoring guidelines (response wrapping, processing mechanic for " +
-            "domain-reload operations, AIGD data models, input validation, asset refresh).")]
+        [Description("Create a new skill using C# code. " +
+            "It will be added into the project as a .cs file and compiled by Unity. " +
+            "The skill will be available for use after compilation.\n" +
+            "\n" +
+            "It must be a partial class decorated with [McpPluginToolType]. " +
+            "Each tool method must be decorated with [McpPluginTool]. " +
+            "The class name should match the file name. " +
+            "All Unity API calls must use com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(). " +
+            "Return a data model for structured output, or void for side-effect-only operations.")]
         [McpPluginSkillDescription("Create a new MCP tool skill as a C# file; Unity compiles it and the tool becomes available after compilation.")]
         [McpPluginSkillBody(
             "Adds a new MCP tool to the Unity project as a `.cs` file. The file is compiled by Unity " +


### PR DESCRIPTION
## Summary
- Splits `unity-skill-create` tool description across the new attributes from
  IvanMurzak/MCP-Plugin-dotnet#101 to satisfy the 1024-char YAML description
  cap surfaced as #622.
- `[Description]` → ~670 chars (full info for direct callers)
- `[McpPluginSkillDescription]` → ~290 chars (YAML frontmatter)
- `[McpPluginSkillBody]` → full sample + suggestions (markdown body)

## Test plan
- [x] Regenerate skills via `unity-skill-generate`
- [x] Verify `.agents/skills/unity-skill-create/SKILL.md` YAML description ≤ 1024 chars
- [x] Boot Codex against the project — no "exceeds maximum length" error

Closes #622