### PR TITLE
Add verbose timing logs for Unity editor discovery

### DIFF
--- a/cli/src/utils/unity-editor.ts
+++ b/cli/src/utils/unity-editor.ts
@@ -4,6 +4,7 @@ import { spawn } from 'child_process';
 import { platform } from 'os';
 import { findUnityHub, ensureUnityHub, listInstalledEditors } from './unity-hub.js';
 import * as ui from './ui.js';
+import { verbose } from './ui.js';
 
 /**
  * Compare two Unity version strings with numeric-aware sorting.
@@ -66,37 +67,64 @@ export function getProjectEditorVersion(projectPath: string): string | null {
  * Uses Unity Hub to locate installed editors. Installs Unity Hub automatically if needed.
  */
 export async function findEditorPath(version?: string): Promise<string | null> {
+  const startedAt = Date.now();
+  verbose(`findEditorPath start (version=${version ?? 'auto'})`);
+
   // Fast path: if we know the version, check common install locations first (instant filesystem check)
   if (version) {
+    const fastStartedAt = Date.now();
     const fastResult = findEditorPathByCommonLocations(version);
-    if (fastResult) return fastResult;
+    verbose(`findEditorPath fast path completed in ${Date.now() - fastStartedAt}ms (${fastResult ? 'hit' : 'miss'})`);
+    if (fastResult) {
+      verbose(`findEditorPath resolved via common locations in ${Date.now() - startedAt}ms`);
+      return fastResult;
+    }
   }
 
   // Slow path: query Unity Hub CLI for installed editors
+  const hubStartedAt = Date.now();
   const hubPath = await ensureUnityHub().catch(() => null);
+  verbose(`findEditorPath ensureUnityHub completed in ${Date.now() - hubStartedAt}ms (${hubPath ? 'found' : 'unavailable'})`);
   if (!hubPath) {
-    return findEditorPathByCommonLocations(version);
+    const fallbackStartedAt = Date.now();
+    const fallback = findEditorPathByCommonLocations(version);
+    verbose(`findEditorPath fallback common-location scan completed in ${Date.now() - fallbackStartedAt}ms (${fallback ? 'hit' : 'miss'})`);
+    verbose(`findEditorPath completed in ${Date.now() - startedAt}ms`);
+    return fallback;
   }
 
+  const listStartedAt = Date.now();
   const editors = listInstalledEditors(hubPath);
+  verbose(`findEditorPath listInstalledEditors completed in ${Date.now() - listStartedAt}ms (count=${editors.length})`);
   if (editors.length === 0) {
-    return findEditorPathByCommonLocations(version);
+    const fallbackStartedAt = Date.now();
+    const fallback = findEditorPathByCommonLocations(version);
+    verbose(`findEditorPath empty-editor fallback completed in ${Date.now() - fallbackStartedAt}ms (${fallback ? 'hit' : 'miss'})`);
+    verbose(`findEditorPath completed in ${Date.now() - startedAt}ms`);
+    return fallback;
   }
 
   if (version) {
     const match = editors.find((e) => e.version === version);
-    if (match) return getEditorBinary(match.path);
+    if (match) {
+      const resolved = getEditorBinary(match.path);
+      verbose(`findEditorPath matched requested version ${version} in ${Date.now() - startedAt}ms`);
+      return resolved;
+    }
   }
 
   // Return the highest installed editor by version-aware sorting
   const sorted = [...editors].sort((a, b) => compareUnityVersions(b.version, a.version));
-  return getEditorBinary(sorted[0].path);
+  const resolved = getEditorBinary(sorted[0].path);
+  verbose(`findEditorPath selected highest installed version ${sorted[0].version} in ${Date.now() - startedAt}ms`);
+  return resolved;
 }
 
 /**
  * Find editor by checking common installation directories.
  */
 function findEditorPathByCommonLocations(version?: string): string | null {
+  const startedAt = Date.now();
   const os = platform();
   const candidates: string[] = [];
 
@@ -157,10 +185,12 @@ function findEditorPathByCommonLocations(version?: string): string | null {
 
   for (const candidate of candidates) {
     if (fs.existsSync(candidate)) {
+      verbose(`findEditorPathByCommonLocations hit ${candidate} after ${Date.now() - startedAt}ms (${candidates.length} candidates)`);      
       return candidate;
     }
   }
 
+  verbose(`findEditorPathByCommonLocations miss after ${Date.now() - startedAt}ms (${candidates.length} candidates)`);
   return null;
 }
 

--- a/cli/src/utils/unity-hub.ts
+++ b/cli/src/utils/unity-hub.ts
@@ -25,6 +25,7 @@ const UNITY_HUB_DOWNLOAD_URLS: Record<string, string> = {
  * Returns the path if found, or null.
  */
 export function findUnityHub(): string | null {
+  const startedAt = Date.now();
   const plat = platform();
   const candidates: string[] = [];
 
@@ -48,14 +49,16 @@ export function findUnityHub(): string | null {
   }
 
   for (const candidate of candidates) {
+    const candidateStartedAt = Date.now();
     verbose(`Checking Unity Hub candidate: ${candidate}`);
     if (candidate && fs.existsSync(candidate)) {
-      verbose(`Found Unity Hub at: ${candidate}`);
+      verbose(`Found Unity Hub at: ${candidate} (${Date.now() - candidateStartedAt}ms for candidate, ${Date.now() - startedAt}ms total)`);
       return candidate;
     }
+    verbose(`Unity Hub candidate missing: ${candidate} (${Date.now() - candidateStartedAt}ms)`);
   }
 
-  verbose('Unity Hub not found in any candidate location');
+  verbose(`Unity Hub not found in any candidate location (${Date.now() - startedAt}ms total)`);
   return null;
 }
 
@@ -177,11 +180,17 @@ export async function installUnityHub(): Promise<string> {
  * Find Unity Hub, or install it automatically if not found.
  */
 export async function ensureUnityHub(): Promise<string> {
+  const startedAt = Date.now();
   const hubPath = findUnityHub();
-  if (hubPath) return hubPath;
+  if (hubPath) {
+    verbose(`ensureUnityHub reused existing installation in ${Date.now() - startedAt}ms`);
+    return hubPath;
+  }
 
   ui.warn('Unity Hub not found. Installing automatically...');
-  return installUnityHub();
+  const installedHubPath = await installUnityHub();
+  verbose(`ensureUnityHub installed Unity Hub in ${Date.now() - startedAt}ms`);
+  return installedHubPath;
 }
 
 export interface InstalledEditor {
@@ -213,12 +222,17 @@ export function parseInstalledEditorsLine(line: string): InstalledEditor | null 
 
 export function listInstalledEditors(hubPath: string): InstalledEditor[] {
   const spinner = ui.startSpinner('Listing installed editors...');
+  const startedAt = Date.now();
   try {
+    verbose(`listInstalledEditors invoking Unity Hub CLI: ${hubPath} -- --headless editors --installed`);
+    const execStartedAt = Date.now();
     const output = execFileSync(hubPath, ['--', '--headless', 'editors', '--installed'], {
       encoding: 'utf-8',
       timeout: 120000,
     });
+    verbose(`listInstalledEditors Unity Hub CLI returned in ${Date.now() - execStartedAt}ms`);
 
+    const parseStartedAt = Date.now();
     const editors: InstalledEditor[] = [];
     for (const line of output.split('\n')) {
       const editor = parseInstalledEditorsLine(line);
@@ -226,11 +240,14 @@ export function listInstalledEditors(hubPath: string): InstalledEditor[] {
         editors.push(editor);
       }
     }
+    verbose(`listInstalledEditors parsed ${editors.length} editor(s) in ${Date.now() - parseStartedAt}ms`);
 
     spinner.success(`Found ${editors.length} installed editor${editors.length !== 1 ? 's' : ''}`);
+    verbose(`listInstalledEditors completed in ${Date.now() - startedAt}ms`);
     return editors;
   } catch (err) {
     spinner.error(`Failed to list installed editors: ${(err as Error).message}`);
+    verbose(`listInstalledEditors failed after ${Date.now() - startedAt}ms`);
     return [];
   }
 }


### PR DESCRIPTION
## Summary

Add verbose timing logs around Unity editor discovery so we can see exactly where time is spent during lookup.

## What changed

- log total and phase timings in `findEditorPath(...)`
- log common-location cache/path scan hits and misses
- log Unity Hub candidate probing timings in `findUnityHub()`
- log `ensureUnityHub()` reuse/install timings
- log `listInstalledEditors(...)` invocation, Hub CLI runtime, parse time, and total runtime

## Why

Local profiling showed the slow step is Unity Hub startup during `--headless editors --installed`, not our own file scanning or parsing. These logs make that visible directly in `--verbose` output and help future investigations.

Closes #734
