### PR TITLE
fix: Unity 6.5+ CS0618 deprecations (Light.cookieSize, FindObjectsByType FindObjectsSortMode overload)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -515,7 +515,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 light.colorTemperature = cfg.ColorTemperature.Value;
             }
             if (cfg.CookieSize.HasValue)
+            {
+#if UNITY_6000_5_OR_NEWER
+                // Unity 6.5+ deprecated the float cookieSize in favour of Vector2 cookieSize2D.
+                // The IsolatedLightConfig wire shape stays a single float (uniform XY size) to
+                // preserve backwards-compatible JSON; expand it to (x,y) at the API boundary.
+                light.cookieSize2D = new Vector2(cfg.CookieSize.Value, cfg.CookieSize.Value);
+#else
                 light.cookieSize = cfg.CookieSize.Value;
+#endif
+            }
 
             light.shadows = ParseShadows(cfg.Shadows);
             if (cfg.ShadowStrength.HasValue)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs
@@ -244,16 +244,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var go = CreateTargetCube("CleanupTarget");
             var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
 
-            var beforeCount = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
+            var beforeCount = Object.FindObjectsByType<Camera>().Length;
 
             new Tool_Screenshot().ScreenshotIsolated(
                 gameObjectRef: goRef,
                 resolution: 32);
 
-            var afterCount = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
+            var afterCount = Object.FindObjectsByType<Camera>().Length;
             Assert.AreEqual(beforeCount, afterCount, "All temporary cameras must be destroyed in finally");
 
-            var leftoverLights = new List<Light>(Object.FindObjectsByType<Light>(FindObjectsSortMode.None)).FindAll(l =>
+            var leftoverLights = new List<Light>(Object.FindObjectsByType<Light>()).FindAll(l =>
                 l != null && l.name != null && l.name.StartsWith("__TempIsolation"));
             Assert.AreEqual(0, leftoverLights.Count, "All temporary lights must be destroyed in finally");
         }
@@ -264,26 +264,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var go = CreateTargetCube("CompositeCleanupTarget");
             var goRef = new GameObjectRef { InstanceID = go.GetEntityId() };
 
-            var beforeCameras = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
-            var beforeLights = Object.FindObjectsByType<Light>(FindObjectsSortMode.None).Length;
+            var beforeCameras = Object.FindObjectsByType<Camera>().Length;
+            var beforeLights = Object.FindObjectsByType<Light>().Length;
 
             new Tool_Screenshot().ScreenshotIsolated(
                 gameObjectRef: goRef,
                 cameraView: Tool_Screenshot.CameraView.Composite,
                 resolution: 32);
 
-            var afterCameras = Object.FindObjectsByType<Camera>(FindObjectsSortMode.None).Length;
+            var afterCameras = Object.FindObjectsByType<Camera>().Length;
             Assert.AreEqual(beforeCameras, afterCameras, "All composite-quadrant temporary cameras must be destroyed in finally");
 
             var leftoverIsolation = new List<GameObject>();
-            foreach (var camera in Object.FindObjectsByType<Camera>(FindObjectsSortMode.None))
+            foreach (var camera in Object.FindObjectsByType<Camera>())
             {
                 if (camera != null && camera.name != null && camera.name.StartsWith("__TempIsolation"))
                     leftoverIsolation.Add(camera.gameObject);
             }
             Assert.AreEqual(0, leftoverIsolation.Count, "No __TempIsolationCamera GameObjects must survive a composite render");
 
-            var afterLights = Object.FindObjectsByType<Light>(FindObjectsSortMode.None).Length;
+            var afterLights = Object.FindObjectsByType<Light>().Length;
             Assert.AreEqual(beforeLights, afterLights, "All composite-quadrant temporary lights must be destroyed in finally");
         }
 


### PR DESCRIPTION
## Summary
- Replace deprecated `Light.cookieSize` (float) with `Light.cookieSize2D` (Vector2) under `#if UNITY_6000_5_OR_NEWER` in `Editor/Scripts/API/Tool/Screenshot.Isolated.cs`. JSON wire shape stays a single float (uniform XY); expanded to (x, x) at the API boundary. Legacy `cookieSize` path retained under `#else` so the package keeps working on the stated minimum Unity 2022.3+.
- Replace every `Object.FindObjectsByType<T>(FindObjectsSortMode.None)` call site in `Tests/Editor/Tool/Screenshot/ScreenshotIsolatedTests.cs` with the parameterless `Object.FindObjectsByType<T>()`. None of the call sites passed `FindObjectsInactive`, so the active-only behavior is preserved. The whole file is already wrapped in `#if UNITY_6000_5_OR_NEWER`.
- Net effect: zero CS0618 warnings from these two surfaces on Unity 6.5+ while preserving runtime behavior on every supported Unity matrix.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): Unity EditMode 911/911 pass on Unity 2022.3.62f3, Unity PlayMode 1/1 pass.
- [ ] CI matrix (test-pull-request) including Unity 6.5+ to confirm CS0618 no longer fires from these two files.