### PR TITLE
fix: use EditorPrefs instead of PlayerPrefs for editor-only state

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
@@ -80,11 +80,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 // Running tests against a dirty scene is unsafe: Unity may reload the scene on
                 // play-mode entry, silently discarding edits and producing non-reproducible
                 // results. Throws InvalidOperationException listing every dirty scene so the
-                // caller can save and retry. MUST run before PlayerPrefs writes and before
+                // caller can save and retry. MUST run before EditorPrefs writes and before
                 // AssetDatabase.Refresh so nothing is side-effected on abort.
                 ThrowIfAnyOpenSceneIsDirty();
 
-                // Save display options to PlayerPrefs BEFORE AssetDatabase.Refresh —
+                // Save display options to EditorPrefs BEFORE AssetDatabase.Refresh —
                 // these must be persisted before a potential domain reload
                 TestResultCollector.TestCallRequestID.Value = requestId;
                 TestResultCollector.IncludePassingTests.Value = includePassingTests;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
@@ -180,7 +180,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         /// Running tests while a scene is dirty is unsafe: Unity may reload the scene when
         /// entering play mode, silently discarding the unsaved edits and producing a test run
         /// against a scene state that does not match either the in-memory scene or the asset
-        /// on disk. This check aborts before any state is mutated (no PlayerPrefs, no
+        /// on disk. This check aborts before any state is mutated (no EditorPrefs, no
         /// AssetDatabase.Refresh, no domain reload is triggered).
         ///
         /// MUST be called on the Unity main thread.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/TestResultCollector.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/TestResultCollector.cs
@@ -13,8 +13,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using com.IvanMurzak.Unity.MCP.Runtime.Utils;
-using Extensions.Unity.PlayerPrefsEx;
 using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
 
@@ -50,15 +50,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
             _ => "Unknown"
         };
 
-        public static PlayerPrefsString TestCallRequestID = new PlayerPrefsString("Unity_MCP_TestRunner_TestCallRequestID");
+        public static EditorPrefsString TestCallRequestID = new EditorPrefsString("Unity_MCP_TestRunner_TestCallRequestID");
 
-        public static PlayerPrefsBool IncludePassingTests = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludePassingTests");
-        public static PlayerPrefsBool IncludeMessage = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeMessage", true);
-        public static PlayerPrefsBool IncludeMessageStacktrace = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeStacktrace");
+        public static EditorPrefsBool IncludePassingTests = new EditorPrefsBool("Unity_MCP_TestRunner_IncludePassingTests");
+        public static EditorPrefsBool IncludeMessage = new EditorPrefsBool("Unity_MCP_TestRunner_IncludeMessage", true);
+        public static EditorPrefsBool IncludeMessageStacktrace = new EditorPrefsBool("Unity_MCP_TestRunner_IncludeStacktrace");
 
-        public static PlayerPrefsBool IncludeLogs = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeLogs");
-        public static PlayerPrefsInt IncludeLogsMinLevel = new PlayerPrefsInt("Unity_MCP_TestRunner_IncludeLogsMinLevel", (int)LogType.Warning);
-        public static PlayerPrefsBool IncludeLogsStacktrace = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeLogsStacktrace");
+        public static EditorPrefsBool IncludeLogs = new EditorPrefsBool("Unity_MCP_TestRunner_IncludeLogs");
+        public static EditorPrefsInt IncludeLogsMinLevel = new EditorPrefsInt("Unity_MCP_TestRunner_IncludeLogsMinLevel", (int)LogType.Warning);
+        public static EditorPrefsBool IncludeLogsStacktrace = new EditorPrefsBool("Unity_MCP_TestRunner_IncludeLogsStacktrace");
 
         public TestResultCollector()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
@@ -42,7 +42,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public abstract string AgentName { get; }
 
         /// <summary>
-        /// The unique identifier for this agent (used for dropdown values and PlayerPrefs).
+        /// The unique identifier for this agent (used for dropdown values and EditorPrefs).
         /// </summary>
         public abstract string AgentId { get; }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.AiAgents.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.AiAgents.cs
@@ -9,7 +9,7 @@
 */
 
 #nullable enable
-using Extensions.Unity.PlayerPrefsEx;
+using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using Microsoft.Extensions.Logging;
 using R3;
 using UnityEngine;
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 {
     public partial class MainWindowEditor
     {
-        internal static PlayerPrefsString selectedAiAgentId = new("Unity_MCP_SelectedAiAgent");
+        internal static EditorPrefsString selectedAiAgentId = new("Unity_MCP_SelectedAiAgent");
 
         private AiAgentConfigurator? currentAiAgentConfigurator;
 
@@ -48,7 +48,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             var agentNames = AiAgentConfiguratorRegistry.GetAgentNames();
             aiAgentDropdown.choices = agentNames;
 
-            // Load saved selection from PlayerPrefs
+            // Load saved selection from EditorPrefs
             var savedAiAgentId = selectedAiAgentId.Value;
             var selectedIndex = 0;
 
@@ -79,7 +79,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 var newIndex = agentNames.IndexOf(evt.newValue);
                 if (newIndex < 0) return;
 
-                // Save selection to PlayerPrefs
+                // Save selection to EditorPrefs
                 var configurator = AiAgentConfiguratorRegistry.All[newIndex];
                 selectedAiAgentId.Value = configurator.AgentId;
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowInitializer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowInitializer.cs
@@ -9,7 +9,7 @@
 */
 
 #nullable enable
-using Extensions.Unity.PlayerPrefsEx;
+using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using UnityEditor;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.UI
@@ -17,7 +17,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
     [InitializeOnLoad]
     static class MainWindowInitializer
     {
-        static PlayerPrefsBool isInitialized = new PlayerPrefsBool("Unity-MCP.MainWindow.Initialized");
+        static EditorPrefsBool isInitialized = new EditorPrefsBool("Unity-MCP.MainWindow.Initialized");
 
         static MainWindowInitializer()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/McpPromptsWindow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/McpPromptsWindow.cs
@@ -17,7 +17,6 @@ using System.Text.Json.Nodes;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using Extensions.Unity.PlayerPrefsEx;
 using Microsoft.Extensions.Logging;
 using R3;
 using UnityEngine.UIElements;
@@ -137,8 +136,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             public string Role { get; set; }
             public bool IsEnabled { get; set; }
             public IReadOnlyList<ArgumentData> Arguments { get; set; }
-            public PlayerPrefsBool descriptionExpanded;
-            public PlayerPrefsBool argumentsExpanded;
+            public EditorPrefsBool descriptionExpanded;
+            public EditorPrefsBool argumentsExpanded;
 
             public PromptViewModel(IPromptManager promptManager, IRunPrompt prompt)
             {
@@ -148,8 +147,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 Role = prompt.Role.ToString();
                 IsEnabled = promptManager?.IsPromptEnabled(prompt.Name) == true;
                 Arguments = ParseSchemaArguments(prompt.InputSchema);
-                descriptionExpanded = new PlayerPrefsBool(GetFoldoutKey(prompt.Name, "description-foldout"));
-                argumentsExpanded = new PlayerPrefsBool(GetFoldoutKey(prompt.Name, "arguments-foldout"));
+                descriptionExpanded = new EditorPrefsBool(GetFoldoutKey(prompt.Name, "description-foldout"));
+                argumentsExpanded = new EditorPrefsBool(GetFoldoutKey(prompt.Name, "arguments-foldout"));
             }
 
             private IReadOnlyList<ArgumentData> ParseSchemaArguments(JsonNode? schema)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/McpResourcesWindow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/McpResourcesWindow.cs
@@ -15,7 +15,6 @@ using System.Collections.Generic;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using Extensions.Unity.PlayerPrefsEx;
 using Microsoft.Extensions.Logging;
 using R3;
 using UnityEngine.UIElements;
@@ -127,7 +126,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             public string? Uri { get; set; }
             public string? MimeType { get; set; }
             public bool IsEnabled { get; set; }
-            public PlayerPrefsBool descriptionExpanded;
+            public EditorPrefsBool descriptionExpanded;
 
             public ResourceViewModel(IResourceManager resourceManager, IRunResource resource)
             {
@@ -136,7 +135,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 Uri = resource.Route;
                 MimeType = resource.MimeType;
                 IsEnabled = resourceManager?.IsResourceEnabled(resource.Name) == true;
-                descriptionExpanded = new PlayerPrefsBool(GetFoldoutKey(resource.Name, "description-foldout"));
+                descriptionExpanded = new EditorPrefsBool(GetFoldoutKey(resource.Name, "description-foldout"));
             }
 
             private string GetFoldoutKey(string resourceName, string foldoutName)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/McpToolsWindow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/McpToolsWindow.cs
@@ -17,7 +17,6 @@ using System.Text.Json.Nodes;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
-using Extensions.Unity.PlayerPrefsEx;
 using Microsoft.Extensions.Logging;
 using R3;
 using UnityEngine.UIElements;
@@ -162,9 +161,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             public IReadOnlyList<ArgumentData> Inputs { get; set; }
             public IReadOnlyList<ArgumentData> Outputs { get; set; }
             public string TokenCount { get; set; }
-            public PlayerPrefsBool descriptionExpanded;
-            public PlayerPrefsBool inputsExpanded;
-            public PlayerPrefsBool outputsExpanded;
+            public EditorPrefsBool descriptionExpanded;
+            public EditorPrefsBool inputsExpanded;
+            public EditorPrefsBool outputsExpanded;
 
             public ToolViewModel(IToolManager toolManager, IRunTool tool)
             {
@@ -175,9 +174,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 Inputs = ParseSchemaArguments(tool.InputSchema);
                 Outputs = ParseSchemaArguments(tool.OutputSchema);
                 TokenCount = UIMcpUtils.FormatTokenCount(tool.TokenCount);
-                descriptionExpanded = new PlayerPrefsBool(GetFoldoutKey(tool.Name, "description-foldout"));
-                inputsExpanded = new PlayerPrefsBool(GetFoldoutKey(tool.Name, "arguments-foldout"));
-                outputsExpanded = new PlayerPrefsBool(GetFoldoutKey(tool.Name, "outputs-foldout"));
+                descriptionExpanded = new EditorPrefsBool(GetFoldoutKey(tool.Name, "description-foldout"));
+                inputsExpanded = new EditorPrefsBool(GetFoldoutKey(tool.Name, "arguments-foldout"));
+                outputsExpanded = new EditorPrefsBool(GetFoldoutKey(tool.Name, "outputs-foldout"));
             }
 
             private IReadOnlyList<ArgumentData> ParseSchemaArguments(JsonNode? schema)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/EditorPrefsValue.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/EditorPrefsValue.cs
@@ -1,0 +1,95 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using UnityEditor;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Utils
+{
+    // Editor-only state used to be stored via PlayerPrefsEx (PlayerPrefsBool / String / Int).
+    // PlayerPrefs is the same store the player game uses for runtime settings, so when a user
+    // clears their game's save data — including audio volume or other runtime preferences —
+    // they also wipe editor-only state that has nothing to do with the game (e.g. the update
+    // checker's "Don't show again" choice, foldout expanded state, etc.). See
+    // https://github.com/IvanMurzak/Unity-MCP/issues/755.
+    //
+    // EditorPrefs is the correct backing store for editor-only state: it persists per Unity
+    // installation (Windows registry / macOS plist / Linux config dir), is never touched by
+    // PlayerPrefs.DeleteAll(), and is not even available at runtime. These thin wrappers
+    // mirror the PlayerPrefsEx `Value` property API so call sites can swap the type name
+    // with no other change. There is no `Save()` method — EditorPrefs persists immediately
+    // (verifiable: re-reading right after a set always returns the written value), so no
+    // explicit flush is required when migrating from PlayerPrefsEx.
+    public sealed class EditorPrefsBool
+    {
+        readonly string _key;
+        readonly bool _defaultValue;
+
+        public EditorPrefsBool(string key, bool defaultValue = false)
+        {
+            _key = key;
+            _defaultValue = defaultValue;
+        }
+
+        public string Key => _key;
+
+        public bool Value
+        {
+            get => EditorPrefs.GetBool(_key, _defaultValue);
+            set => EditorPrefs.SetBool(_key, value);
+        }
+
+        public void Delete() => EditorPrefs.DeleteKey(_key);
+    }
+
+    public sealed class EditorPrefsString
+    {
+        readonly string _key;
+        readonly string _defaultValue;
+
+        public EditorPrefsString(string key, string defaultValue = "")
+        {
+            _key = key;
+            _defaultValue = defaultValue;
+        }
+
+        public string Key => _key;
+
+        public string Value
+        {
+            get => EditorPrefs.GetString(_key, _defaultValue);
+            set => EditorPrefs.SetString(_key, value);
+        }
+
+        public void Delete() => EditorPrefs.DeleteKey(_key);
+    }
+
+    public sealed class EditorPrefsInt
+    {
+        readonly string _key;
+        readonly int _defaultValue;
+
+        public EditorPrefsInt(string key, int defaultValue = 0)
+        {
+            _key = key;
+            _defaultValue = defaultValue;
+        }
+
+        public string Key => _key;
+
+        public int Value
+        {
+            get => EditorPrefs.GetInt(_key, _defaultValue);
+            set => EditorPrefs.SetInt(_key, value);
+        }
+
+        public void Delete() => EditorPrefs.DeleteKey(_key);
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/EditorPrefsValue.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/EditorPrefsValue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 727cc6c904d045e8bbdf1b1e16354948
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -15,7 +15,6 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Editor.UI;
-using Extensions.Unity.PlayerPrefsEx;
 using Microsoft.Extensions.Logging;
 using UnityEditor;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -50,9 +49,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         // elsewhere in this package. The 10s timeout covers OpenUPM's slowest realistic responses.
         private static readonly HttpClient HttpClient = CreateHttpClient();
 
-        private static PlayerPrefsBool DoNotShowAgain = new("Unity-MCP.UpdateChecker.DoNotShowAgain");
-        private static PlayerPrefsString NextCheckTime = new("Unity-MCP.UpdateChecker.NextCheckTime");
-        private static PlayerPrefsString SkippedVersion = new("Unity-MCP.UpdateChecker.SkippedVersion");
+        // EditorPrefs (not PlayerPrefs) — these are editor-only states. Storing them in
+        // PlayerPrefs meant a user clearing their game's save data (PlayerPrefs.DeleteAll)
+        // would also reset the update checker. See
+        // https://github.com/IvanMurzak/Unity-MCP/issues/755.
+        private static EditorPrefsBool DoNotShowAgain = new("Unity-MCP.UpdateChecker.DoNotShowAgain");
+        private static EditorPrefsString NextCheckTime = new("Unity-MCP.UpdateChecker.NextCheckTime");
+        private static EditorPrefsString SkippedVersion = new("Unity-MCP.UpdateChecker.SkippedVersion");
 
         private static bool isChecking = false;
         private static string? latestVersion = null;
@@ -71,11 +74,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         public static bool IsDoNotShowAgain
         {
             get => DoNotShowAgain.Value;
-            set
-            {
-                DoNotShowAgain.Value = value;
-                PlayerPrefsEx.Save();
-            }
+            set => DoNotShowAgain.Value = value;
         }
 
         /// <summary>
@@ -140,7 +139,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         public static void SkipVersion(string version)
         {
             SkippedVersion.Value = version;
-            PlayerPrefsEx.Save();
         }
 
         /// <summary>
@@ -151,7 +149,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
             DoNotShowAgain.Value = false;
             NextCheckTime.Value = string.Empty;
             SkippedVersion.Value = string.Empty;
-            PlayerPrefsEx.Save();
         }
 
         /// <summary>
@@ -221,7 +218,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
                 if (!forceCheck)
                 {
                     NextCheckTime.Value = DateTime.UtcNow.AddHours(1).ToString("O");
-                    PlayerPrefsEx.Save();
                 }
                 isChecking = false;
             }


### PR DESCRIPTION
## Summary
- Migrate every editor-only PlayerPrefsEx usage (UpdateChecker, MainWindow init/foldouts, AI agent dropdown selection, test runner display options) onto a new lightweight `EditorPrefsBool` / `EditorPrefsString` / `EditorPrefsInt` wrapper backed by `UnityEditor.EditorPrefs`.
- Editor state is no longer wiped when a player clears their game's PlayerPrefs (the bug the issue reports). EditorPrefs lives in the Unity-installation store, not the per-project PlayerPrefs store.
- Wrappers mirror the PlayerPrefsEx `Value` API to keep call-site churn minimal. Stray `PlayerPrefsEx.Save()` calls are dropped because EditorPrefs persists immediately.

## Test plan
- [x] Unity EditMode tests passed locally (911/911, 0 failures), including the UpdateChecker preference-management tests that previously verified PlayerPrefs-backed behaviour and continue to verify it through the new EditorPrefs-backed implementation.

Closes #755