### PR TITLE
feat(skills): extend SkillDescription/Body coverage to remaining tools

### DIFF
--- a/Unity-MCP-Plugin/.claude/skills/assets-copy/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-copy/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: assets-copy
-description: Copy assets at given paths and store them at new paths. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before copying.
+description: Copy assets at given paths and store them at new paths. Refreshes the AssetDatabase at the end. Use 'assets-find' to locate the source assets first.
 ---
 
 # Assets / Copy
+
+Copy assets at given paths and store them at new paths. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before copying.
+
+## Inputs
+
+- `sourcePaths` — paths of the assets to copy.
+- `destinationPaths` — paths to store the copied assets (must match `sourcePaths` length).
+
+## Behavior
+
+Each source/destination pair is copied in order. Per-pair errors are accumulated in the response instead of throwing, so a single bad pair does not abort the whole batch.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-create-folder/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-create-folder/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: assets-create-folder
-description: Creates a new folder in the specified parent folder. The parent folder string must start with the 'Assets' folder, and all folders within the parent folder string must already exist. For example, when specifying 'Assets/ParentFolder1/ParentFolder2/', the new folder will be created in 'ParentFolder2' only if ParentFolder1 and ParentFolder2 already exist. Use it to organize scripts and assets in the project. Does AssetDatabase.Refresh() at the end. Returns the GUID of the newly created folder, if successful.
+description: Create a new folder under a parent folder inside 'Assets/'. The parent path must start with 'Assets/' and every intermediate folder in it must already exist. Refreshes the AssetDatabase at the end and returns the GUID(s) of the created folder(s).
 ---
 
 # Assets / Create Folder
+
+Creates a new folder in the specified parent folder. The parent folder string must start with the 'Assets' folder, and all folders within the parent folder string must already exist. For example, when specifying 'Assets/ParentFolder1/ParentFolder2/', the new folder will be created in 'ParentFolder2' only if ParentFolder1 and ParentFolder2 already exist. Use it to organize scripts and assets in the project. Does AssetDatabase.Refresh() at the end. Returns the GUID of the newly created folder, if successful.
+
+## Inputs
+
+- `inputs` — list of `{ParentFolderPath, NewFolderName}` entries. Each entry is processed independently; per-entry errors are collected in the response so a single bad input does not abort the batch.
+
+## Validation
+
+- `NewFolderName` must be non-empty and must not contain any of `/`, `\`, `<`, `>`, `:`, `"`, `|`, `?`, `*`, or control characters (these checks are cross-platform even on Linux/Mac).
+- `ParentFolderPath` must already exist as an `AssetDatabase.IsValidFolder` path.
+- A folder with the same target name must not already exist under the parent.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-delete/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-delete/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: assets-delete
-description: Delete the assets at paths from the project. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before deleting.
+description: Delete the assets at the given project paths. Refreshes the AssetDatabase at the end. Use 'assets-find' to locate the assets first.
 ---
 
 # Assets / Delete
+
+Delete the assets at paths from the project. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before deleting.
+
+## Inputs
+
+- `paths` — project-relative asset paths to delete. Must be non-empty.
+
+## Behavior
+
+Routes through `AssetDatabase.DeleteAssets`, which deletes the batch atomically. Paths Unity reports as failed are surfaced in `response.Errors`; successfully deleted paths are surfaced in `response.DeletedPaths`. The tool is destructive (removes files from disk).
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-find-built-in/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-find-built-in/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: assets-find-built-in
-description: "Search the built-in assets of the Unity Editor located in the built-in resources: Resources/unity_builtin_extra. Doesn't support GUIDs since built-in assets do not have them."
+description: Search the built-in assets of the Unity Editor (located at Resources/unity_builtin_extra). Filters by name and/or type; built-in assets have no GUID so GUID-based lookups are not supported.
 ---
 
 # Assets / Find (Built-in)
+
+Search the built-in assets of the Unity Editor located in the built-in resources: Resources/unity_builtin_extra. Doesn't support GUIDs since built-in assets do not have them.
+
+## Inputs
+
+- `name` (optional) — case-insensitive name fragment. Underscores, hyphens, spaces, and periods delimit search words so partial-word matching works.
+- `type` (optional) — restrict results to assets assignable to this type (e.g. `UnityEngine.Texture2D`).
+- `maxResults` — cap on returned list size (default 10).
+
+## Ranking
+
+Results are sorted by descending match quality: exact match → substring match → all-words match → partial-words match. Within a rank, results are sorted alphabetically by filename for stable ordering.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-find/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-find/SKILL.md
@@ -1,9 +1,22 @@
 ---
 name: assets-find
-description: Search the asset database using the search filter string. Allows you to search for Assets. The string argument can provide names, labels or types (classnames).
+description: "Search the Unity asset database using a search filter string. The filter accepts names, labels (`l:`), types (`t:`), AssetBundles (`b:`), areas (`a:`), and globs (`glob:`). See the body for the full filter syntax."
 ---
 
 # Assets / Find
+
+Search the asset database using the search filter string. Allows you to search for Assets. The string argument can provide names, labels or types (classnames).
+
+## Filter syntax
+
+- **Name** — filter assets by their filename (without extension). Words separated by whitespace are treated as separate name searches.
+- **Labels (`l:`)** — assets can have labels attached. Use `l:` before each label.
+- **Types (`t:`)** — find assets based on explicitly identified types. Available types include AnimationClip, AudioClip, AudioMixer, ComputeShader, Font, GUISkin, Material, Mesh, Model, PhysicMaterial, Prefab, Scene, Script, Shader, Sprite, Texture, VideoClip, VisualEffectAsset, VisualEffectSubgraph.
+- **AssetBundles (`b:`)** — find assets which are part of an Asset bundle.
+- **Area (`a:`)** — find assets in a specific area. Valid values: `all`, `assets`, `packages`.
+- **Globbing (`glob:`)** — use globbing to match specific rules.
+
+Searching is case-insensitive. Use `searchInFolders` to restrict the search scope. `maxResults` caps the returned list (default 10) — results beyond it are truncated.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-get-data/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-get-data/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: assets-get-data
-description: |-
-  Get asset data from the asset file in the Unity project. It includes all serializable fields and properties of the asset. Use 'assets-find' tool to find asset before using this tool.
-  
-  Path-scoped reads (token-saving): supply 'paths' (a list of paths) to read only the listed fields/elements via Reflector.TryReadAt, or 'viewQuery' (a ViewQuery) to navigate to a subtree and/or filter by name regex / max depth / type via Reflector.View. These two parameters are mutually exclusive — supply at most one. When neither is supplied the full asset is serialized as before (backwards compatible).
-  Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.
+description: Get asset data from the asset file in the Unity project — every serializable field and property. Supports token-saving path-scoped reads via `paths` or `viewQuery`. Use 'assets-find' to find the asset first.
 ---
 
 # Assets / Get Data
+
+Get asset data from the asset file in the Unity project. It includes all serializable fields and properties of the asset. Use 'assets-find' tool to find asset before using this tool.
+
+## Path-scoped reads (token-saving)
+
+Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type via `Reflector.View`. These two parameters are mutually exclusive — supply at most one. When neither is supplied the full asset is serialized (backwards compatible).
+
+## Path syntax
+
+`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-material-create/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-material-create/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: assets-material-create
-description: Create new material asset with default parameters. Creates folders recursively if they do not exist. Provide proper 'shaderName' - use 'assets-shader-list-all' tool to find available shaders.
+description: Create a new Material asset with default parameters at a given 'Assets/'-rooted path ending in '.mat'. Creates intermediate folders if missing. Use 'assets-shader-list-all' to find a valid `shaderName`.
 ---
 
 # Assets / Create Material
+
+Create new material asset with default parameters. Creates folders recursively if they do not exist. Provide proper 'shaderName' - use 'assets-shader-list-all' tool to find available shaders.
+
+## Inputs
+
+- `assetPath` — must start with `Assets/` and end with `.mat`.
+- `shaderName` — name resolvable via `UnityEngine.Shader.Find`.
+
+## Behavior
+
+Throws if the path is empty, malformed, or the shader cannot be resolved. Creates a default Material from the resolved shader, saves it, refreshes the AssetDatabase, and returns an `AssetObjectRef` pointing at the new asset.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-move/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-move/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: assets-move
-description: Move the assets at paths in the project. Should be used for asset rename. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before moving.
+description: Move or rename assets at the given project paths. Refreshes the AssetDatabase at the end. Use 'assets-find' to locate the assets first.
 ---
 
 # Assets / Move
+
+Move the assets at paths in the project. Should be used for asset rename. Does AssetDatabase.Refresh() at the end. Use 'assets-find' tool to find assets before moving.
+
+## Inputs
+
+- `sourcePaths` — paths of the assets to move.
+- `destinationPaths` — target paths (must match `sourcePaths` length).
+
+## Behavior
+
+Each pair is moved independently via `AssetDatabase.MoveAsset`. Per-pair failures (Unity's `MoveAsset` returns a non-empty error string) are surfaced in `response.Errors`; successful moves accumulate into `response.MovedPaths`.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-prefab-close/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-prefab-close/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: assets-prefab-close
-description: Close currently opened prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+description: Close the currently opened prefab edit stage. Optionally saves changes back to the prefab asset before closing. Pair with 'assets-prefab-open' to enter the edit mode first.
 ---
 
 # Assets / Prefab / Close
+
+Close currently opened prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+
+## Inputs
+
+- `save` (default `true`) — when `true`, calls `PrefabUtility.SaveAsPrefabAsset` before exiting the stage; when `false`, the prefab stage's dirtiness is cleared and changes are discarded.
+
+## Behavior
+
+Throws when no prefab stage is currently open. Returns an `AssetObjectRef` for the closed prefab asset.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-prefab-close/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-prefab-close/SKILL.md
@@ -9,7 +9,7 @@ Close currently opened prefab. Use it when you are in prefab editing mode in Uni
 
 ## Inputs
 
-- `save` (default `true`) — when `true`, calls `PrefabUtility.SaveAsPrefabAsset` before exiting the stage; when `false`, the prefab stage's dirtiness is cleared and changes are discarded.
+- `save` (default `true`) — when `true`, calls `PrefabUtility.SaveAsPrefabAsset` before exiting the stage; when `false`, the save is skipped. The prefab stage's dirtiness is always cleared at the end, so any unsaved changes are discarded when `save` is `false`.
 
 ## Behavior
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-prefab-create/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-prefab-create/SKILL.md
@@ -1,9 +1,22 @@
 ---
 name: assets-prefab-create
-description: Create a prefab from a GameObject in the current active scene. The prefab will be saved in the project assets at the specified path. Creates folders recursively if they do not exist. If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. To create a Prefab Variant from an existing prefab asset, provide 'sourcePrefabAssetPath' instead of 'gameObjectRef'. Use 'gameobject-find' tool to find the target GameObject first.
+description: Create a Prefab (or Prefab Variant) at a project asset path. Source can be a scene GameObject (`gameObjectRef`) or an existing prefab asset (`sourcePrefabAssetPath`). Creates intermediate folders if missing. Use 'gameobject-find' to locate the source GameObject first.
 ---
 
 # Assets / Prefab / Create
+
+Create a prefab from a GameObject in the current active scene. The prefab will be saved in the project assets at the specified path. Creates folders recursively if they do not exist. If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. To create a Prefab Variant from an existing prefab asset, provide 'sourcePrefabAssetPath' instead of 'gameObjectRef'. Use 'gameobject-find' tool to find the target GameObject first.
+
+## Inputs (mutually exclusive sources)
+
+- `prefabAssetPath` — required. Must start with `Assets/` and end with `.prefab`.
+- `gameObjectRef` — scene GameObject to convert (or to seed a Prefab Variant from when it is already a prefab instance).
+- `sourcePrefabAssetPath` — existing prefab asset to seed a Prefab Variant from. Cannot be combined with `gameObjectRef`.
+- `connectGameObjectToPrefab` (default `true`) — when sourcing from a scene GameObject, connect the scene object to the new prefab asset (becoming a prefab instance). Ignored for `sourcePrefabAssetPath` (always creates a variant).
+
+## Behavior
+
+Creates intermediate folders along `prefabAssetPath` if they don't already exist. Returns an `AssetObjectRef` pointing at the new prefab asset.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-prefab-instantiate/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-prefab-instantiate/SKILL.md
@@ -1,9 +1,18 @@
 ---
 name: assets-prefab-instantiate
-description: Instantiates prefab in the current active scene. Use 'assets-find' tool to find prefab assets in the project.
+description: Instantiate a prefab into the currently active scene at an optional position/rotation/scale, parented under an optional scene GameObject path. Use 'assets-find' to locate the prefab asset first.
 ---
 
 # Assets / Prefab / Instantiate
+
+Instantiates prefab in the current active scene. Use 'assets-find' tool to find prefab assets in the project.
+
+## Inputs
+
+- `prefabAssetPath` — project asset path of the prefab to instantiate.
+- `gameObjectPath` — destination path in the scene; the last segment becomes the new GameObject's name, any prefix is looked up as the parent (must already exist).
+- `position` / `rotation` / `scale` — optional transform; default to zero / zero / one.
+- `isLocalSpace` — when `true`, applies the transform in local space relative to the parent.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-prefab-open/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-prefab-open/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: assets-prefab-open
-description: "Open prefab edit mode for a specific GameObject. In the Edit mode you can modify the prefab. The modification will be applied to all instances of the prefab across the project. Note: Please use 'assets-prefab-close' tool later to exit prefab editing mode."
+description: Open the prefab edit stage for a prefab instance or prefab asset GameObject. Modifications inside the edit stage propagate to all instances. Pair with 'assets-prefab-close' to exit the stage when done.
 ---
 
 # Assets / Prefab / Open
+
+Open prefab edit mode for a specific GameObject. In the Edit mode you can modify the prefab. The modification will be applied to all instances of the prefab across the project. Note: Please use 'assets-prefab-close' tool later to exit prefab editing mode.
+
+## Inputs
+
+- `gameObjectRef` — reference to a scene prefab instance OR a prefab asset GameObject. The tool resolves the prefab asset path via `PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot` and opens the appropriate prefab stage.
+
+## Behavior
+
+Asset-side GameObjects open via the simple `OpenPrefab(path)` overload. Scene-instance GameObjects open via `OpenPrefab(path, gameObject)` so the editor remembers which instance prompted the edit. Editor windows are repainted before returning. Throws when the GameObject cannot be resolved or the stage fails to open.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-prefab-save/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-prefab-save/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: assets-prefab-save
-description: Save a prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+description: Save the currently opened prefab edit stage back to its prefab asset without exiting the stage. Pair with 'assets-prefab-open' to enter the edit mode first.
 ---
 
 # Assets / Prefab / Save
+
+Save a prefab. Use it when you are in prefab editing mode in Unity Editor. Use 'assets-prefab-open' tool to open a prefab first.
+
+## Behavior
+
+Calls `PrefabUtility.SaveAsPrefabAsset` on the current prefab stage's contents root, clears the stage's dirtiness flag, repaints editor windows, and returns an `AssetObjectRef` to the saved prefab. Throws when no prefab stage is currently open.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-refresh/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-refresh/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: assets-refresh
-description: Refreshes the AssetDatabase. Use it if any file was added or updated in the project outside of Unity API. Use it if need to force scripts recompilation when '.cs' file changed.
+description: Refresh the Unity AssetDatabase. Use after files were added or updated outside of the Unity API, or to force script recompilation when a '.cs' file changed. Returns a processing/success response and waits for compilation when triggered.
 ---
 
 # Assets / Refresh
+
+Refreshes the AssetDatabase. Use it if any file was added or updated in the project outside of Unity API. Use it if need to force scripts recompilation when '.cs' file changed.
+
+## Inputs
+
+- `options` — `ImportAssetOptions` flag (default `ForceSynchronousImport`).
+- `requestId` — required for processing-mode responses; the tool returns `Processing` immediately and delivers a follow-up completion when compilation finishes.
+
+## Behavior
+
+Runs `AssetDatabase.Refresh(options)`. If `EditorApplication.isCompiling` is true after the refresh, schedules a post-compilation notification and returns a `Processing` response. If compilation already failed (`EditorUtility.scriptCompilationFailed`), returns `Success` with the compilation error details. Otherwise returns a plain `Success`.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-shader-get-data/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-shader-get-data/SKILL.md
@@ -7,7 +7,7 @@ description: "Get detailed data about a shader asset — properties, subshaders,
 
 Get detailed data about a shader asset in the Unity project. Returns shader properties, subshaders, passes, compilation errors, and supported status. Use 'assets-find' tool with filter 't:Shader' to find shaders, or 'assets-shader-list-all' tool to list all shader names.
 
-## Toggles (default off to keep responses small)
+## Toggles (most default off to keep responses small)
 
 - `includeMessages` (default `true`) — shader compilation messages.
 - `includeProperties` (default `false`) — uniforms list.

--- a/Unity-MCP-Plugin/.claude/skills/assets-shader-get-data/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-shader-get-data/SKILL.md
@@ -1,13 +1,26 @@
 ---
 name: assets-shader-get-data
-description: |-
-  Get detailed data about a shader asset in the Unity project. Returns shader properties, subshaders, passes, compilation errors, and supported status. Use 'assets-find' tool with filter 't:Shader' to find shaders, or 'assets-shader-list-all' tool to list all shader names.
-  
-  Path-scoped reads (token-saving): supply 'paths' (a list of paths) to read only the listed fields/elements via Reflector.TryReadAt, or 'viewQuery' (a ViewQuery) to navigate to a subtree and/or filter by name regex / max depth / type via Reflector.View. The result populates 'View' on the returned ShaderData. These two parameters are mutually exclusive.
-  Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.
+description: "Get detailed data about a shader asset — properties, subshaders, passes, compilation messages, and supported status. Supports token-saving path-scoped reads via `paths` or `viewQuery`. Use 'assets-find' with `t:Shader` or 'assets-shader-list-all' to locate the shader first."
 ---
 
 # Assets / Shader / Get Data
+
+Get detailed data about a shader asset in the Unity project. Returns shader properties, subshaders, passes, compilation errors, and supported status. Use 'assets-find' tool with filter 't:Shader' to find shaders, or 'assets-shader-list-all' tool to list all shader names.
+
+## Toggles (default off to keep responses small)
+
+- `includeMessages` (default `true`) — shader compilation messages.
+- `includeProperties` (default `false`) — uniforms list.
+- `includeSubshaders` (default `false`) — subshader and pass structure.
+- `includeSourceCode` (default `false`) — pass source code. Implies `includeSubshaders` and can produce very large responses.
+
+## Path-scoped reads (token-saving)
+
+Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type via `Reflector.View`. The result populates `View` on the returned `ShaderData`. These two parameters are mutually exclusive.
+
+## Path syntax
+
+`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/assets-shader-list-all/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/assets-shader-list-all/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: assets-shader-list-all
-description: List all available shaders in the project assets and packages. Returns their names. Use this to find a shader name for 'assets-material-create' tool.
+description: List all shaders available in the project assets and packages, sorted by name. Use this to discover a valid `shaderName` for 'assets-material-create'.
 ---
 
 # Assets / List Shaders
+
+List all available shaders in the project assets and packages. Returns their names. Use this to find a shader name for 'assets-material-create' tool.
+
+## Behavior
+
+Enumerates shaders via `ShaderUtils.GetAllShaders`, filters out nulls, and returns the names alphabetically sorted.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/console-clear-logs/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/console-clear-logs/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: console-clear-logs
-description: Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. Useful for isolating errors related to a specific action by clearing logs before performing the action.
+description: Clear the MCP log cache (used by 'console-get-logs') and the Unity Editor Console window. Useful for isolating logs to a specific action by clearing the slate first.
 ---
 
 # Console / Clear Logs
+
+Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. Useful for isolating errors related to a specific action by clearing logs before performing the action.
+
+## Behavior
+
+Calls `Debug.ClearDeveloperConsole()` to wipe the Editor Console, then clears the MCP-side `LogCollector` cache so subsequent 'console-get-logs' calls only see new entries.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/console-get-logs/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/console-get-logs/SKILL.md
@@ -1,9 +1,18 @@
 ---
 name: console-get-logs
-description: Retrieves Unity Editor logs. Useful for debugging and monitoring Unity Editor activity.
+description: Retrieve Unity Editor logs from the MCP plugin's `LogCollector`, optionally filtered by log type or time window. Useful for debugging and monitoring Editor activity.
 ---
 
 # Console / Get Logs
+
+Retrieves Unity Editor logs. Useful for debugging and monitoring Unity Editor activity.
+
+## Inputs
+
+- `maxEntries` (default 100, minimum 1) — caps the size of the returned array.
+- `logTypeFilter` — Unity `LogType` filter; `null` returns all severities.
+- `includeStackTrace` (default `false`) — include stack-trace strings in each entry.
+- `lastMinutes` (default 0) — when non-zero, only logs from the last N minutes are returned.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/editor-application-get-state/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/editor-application-get-state/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: editor-application-get-state
-description: "Returns available information about 'UnityEditor.EditorApplication'. Use it to get information about the current state of the Unity Editor application. Such as: playmode, paused state, compilation state, etc."
+description: Return the current state of `UnityEditor.EditorApplication` — playmode, paused state, compilation state, and related flags.
 ---
 
 # Editor / Application / Get State
+
+Returns available information about 'UnityEditor.EditorApplication'. Use it to get information about the current state of the Unity Editor application. Such as: playmode, paused state, compilation state, etc.
+
+## Behavior
+
+Snapshots Editor state via `EditorStatsData.FromEditor()` on the main thread and returns the result.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/editor-application-set-state/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/editor-application-set-state/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: editor-application-set-state
-description: Control the Unity Editor application state. You can start, stop, or pause the 'playmode'. Use 'editor-application-get-state' tool to get the current state first.
+description: Start / stop / pause the Unity Editor 'playmode'. Use 'editor-application-get-state' to inspect the current state first. Throws if the project currently has compilation errors.
 ---
 
 # Editor / Application / Set State
+
+Control the Unity Editor application state. You can start, stop, or pause the 'playmode'. Use 'editor-application-get-state' tool to get the current state first.
+
+## Inputs
+
+- `isPlaying` (default `false`) — sets `EditorApplication.isPlaying`.
+- `isPaused` (default `false`) — sets `EditorApplication.isPaused`.
+
+## Behavior
+
+Refuses to switch into play mode while `EditorUtility.scriptCompilationFailed` is true — instead throws with the compilation error details so the caller can fix them first. On success returns the post-change `EditorStatsData` snapshot.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/editor-application-set-state/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/editor-application-set-state/SKILL.md
@@ -14,7 +14,7 @@ Control the Unity Editor application state. You can start, stop, or pause the 'p
 
 ## Behavior
 
-Refuses to switch into play mode while `EditorUtility.scriptCompilationFailed` is true — instead throws with the compilation error details so the caller can fix them first. On success returns the post-change `EditorStatsData` snapshot.
+Refuses any state change while `EditorUtility.scriptCompilationFailed` is true — instead throws with the compilation error details so the caller can fix them first. On success returns the post-change `EditorStatsData` snapshot.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/editor-selection-get/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/editor-selection-get/SKILL.md
@@ -1,9 +1,22 @@
 ---
 name: editor-selection-get
-description: Get information about the current Selection in the Unity Editor. Use 'editor-selection-set' tool to set the selection.
+description: Get information about the current Selection in the Unity Editor — active object, active transform, selected GameObjects, transforms, instance IDs, and asset GUIDs (each enrichment is opt-in). Pair with 'editor-selection-set' to change the selection.
 ---
 
 # Editor / Selection / Get
+
+Get information about the current Selection in the Unity Editor. Use 'editor-selection-set' tool to set the selection.
+
+## Toggles (default off where indicated to keep responses small)
+
+- `includeGameObjects` (default `false`) — populate `GameObjects[]`.
+- `includeTransforms` (default `false`) — populate `Transforms[]` as `ComponentRef`s.
+- `includeInstanceIDs` (default `false`) — populate `InstanceIDs[]`.
+- `includeAssetGUIDs` (default `false`) — populate `AssetGUIDs[]` from project-window selection.
+- `includeActiveObject` (default `true`) — populate `ActiveObject` as a generic `ObjectRef`.
+- `includeActiveTransform` (default `true`) — populate `ActiveTransform` as a `ComponentRef`.
+
+`ActiveGameObject` and `ActiveInstanceID` are always populated.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/editor-selection-set/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/editor-selection-set/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: editor-selection-set
-description: Set the current Selection in the Unity Editor to the provided objects. Use 'editor-selection-get' tool to get the current selection first.
+description: Set the current Selection in the Unity Editor to the provided objects. All `ObjectRef`s must resolve to existing Unity objects; otherwise the call throws. Use 'editor-selection-get' to inspect the current selection first.
 ---
 
 # Editor / Selection / Set
+
+Set the current Selection in the Unity Editor to the provided objects. Use 'editor-selection-get' tool to get the current selection first.
+
+## Inputs
+
+- `select` — array of `ObjectRef`. Every entry MUST resolve via `FindObject()`; otherwise the tool throws before touching `Selection.objects`.
+
+## Behavior
+
+Assigns the resolved array to `Selection.objects`, then calls `UnityEditorInternal.InternalEditorUtility.RepaintAllViews()` so Hierarchy/Inspector reflect the change. Returns the post-change `SelectionData` snapshot.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-component-add/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-component-add/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: gameobject-component-add
-description: Add Component to GameObject in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first. Use 'gameobject-component-list-all' tool to find the component type names to add.
+description: Add one or more Components to a GameObject in the opened Prefab or active Scene. Component types are looked up by full name (with namespace) or by class-name fallback. Use 'gameobject-find' to locate the host GameObject and 'gameobject-component-list-all' to discover valid component type names.
 ---
 
 # GameObject / Component / Add
+
+Add Component to GameObject in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first. Use 'gameobject-component-list-all' tool to find the component type names to add.
+
+## Inputs
+
+- `componentNames` — list of component type names. Each entry may be a fully-qualified type name (preferred) or a bare class name (resolved via fallback to `AllComponentTypes`).
+- `gameObjectRef` — the target GameObject. Required.
+
+## Behavior
+
+Per-name errors (unknown type, type not assignable to `UnityEngine.Component`, add-failed/duplicate) are accumulated in `response.Errors` / `response.Warnings` instead of throwing, so a single bad name does not abort the whole batch. Successful additions populate `response.AddedComponents` with `ComponentDataShallow` snapshots.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-component-destroy/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-component-destroy/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: gameobject-component-destroy
-description: Destroy one or many components from target GameObject. Can't destroy missed components. Use 'gameobject-find' tool to find the target GameObject and 'gameobject-component-get' to get component details first.
+description: Destroy one or more Components from a target GameObject. Missing (null) components are skipped — they cannot be destroyed. Use 'gameobject-find' and 'gameobject-component-get' to identify the components first.
 ---
 
 # GameObject / Component / Destroy
+
+Destroy one or many components from target GameObject. Can't destroy missed components. Use 'gameobject-find' tool to find the target GameObject and 'gameobject-component-get' to get component details first.
+
+## Inputs
+
+- `gameObjectRef` — the host GameObject.
+- `destroyComponentRefs` — `ComponentRefList` of components to destroy (matched against the GameObject's components).
+
+## Behavior
+
+Iterates `go.GetComponents<Component>()`, skipping null entries (missing scripts). For each non-null component that matches one of `destroyComponentRefs`, the tool snapshots a `ComponentRef`, calls `Object.DestroyImmediate`, and records the destroyed reference. If no component matches at all, throws with the help text from `Error.NotFoundComponents` (which includes a preview of all available components on the GameObject).
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-component-get/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-component-get/SKILL.md
@@ -1,13 +1,27 @@
 ---
 name: gameobject-component-get
-description: |-
-  Get detailed information about a specific Component on a GameObject. Returns component type, enabled state, and optionally serialized fields and properties. Use this to inspect component data before modifying it. Use 'gameobject-find' tool to get the list of all components on the GameObject.
-  
-  Path-scoped reads (token-saving): supply 'paths' (a list of paths) to read only the listed fields/elements via Reflector.TryReadAt, or 'viewQuery' (a ViewQuery) to navigate to a subtree and/or filter by name regex / max depth / type via Reflector.View. The result is returned in the 'View' field of the response. These two parameters are mutually exclusive — supply at most one.
-  Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.
+description: Get detailed information about a specific Component on a GameObject — type, enabled state, and (optionally) serialized fields and properties. Supports token-saving path-scoped reads via `paths` or `viewQuery`. Use 'gameobject-find' to list components first.
 ---
 
 # GameObject / Component / Get
+
+Get detailed information about a specific Component on a GameObject. Returns component type, enabled state, and optionally serialized fields and properties. Use this to inspect component data before modifying it. Use 'gameobject-find' tool to get the list of all components on the GameObject.
+
+## Inputs
+
+- `gameObjectRef` — the host GameObject.
+- `componentRef` — the specific component to inspect (matched by index or instance ID).
+- `includeFields` (default `true`) — populate the legacy `Fields` list.
+- `includeProperties` (default `true`) — populate the legacy `Properties` list.
+- `deepSerialization` (default `false`) — when populating legacy lists, recurse into nested members.
+
+## Path-scoped reads (token-saving)
+
+Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type via `Reflector.View`. The result is returned in the `View` field of the response, and the legacy `Fields`/`Properties` lists are skipped. These two parameters are mutually exclusive — supply at most one.
+
+## Path syntax
+
+`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-component-list-all/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-component-list-all/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: gameobject-component-list-all
-description: List C# class names extended from UnityEngine.Component. Use this to find component type names for 'gameobject-component-add' tool. Results are paginated to avoid overwhelming responses.
+description: List the fully-qualified C# type names of every concrete `UnityEngine.Component` subclass available in the project. Paginated (default 5/page, max 500). Use this to find a valid `componentName` for 'gameobject-component-add'.
 ---
 
 # GameObject / Component / List All
+
+List C# class names extended from UnityEngine.Component. Use this to find component type names for 'gameobject-component-add' tool. Results are paginated to avoid overwhelming responses.
+
+## Inputs
+
+- `search` (optional) — case-insensitive substring filter on type names.
+- `page` (default 0, 0-based) — page index.
+- `pageSize` (default 5, range 1..500) — items per page.
+
+## Behavior
+
+Enumerates `AllComponentTypes` (every non-abstract subclass of `UnityEngine.Component`), filters by `search` if supplied, then returns a `ComponentListResult` containing the requested page plus `TotalCount` / `TotalPages` so the caller can iterate.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-create/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-create/SKILL.md
@@ -10,7 +10,7 @@ Create a new GameObject in opened Prefab or in a Scene. If needed - provide prop
 ## Inputs
 
 - `name` — required non-empty name.
-- `parentGameObjectRef` (optional) — when provided, the new GameObject is parented under this one (`SetParent(parent, false)`); otherwise it's created at scene/prefab root.
+- `parentGameObjectRef` (optional) — when provided, the new GameObject is parented under this one (`SetParent(parent, worldPositionStays: false)`); otherwise it's created at scene/prefab root.
 - `position` / `rotation` / `scale` — optional transform; default to zero / zero / one.
 - `isLocalSpace` — when `true`, applies the transform in local space relative to the parent.
 - `primitiveType` (optional) — when set, the GameObject is created via `GameObject.CreatePrimitive` (adds the appropriate renderer/collider for the primitive shape).

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-create/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-create/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: gameobject-create
-description: Create a new GameObject in opened Prefab or in a Scene. If needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.
+description: Create a new GameObject in the currently opened Prefab or active Scene, optionally parented under another GameObject and pre-positioned. Pass `primitiveType` to spawn a Unity primitive (Cube, Sphere, etc.) instead of an empty GameObject.
 ---
 
 # GameObject / Create
+
+Create a new GameObject in opened Prefab or in a Scene. If needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.
+
+## Inputs
+
+- `name` — required non-empty name.
+- `parentGameObjectRef` (optional) — when provided, the new GameObject is parented under this one (`SetParent(parent, false)`); otherwise it's created at scene/prefab root.
+- `position` / `rotation` / `scale` — optional transform; default to zero / zero / one.
+- `isLocalSpace` — when `true`, applies the transform in local space relative to the parent.
+- `primitiveType` (optional) — when set, the GameObject is created via `GameObject.CreatePrimitive` (adds the appropriate renderer/collider for the primitive shape).
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-destroy/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-destroy/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: gameobject-destroy
-description: Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first.
+description: Destroy a GameObject (and all nested children) in the currently opened Prefab or active Scene. Returns the destroyed GameObject's name, path, and instance ID for confirmation. Use 'gameobject-find' to locate the target first.
 ---
 
 # GameObject / Destroy
+
+Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObject first.
+
+## Behavior
+
+Validates the `gameObjectRef`, resolves it on the main thread, then calls `Object.DestroyImmediate` (the immediate variant is required for Editor-mode operations). Returns a `DestroyGameObjectResult` containing `DestroyedName`, `DestroyedPath`, and `DestroyedInstanceId` so the caller has a record of what was removed.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-duplicate/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-duplicate/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: gameobject-duplicate
-description: Duplicate GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+description: Duplicate a batch of GameObjects in the currently opened Prefab or active Scene. Marks each affected scene as dirty after duplication. Use 'gameobject-find' to locate the source GameObjects first.
 ---
 
 # GameObject / Duplicate
+
+Duplicate GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+
+## Inputs
+
+- `gameObjectRefs` — `GameObjectRefList` of source GameObjects.
+
+## Behavior
+
+Resolves every input ref on the main thread (throwing on any unresolved entry to keep the batch atomic). Sets `Selection.entityIds`/`instanceIDs` to the sources and invokes `Unsupported.DuplicateGameObjectsUsingPasteboard()` (Unity's canonical duplicate routine). Marks every distinct affected scene dirty so the duplicated objects are saved with the scene. Returns refs to the sources (the duplicates are reachable via the post-call `Selection`).
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-find/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-find/SKILL.md
@@ -1,13 +1,27 @@
 ---
 name: gameobject-find
-description: |-
-  Finds specific GameObject by provided information in opened Prefab or in a Scene. First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. If no opened Prefab it looks into current active scene. Returns GameObject information and its children. Also, it returns Components preview just for the target GameObject.
-  
-  Path-scoped reads (token-saving): supply 'paths' (a list of paths) to read only the listed fields/elements via Reflector.TryReadAt, or 'viewQuery' (a ViewQuery) to navigate to a subtree and/or filter by name regex / max depth / type via Reflector.View. When either is supplied, the result populates 'Data' on the returned GameObjectData and overrides 'includeData' (which would otherwise produce a full recursive serialization). These two parameters are mutually exclusive — supply at most one.
-  Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.
+description: Find a specific GameObject in the opened Prefab (preferred when present) or the active Scene. Optionally include editable data, components preview, bounds, and limited hierarchy. Supports token-saving path-scoped reads via `paths` or `viewQuery`.
 ---
 
 # GameObject / Find
+
+Finds specific GameObject by provided information in opened Prefab or in a Scene. First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. If no opened Prefab it looks into current active scene. Returns GameObject information and its children. Also, it returns Components preview just for the target GameObject.
+
+## Toggles (all default `false` to keep responses small)
+
+- `includeData` — full editable GameObject data (tag, layer, etc.).
+- `includeComponents` — attached components references.
+- `includeBounds` — 3D bounds.
+- `includeHierarchy` — hierarchy metadata.
+- `hierarchyDepth` (default 0) — depth of the hierarchy to include. `0` = target only, `1` = one layer below, etc.
+
+## Path-scoped reads (token-saving)
+
+Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type via `Reflector.View`. When either is supplied, the result populates `Data` on the returned `GameObjectData` and overrides `includeData` (which would otherwise produce a full recursive serialization). These two parameters are mutually exclusive — supply at most one.
+
+## Path syntax
+
+`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/gameobject-set-parent/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/gameobject-set-parent/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: gameobject-set-parent
-description: Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+description: Reparent a batch of GameObjects under a new parent in the currently opened Prefab or active Scene. Per-item failures are reported in the returned status string instead of aborting the batch. Use 'gameobject-find' to locate the GameObjects first.
 ---
 
 # GameObject / Set Parent
+
+Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. Use 'gameobject-find' tool to find the target GameObjects first.
+
+## Inputs
+
+- `gameObjectRefs` — list of children to reparent.
+- `parentGameObjectRef` — new parent. Must resolve, otherwise the call returns early with an error string.
+- `worldPositionStays` (default `true`) — preserve world-space transform when reparenting (passed to `Transform.SetParent`).
+
+## Behavior
+
+Iterates `gameObjectRefs` and reparents each one independently; per-item resolve errors are appended to the returned status string instead of throwing. After the loop, if at least one reparent succeeded, marks the active scene dirty and repaints editor windows.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/object-get-data/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/object-get-data/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: object-get-data
-description: |-
-  Get data of the specified Unity Object. Returns serialized data of the object including its properties and fields. If need to modify the data use 'object-modify' tool.
-  
-  Path-scoped reads (token-saving): supply 'paths' (a list of paths) to read only the listed fields/elements via Reflector.TryReadAt, or 'viewQuery' (a ViewQuery) to navigate to a subtree and/or filter by name regex / max depth / type via Reflector.View. These two parameters are mutually exclusive — supply at most one. When neither is supplied the full object is serialized as before (backwards compatible).
-  Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.
+description: Get serialized data for a Unity `UnityEngine.Object` — all serializable fields and properties. Supports token-saving path-scoped reads via `paths` or `viewQuery`. Pair with 'object-modify' when you need to write back.
 ---
 
 # Object / Get Data
+
+Get data of the specified Unity Object. Returns serialized data of the object including its properties and fields. If need to modify the data use 'object-modify' tool.
+
+## Path-scoped reads (token-saving)
+
+Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type via `Reflector.View`. These two parameters are mutually exclusive — supply at most one. When neither is supplied the full object is serialized (backwards compatible).
+
+## Path syntax
+
+`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/object-modify/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/object-modify/SKILL.md
@@ -1,17 +1,25 @@
 ---
 name: object-modify
-description: |-
-  Modify the specified Unity Object. Allows direct modification of object fields and properties. Use 'object-get-data' first to inspect the object structure before modifying.
-  
-  Three modification surfaces (use whichever fits the task):
-    1. 'objectDiff' — full SerializedMember diff (legacy, backwards compatible).
-    2. 'pathPatches' — list of {path, value} pairs routed through Reflector.TryModifyAt; atomic per-path modification, multiple entries can target different depths.
-    3. 'jsonPatch' — a JSON Merge Patch (RFC 7396, extended with [i]/[key] notation) routed through Reflector.TryPatch; multiple fields at any depth in a single call.
-  When more than one is supplied they run in this order: jsonPatch → pathPatches → objectDiff. At least one is required.
-  Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped.
+description: Modify a Unity `UnityEngine.Object`'s serializable fields/properties. Three modification surfaces are available (`objectDiff`, `pathPatches`, `jsonPatch`) — see the skill body. Use 'object-get-data' first to inspect the object structure.
 ---
 
 # Object / Modify
+
+Modify the specified Unity Object. Allows direct modification of object fields and properties. Use 'object-get-data' first to inspect the object structure before modifying.
+
+## Three modification surfaces
+
+Use whichever fits the task:
+
+1. `objectDiff` — full `SerializedMember` diff (legacy, backwards compatible).
+2. `pathPatches` — list of `{path, value}` pairs routed through `Reflector.TryModifyAt`; atomic per-path modification, multiple entries can target different depths.
+3. `jsonPatch` — a JSON Merge Patch (RFC 7396, extended with `[i]`/`[key]` notation) routed through `Reflector.TryPatch`; multiple fields at any depth in a single call.
+
+When more than one is supplied they run in this order: `jsonPatch` → `pathPatches` → `objectDiff`. At least one is required.
+
+## Path syntax
+
+`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/package-add/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/package-add/SKILL.md
@@ -1,9 +1,23 @@
 ---
 name: package-add
-description: "Install a package from the Unity Package Manager registry, Git URL, or local path. This operation modifies the project's manifest.json and triggers package resolution. Note: Package installation may trigger a domain reload. The result will be sent after the reload completes. Use 'package-search' tool to search for packages and 'package-list' to list installed packages."
+description: Install a Unity package from the registry, a Git URL, or a local path. Modifies `manifest.json` and triggers package resolution; may also trigger a domain reload — the final result is delivered after the reload via the request's `requestId`. Use 'package-search' / 'package-list' for discovery first.
 ---
 
 # Package Manager / Add
+
+Install a package from the Unity Package Manager registry, Git URL, or local path. This operation modifies the project's manifest.json and triggers package resolution. Note: Package installation may trigger a domain reload. The result will be sent after the reload completes. Use 'package-search' tool to search for packages and 'package-list' to list installed packages.
+
+## `packageId` formats
+
+- Plain package ID: `com.unity.textmeshpro` (installs latest compatible version).
+- Pinned version: `com.unity.textmeshpro@3.0.6`.
+- Git URL: `https://github.com/user/repo.git`.
+- Git URL with branch/tag: `https://github.com/user/repo.git#v1.0.0`.
+- Local path: `file:../MyPackage`.
+
+## Processing model
+
+Returns `Processing` immediately with the supplied `requestId`. Once `Client.Add` completes, a follow-up result is delivered: success → `SchedulePostDomainReloadNotification` (delivers after the reload finishes), failure → an immediate error notification with the underlying Unity error message.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/package-list/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/package-list/SKILL.md
@@ -1,9 +1,17 @@
 ---
 name: package-list
-description: List all packages installed in the Unity project (UPM packages). Returns information about each installed package including name, version, source, and description. Use this to check which packages are currently installed before adding or removing packages.
+description: List all UPM packages installed in the Unity project — name, version, source, description. Optionally filter by source (registry, embedded, local, git, built-in, local tarball), by name/display/description substring, and by direct-dependency-only.
 ---
 
 # Package Manager / List Installed
+
+List all packages installed in the Unity project (UPM packages). Returns information about each installed package including name, version, source, and description. Use this to check which packages are currently installed before adding or removing packages.
+
+## Inputs
+
+- `sourceFilter` (default `All`) — restrict by Unity `PackageSource`: `All`, `Registry`, `Embedded`, `Local`, `Git`, `BuiltIn`, `LocalTarball`.
+- `nameFilter` (optional) — case-insensitive substring filter over name / displayName / description. Results are prioritized: exact name → exact displayName → name substring → displayName substring → description substring.
+- `directDependenciesOnly` (default `false`) — when true, return only packages listed in `manifest.json` (no transitive dependencies).
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/package-remove/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/package-remove/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: package-remove
-description: "Remove (uninstall) a package from the Unity project. This removes the package from the project's manifest.json and triggers package resolution. Note: Built-in packages and packages that are dependencies of other installed packages cannot be removed. Note: Package removal may trigger a domain reload. The result will be sent after the reload completes. Use 'package-list' tool to list installed packages first."
+description: Uninstall a UPM package from the Unity project. Modifies `manifest.json` and may trigger a domain reload — the final result is delivered after the reload via the request's `requestId`. Built-in packages and packages that are dependencies of others cannot be removed. Use 'package-list' to list installed packages first.
 ---
 
 # Package Manager / Remove
+
+Remove (uninstall) a package from the Unity project. This removes the package from the project's manifest.json and triggers package resolution. Note: Built-in packages and packages that are dependencies of other installed packages cannot be removed. Note: Package removal may trigger a domain reload. The result will be sent after the reload completes. Use 'package-list' tool to list installed packages first.
+
+## Inputs
+
+- `packageId` — package name (e.g. `com.unity.textmeshpro`). A trailing `@<version>` is stripped automatically before being passed to `Client.Remove`, so accidental versioned IDs still work.
+
+## Behavior
+
+First verifies the package is installed via an offline `Client.List` — returns a clear `PackageNotFound` error if not. On removal failure, surfaces Unity's error message. On success, schedules a post-domain-reload notification so the response is delivered after Unity finishes the resolution.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/package-search/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/package-search/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: package-search
-description: "Search for packages in both Unity Package Manager registry and installed packages. Use this to find packages by name before installing them. Returns available versions and installation status. Searches both the Unity registry and locally installed packages (including Git, local, and embedded sources). Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. Note: Online mode fetches exact matches from live registry, then supplements with cached substring matches."
+description: Search Unity's package registry plus locally installed packages (Git, local, embedded sources) by query string. Returns available versions and installation status. Online mode fetches exact matches from the live registry then supplements with cached substring matches.
 ---
 
 # Package Manager / Search
+
+Search for packages in both Unity Package Manager registry and installed packages. Use this to find packages by name before installing them. Returns available versions and installation status. Searches both the Unity registry and locally installed packages (including Git, local, and embedded sources). Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. Note: Online mode fetches exact matches from live registry, then supplements with cached substring matches.
+
+## Inputs
+
+- `query` — package id, name, display name, or description keyword (case-insensitive). Required.
+- `maxResults` (default 10) — caps the returned list.
+- `offlineMode` (default `true`) — when `false`, hits the live registry for exact matches; cached registry data still backs the substring matches in both modes.
+
+## Result composition
+
+Each entry includes name, display name, latest version, truncated description, install status, installed version (if any), and the top-5 compatible versions.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/ping/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/ping/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: ping
-description: Lightweight readiness probe. Returns the input message or 'pong' if omitted.
+description: Lightweight readiness probe. Returns the input `message` echoed back, or `'pong'` when omitted. Useful for CLI health checks and SignalR connectivity smoke tests.
 ---
 
 # Ping
+
+Lightweight readiness probe. Returns the input message or 'pong' if omitted.
+
+## Inputs
+
+- `message` (optional) — when present, echoed back verbatim.
+
+## Behavior
+
+No I/O, no Unity API calls — pure echo. Ideal for measuring round-trip latency or confirming the MCP transport is alive before invoking a heavier tool.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/reflection-method-call/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/reflection-method-call/SKILL.md
@@ -1,9 +1,22 @@
 ---
 name: reflection-method-call
-description: Call C# method. Any method could be called, even private methods. It requires to receive proper method schema. Use 'reflection-method-find' to find available method before using it. Receives input parameters and returns result.
+description: Call a C# method by reflection — including private methods. Requires a method schema obtained via 'reflection-method-find'. Supports static methods, instance methods (with optional target deserialization), and main-thread / off-thread execution.
 ---
 
 # Method C# / Call
+
+Call C# method. Any method could be called, even private methods. It requires to receive proper method schema. Use 'reflection-method-find' to find available method before using it. Receives input parameters and returns result.
+
+## Match levels (apply to `typeName`, `MethodName`, `Parameters`)
+
+- `typeNameMatchLevel` / `methodNameMatchLevel` (default 1 — contains ignoring case): `0` ignore filter, `1` contains-ic, `2` contains-cs, `3` starts-with-ic, `4` starts-with-cs, `5` equals-ic, `6` equals-cs.
+- `parametersMatchLevel` (default 2 — equals): `0` ignore filter, `1` count matches, `2` equals.
+
+## Inputs
+
+- `targetObject` (optional) — for instance methods. When null, a new instance is created from the declaring type. Required shape: `{ type, value }` (value is deserialized to `type`).
+- `inputParameters` (optional) — list of `{ type, name, value }`. Names are enhanced against the resolved method signature if omitted.
+- `executeInMainThread` (default `true`) — Unity API calls should keep this true; set false only for thread-safe pure logic.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/reflection-method-find/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/reflection-method-find/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: reflection-method-find
-description: Find method in the project using C# Reflection. It looks for all assemblies in the project and finds method by its name, class name and parameters. Even private methods are available. Use 'reflection-method-call' to call the method after finding it.
+description: Find C# methods across every loaded assembly by name / type / parameters — including private methods. Returns serialized `MethodData` entries usable as schemas for 'reflection-method-call'.
 ---
 
 # Method C# / Find
+
+Find method in the project using C# Reflection. It looks for all assemblies in the project and finds method by its name, class name and parameters. Even private methods are available. Use 'reflection-method-call' to call the method after finding it.
+
+## Match levels (apply to `typeName`, `MethodName`, `Parameters`)
+
+- `typeNameMatchLevel` / `methodNameMatchLevel` (default 1 — contains ignoring case): `0` ignore filter, `1` contains-ic, `2` contains-cs, `3` starts-with-ic, `4` starts-with-cs, `5` equals-ic, `6` equals-cs.
+- `parametersMatchLevel` (default 0 — ignore filter): `0` ignore, `1` count matches, `2` equals.
+
+## Output
+
+On match, returns a `[Success] Found N method(s):` line followed by a JSON dump of every method's `MethodData`. Pass any single entry to 'reflection-method-call' as its `filter`.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/scene-create/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/scene-create/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: scene-create
-description: Create new scene in the project assets. Use 'scene-list-opened' tool to list all opened scenes after creation.
+description: Create a new Unity scene asset and save it at the given `.unity` path. Use 'scene-list-opened' to inspect the resulting opened-scene set afterwards.
 ---
 
 # Scene / Create
+
+Create new scene in the project assets. Use 'scene-list-opened' tool to list all opened scenes after creation.
+
+## Inputs
+
+- `path` — must end with `.unity`. Non-empty.
+- `newSceneSetup` (default `DefaultGameObjects`) — Unity's `NewSceneSetup` flag (`EmptyScene` or `DefaultGameObjects`).
+- `newSceneMode` (default `Single`) — `Single` closes other scenes, `Additive` keeps them open.
+
+## Behavior
+
+Calls `EditorSceneManager.NewScene` + `SaveScene(path)` on the main thread, repaints editor windows, and returns a `SceneDataShallow` for the newly created scene.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/scene-get-data/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/scene-get-data/SKILL.md
@@ -1,13 +1,26 @@
 ---
 name: scene-get-data
-description: |-
-  This tool retrieves the list of root GameObjects in the specified scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
-  
-  Path-scoped reads (token-saving): supply 'paths' (a list of paths) to read only the listed fields/elements from the scene's root-GameObjects array via Reflector.TryReadAt, or 'viewQuery' (a ViewQuery) to navigate/filter the same array via Reflector.View. The result populates 'Data' on the returned SceneData. These two parameters are mutually exclusive.
-  Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'. Leading '#/' is stripped. Example: paths=['[0]/name'] reads the name of the first root GameObject.
+description: Retrieve the list of root GameObjects in the specified opened scene (or the active scene when `openedSceneName` is empty). Supports token-saving path-scoped reads over the root-GameObjects array via `paths` or `viewQuery`. Use 'scene-list-opened' to enumerate scenes.
 ---
 
 # Scene / Get Data
+
+This tool retrieves the list of root GameObjects in the specified scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
+
+## Toggles (all default `false` to keep responses small)
+
+- `includeRootGameObjects` — include root GameObjects in the scene data.
+- `includeChildrenDepth` (default 3) — depth of the hierarchy to include.
+- `includeBounds` — include 3D bounds for GameObjects.
+- `includeData` — include serialized component data for GameObjects.
+
+## Path-scoped reads (token-saving)
+
+Supply `paths` to read only the listed fields/elements from the scene's root-GameObjects array via `Reflector.TryReadAt`, or `viewQuery` to navigate/filter the same array via `Reflector.View`. The result populates `Data` on the returned `SceneData`. These two parameters are mutually exclusive.
+
+## Path syntax
+
+`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped. Example: `paths=['[0]/name']` reads the name of the first root GameObject.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/scene-list-opened/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/scene-list-opened/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: scene-list-opened
-description: Returns the list of currently opened scenes in Unity Editor. Use 'scene-get-data' tool to get detailed information about a specific scene.
+description: List every scene currently opened in the Unity Editor as a shallow snapshot (name, path, build flags). Use 'scene-get-data' for the deep view of a specific scene.
 ---
 
 # Scene / List Opened
+
+Returns the list of currently opened scenes in Unity Editor. Use 'scene-get-data' tool to get detailed information about a specific scene.
+
+## Behavior
+
+Maps `OpenedScenes` through `ToSceneDataShallow()` on the main thread and returns the resulting array. No filtering or pagination — every opened scene is included.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/scene-open/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/scene-open/SKILL.md
@@ -1,9 +1,18 @@
 ---
 name: scene-open
-description: Open scene from the project asset file. Use 'assets-find' tool to find the scene asset first.
+description: Open a Unity scene asset in Single or Additive mode. Returns the post-open list of all opened scenes. Use 'assets-find' to locate the scene asset first.
 ---
 
 # Scene / Open
+
+Open scene from the project asset file. Use 'assets-find' tool to find the scene asset first.
+
+## Inputs
+
+- `sceneRef` — `AssetObjectRef` pointing at a `SceneAsset`. Throws if the asset cannot be resolved or is not a `SceneAsset`.
+- `loadSceneMode` (default `Single`):
+  - `Single` — closes the currently opened scenes and opens this one.
+  - `Additive` — keeps the currently opened scenes and opens this one alongside them.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/scene-save/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/scene-save/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: scene-save
-description: Save Opened scene to the asset file. Use 'scene-list-opened' tool to get the list of all opened scenes.
+description: Save an opened scene back to its asset file (or to a new path when `path` is provided). When `openedSceneName` is empty, saves the currently active scene. Use 'scene-list-opened' to find the scene name first.
 ---
 
 # Scene / Save
+
+Save Opened scene to the asset file. Use 'scene-list-opened' tool to get the list of all opened scenes.
+
+## Inputs
+
+- `openedSceneName` (optional) — name of an opened scene to save. Empty/null = active scene.
+- `path` (optional) — destination `.unity` path. Empty/null = save back to the scene's existing path.
+
+## Validation
+
+Throws if the scene cannot be resolved, has no existing path AND no override path was supplied, or the supplied path does not end with `.unity`. On `EditorSceneManager.SaveScene` failure, surfaces an error with the current opened-scenes list for diagnosis.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/scene-set-active/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/scene-set-active/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: scene-set-active
-description: Set the specified opened scene as the active scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
+description: Mark an opened scene as the Editor's active scene (the one new GameObjects are added to and that's used as the default for many operations). Use 'scene-list-opened' to enumerate opened scenes first.
 ---
 
 # Scene / Set Active
+
+Set the specified opened scene as the active scene. Use 'scene-list-opened' tool to get the list of all opened scenes.
+
+## Inputs
+
+- `sceneRef` — `AssetObjectRef` pointing at a `SceneAsset`. The scene must already be opened.
+
+## Behavior
+
+Resolves the `SceneAsset`, finds the matching opened scene (by name then by path), and calls `EditorSceneManager.SetActiveScene`. No-op if the scene is already active. Returns the post-call snapshot of opened scenes.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/scene-unload/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/scene-unload/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: scene-unload
-description: Unload scene from the Opened scenes in Unity Editor. Use 'scene-list-opened' tool to get the list of all opened scenes.
+description: Unload an opened scene from the Unity Editor (asynchronously via `SceneManager.UnloadSceneAsync`). Use 'scene-list-opened' to find the scene name first.
 ---
 
 # Scene / Unload
+
+Unload scene from the Opened scenes in Unity Editor. Use 'scene-list-opened' tool to get the list of all opened scenes.
+
+## Inputs
+
+- `name` — required non-empty scene name. Must match an opened scene; otherwise throws.
+
+## Behavior
+
+Runs `SceneManager.UnloadSceneAsync` on the main thread and awaits completion. Returns an `UnloadSceneResult` containing the scene name and an `AssetObjectRef` to its asset (or `null` if the scene was not backed by an asset on disk).
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/screenshot-camera/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/screenshot-camera/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: screenshot-camera
-description: Captures a screenshot from a camera and returns it as an image. If no camera is specified, uses the Main Camera. Returns the image directly for visual inspection by the LLM.
+description: Capture a screenshot from a Unity `Camera` and return it as a PNG image for direct LLM inspection. Falls back to `Camera.main` (then any active camera) when `cameraRef` is null. Width and height are capped to keep response size manageable.
 ---
 
 # Screenshot / Camera
+
+Captures a screenshot from a camera and returns it as an image. If no camera is specified, uses the Main Camera. Returns the image directly for visual inspection by the LLM.
+
+## Inputs
+
+- `cameraRef` (optional) — reference to a GameObject hosting a `Camera`. When null, `Camera.main` is used; if there is no main camera, the first entry of `Camera.allCameras` is used.
+- `width` (default 1920) / `height` (default 1080) — output pixels. Must be > 0 and ≤ `MaxDimension`.
+
+## Behavior
+
+Allocates a temporary `RenderTexture`, swaps it onto the chosen camera, calls `Camera.Render`, reads back via `Texture2D.ReadPixels`, encodes as PNG, and restores the camera's prior `targetTexture`. Returns a `ResponseCallTool.Image` with `image/png` MIME and a descriptive caption.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/screenshot-game-view/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/screenshot-game-view/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: screenshot-game-view
-description: Captures a screenshot from the Unity Editor Game View and returns it as an image. Reads the Game View's own render texture directly via the Unity Editor API. The image size matches the current Game View resolution. Returns the image directly for visual inspection by the LLM.
+description: Capture a screenshot of the Unity Editor's Game View by reading its internal render texture directly. Image size matches the current Game View resolution; the tool corrects Y-flip on DirectX / Metal so the output is always upright. Requires an open Game View window.
 ---
 
 # Screenshot / Game View
+
+Captures a screenshot from the Unity Editor Game View and returns it as an image. Reads the Game View's own render texture directly via the Unity Editor API. The image size matches the current Game View resolution. Returns the image directly for visual inspection by the LLM.
+
+## Behavior
+
+Locates `UnityEditor.GameView`, repaints it, then reflects the `m_RenderTexture` field and reads back via `Texture2D.ReadPixels`. On graphics APIs whose UV origin is top-left (`SystemInfo.graphicsUVStartsAtTop`), the read-back pixels are vertically flipped before encoding so the orientation matches what the user sees. Returns a PNG image with the resolution baked into the caption.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/screenshot-isolated/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/screenshot-isolated/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: screenshot-isolated
-description: Renders a screenshot of a target GameObject with configurable isolation, background, camera angle, and lighting. When isolated=true (default), only the target object is visible via layer-based culling and inactive children of the target are temporarily activated for the render (their OnEnable callbacks may fire — restored in finally, but side effects like audio/network/animation events are not undoable). When isolated=false, the existing scene state is rendered as-is without activating inactive objects. Supports custom multi-light setups via JSON. Returns a base64-encoded PNG.
+description: Render a target GameObject from a chosen camera angle with optional layer-based isolation, configurable background (solid/skybox/transparent), multi-light setup via JSON, and Composite (2x2 Front/Right/Back/Top) mode. Returns a PNG image. When isolated=true, inactive children may briefly fire OnEnable — see the body for side-effect notes.
 ---
 
 # Screenshot / Isolated GameObject
+
+Renders a screenshot of a target GameObject with configurable isolation, background, camera angle, and lighting. When isolated=true (default), only the target object is visible via layer-based culling and inactive children of the target are temporarily activated for the render (their OnEnable callbacks may fire — restored in finally, but side effects like audio/network/animation events are not undoable). When isolated=false, the existing scene state is rendered as-is without activating inactive objects. Supports custom multi-light setups via JSON. Returns a base64-encoded PNG.
+
+## Camera views
+
+`Front` (-Z), `Back` (+Z), `Left` (-X), `Right` (+X), `Top` (+Y), `Bottom` (-Y). `Composite` produces a single 2x2 image (Front, Right, Back, Top) where each sub-view uses the requested `resolution`, so the final image is `resolution*2 x resolution*2`.
+
+## Background modes
+
+- `SolidColor` — flat color from `backgroundColor` (hex string).
+- `Skybox` — current scene skybox.
+- `Transparent` — alpha-zero (ARGB32 PNG; useful for compositing).
+
+## Lights
+
+`lights` is an optional JSON array of `IsolatedLightConfig` objects (type, color, intensity, rotation, position, range, spotAngle, innerSpotAngle, shadows, shadowStrength, bounceIntensity, colorTemperature, cookieSize, cullingMask, renderMode). When `null`, a default 1.0-intensity white directional light at rotation `(50, -30, 0)` is used. Empty array `[]` explicitly disables extra lights.
+
+## Side-effect caveat
+
+Isolation temporarily activates inactive child GameObjects so their renderers participate in the cull. Activation state is restored in `finally`, but OnEnable-triggered side effects (audio, networking, animation events) are not rewindable. Set `isolated=false` if your scene contains scripts that must not fire OnEnable during the capture.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/screenshot-scene-view/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/screenshot-scene-view/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: screenshot-scene-view
-description: Captures a screenshot from the Unity Editor Scene View and returns it as an image. Returns the image directly for visual inspection by the LLM.
+description: Capture a screenshot from the Unity Editor Scene View at the requested size. Renders via the Scene View's active camera onto a temporary `RenderTexture`. Requires an open Scene View.
 ---
 
 # Screenshot / Scene View
+
+Captures a screenshot from the Unity Editor Scene View and returns it as an image. Returns the image directly for visual inspection by the LLM.
+
+## Inputs
+
+- `width` (default 1920) / `height` (default 1080) — output pixels. Must be > 0 and ≤ `MaxDimension`.
+
+## Behavior
+
+Uses `SceneView.lastActiveSceneView` (falls back to the first window in `SceneView.sceneViews`). Allocates a temporary `RenderTexture`, swaps it onto the Scene View's camera, calls `Render`, reads back with `Texture2D.ReadPixels`, encodes PNG, and restores the camera's prior `targetTexture`. Throws/errors when no Scene View is open or the Scene View camera is null.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/script-delete/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/script-delete/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: script-delete
-description: Delete the script file(s). Does AssetDatabase.Refresh() and waits for Unity compilation to complete before reporting results. Use 'script-read' tool to read existing script files first.
+description: Delete one or more `.cs` script files from disk, refresh the AssetDatabase, and wait for Unity compilation to settle before delivering the final result via the request's `requestId`. Pair with 'script-read' to inspect files before deletion.
 ---
 
 # Script / Delete
+
+Delete the script file(s). Does AssetDatabase.Refresh() and waits for Unity compilation to complete before reporting results. Use 'script-read' tool to read existing script files first.
+
+## Inputs
+
+- `files` — non-empty array of `.cs` paths. Every entry must exist on disk.
+- `requestId` — required for the processing/delivered-later contract.
+
+## Behavior
+
+Validates the array (non-empty, every entry ends with `.cs`, every entry exists). Deletes each file plus its sibling `.meta` (when present). Calls `AssetDatabase.Refresh` and schedules a post-compilation notification — the final response is delivered after Unity finishes the recompile triggered by the delete.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/script-read/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/script-read/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: script-read
-description: Reads the content of a script file and returns it as a string. Use 'script-update-or-create' tool to update or create script files.
+description: Read a `.cs` script file and return its content as a string. Supports a 1-based `lineFrom`/`lineTo` slice for partial reads. Pair with 'script-update-or-create' to write back.
 ---
 
 # Script / Read
+
+Reads the content of a script file and returns it as a string. Use 'script-update-or-create' tool to update or create script files.
+
+## Inputs
+
+- `filePath` — required `.cs` path. Throws if missing on disk.
+- `lineFrom` (default 1, 1-based) — start line; clamped into valid range.
+- `lineTo` (default -1 = end-of-file, 1-based) — inclusive end line; clamped into valid range.
+
+## Behavior
+
+Reads the file with `File.ReadAllLines` and slices `[lineFrom..lineTo]` (inclusive). The slice indices are clamped — passing out-of-range `lineFrom`/`lineTo` is forgiving (read returns at-most the whole file).
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/script-update-or-create/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/script-update-or-create/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: script-update-or-create
-description: Updates or creates script file with the provided C# code. Does AssetDatabase.Refresh() at the end. Provides compilation error details if the code has syntax errors. Use 'script-read' tool to read existing script files first.
+description: Write a `.cs` script file (create or overwrite) with the provided C# code. Validates syntax via Roslyn before write — invalid code is rejected with error details and the file is left untouched. Refreshes the AssetDatabase and delivers the final result via `requestId` after Unity finishes the triggered compilation. Use 'script-read' to inspect existing content first.
 ---
 
 # Script / Update or Create
+
+Updates or creates script file with the provided C# code. Does AssetDatabase.Refresh() at the end. Provides compilation error details if the code has syntax errors. Use 'script-read' tool to read existing script files first.
+
+## Inputs
+
+- `filePath` — required `.cs` path.
+- `content` — C# source. MUST pass `ScriptUtils.IsValidCSharpSyntax`.
+- `requestId` — required for the processing/delivered-later contract.
+
+## Behavior
+
+Creates any missing parent directories, writes the file, then calls `AssetDatabase.Refresh` and schedules a post-compilation notification so the final response is delivered after Unity finishes the recompile.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/tests-run/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/tests-run/SKILL.md
@@ -1,9 +1,29 @@
 ---
 name: tests-run
-description: "Execute Unity tests and return detailed results. Supports filtering by test mode, assembly, namespace, class, and method. Recommended to use 'EditMode' for faster iteration during development. Precondition: every open scene MUST be saved (no unsaved changes). If any open scene is dirty, this tool throws an InvalidOperationException listing the dirty scenes; save them and retry."
+description: "Execute Unity tests (`EditMode` or `PlayMode`) and return per-test results. Supports filtering by test assembly, namespace, class, and method. Refreshes the AssetDatabase first; defers execution across domain reloads if scripts changed. Precondition: every open scene must be saved — dirty scenes abort the run."
 ---
 
 # Tests / Run
+
+Execute Unity tests and return detailed results. Supports filtering by test mode, assembly, namespace, class, and method. Recommended to use 'EditMode' for faster iteration during development. Precondition: every open scene MUST be saved (no unsaved changes). If any open scene is dirty, this tool throws an InvalidOperationException listing the dirty scenes; save them and retry.
+
+## Filters
+
+- `testMode` (default `EditMode`) — `EditMode` or `PlayMode`. EditMode is faster; prefer it during iteration.
+- `testAssembly` / `testNamespace` / `testClass` / `testMethod` — optional, layered filters. Namespace and class filters become regex `groupNames` so the validation count and Unity's execution stay in sync. `testMethod` must be fully qualified (`Namespace.FixtureName.TestName`).
+
+## Response toggles
+
+- `includePassingTests` (default `false`) — include details for passing tests; otherwise only failing test details are returned.
+- `includeMessages` (default `true`) — include per-test result messages.
+- `includeStacktrace` (default `false`) — include stack traces for failing tests.
+- `includeLogs` (default `false`) — include console logs captured during the run.
+- `logType` (default `Warning`) — minimum log severity to include.
+- `includeLogsStacktrace` (default `false`) — include log stack traces (large payload; use sparingly).
+
+## Domain reloads
+
+If the AssetDatabase refresh triggers compilation, the tool persists the run parameters to `SessionState`, returns `Processing`, and resumes the run automatically after the reload completes. Pre-existing compilation errors short-circuit the run and return the error details so the caller can fix the project first.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/tool-list/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/tool-list/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: tool-list
-description: List all available MCP tools. Optionally filter by regex across tool names, descriptions, and arguments.
+description: List all MCP tools registered with this plugin. Optional regex filter matches against tool name, description, and argument names/descriptions. Use the `includeDescription` / `includeInputs` toggles to control the response size.
 ---
 
 # Tool / List
+
+List all available MCP tools. Optionally filter by regex across tool names, descriptions, and arguments.
+
+## Inputs
+
+- `regexSearch` (optional) — case-insensitive regex with a 200ms execution-timeout guard. Invalid regex throws an `ArgumentException`. Matches name → description → input names → input descriptions.
+- `includeDescription` (default `false`) — populate each tool's `Description` field.
+- `includeInputs` (default `None`) — one of `None`, `Inputs` (names only), `InputsWithDescription` (names + descriptions).
+
+## Behavior
+
+Iterates `UnityMcpPluginEditor.Instance.Tools.GetAllTools()`, evaluates the filter (if any), and projects each surviving tool into a `ToolInfoData` honoring the verbosity toggles.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/tool-set-enabled-state/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/tool-set-enabled-state/SKILL.md
@@ -1,9 +1,20 @@
 ---
 name: tool-set-enabled-state
-description: Enable or disable MCP tools by name. Allows controlling which tools are available for the AI agent.
+description: Enable or disable MCP tools by name in batch. Persists the change via `UnityMcpPluginEditor.Instance.Save()` only when at least one tool actually flipped. Returns per-input success flags plus optional operation logs.
 ---
 
 # Tool / Set Enabled State
+
+Enable or disable MCP tools by name. Allows controlling which tools are available for the AI agent.
+
+## Inputs
+
+- `tools` — array of `ToolToggleInput { Name, Enabled }`. Non-empty.
+- `includeLogs` (default `false`) — when true, returns per-step operation logs alongside the success map.
+
+## Behavior
+
+Each entry is resolved against the tool manager's exact-name and case-insensitive lookups. Already-correct state short-circuits as success without writing. The plugin's config is saved once at the end iff at least one tool actually changed state.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/type-get-json-schema/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/type-get-json-schema/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: type-get-json-schema
-description: Generates a JSON Schema for a given C# type name using reflection. Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. The type must be present in any loaded assembly. Use the full type name (e.g. 'UnityEngine.Vector3') for best results.
+description: Generate a JSON Schema for a C# type name via reflection. Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. Knobs control inclusion of nested `$defs` and whether type-level / property-level descriptions are emitted.
 ---
 
 # Type / Get Json Schema
+
+Generates a JSON Schema for a given C# type name using reflection. Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. The type must be present in any loaded assembly. Use the full type name (e.g. 'UnityEngine.Vector3') for best results.
+
+## Inputs
+
+- `typeName` — full type name preferred (e.g. `UnityEngine.Vector3`, `System.Collections.Generic.List<System.Int32>`). Simple names work when unambiguous.
+- `descriptionMode` (default `Ignore`) — controls type-level `description`: `Include` keeps it on the target only, `IncludeRecursively` also keeps it inside `$defs`, `Ignore` strips all.
+- `propertyDescriptionMode` (default `Ignore`) — controls property/field/item `description`: `Include` keeps on the target's own properties/items only, `IncludeRecursively` also keeps inside `$defs`, `Ignore` strips all.
+- `includeNestedTypes` (default `false`) — when true, complex nested types are extracted into `$defs` and referenced via `$ref`. Useful for recursive or large types.
+- `writeIndented` (default `false`) — pretty-print the output JSON.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/.claude/skills/unity-skill-generate/SKILL.md
+++ b/Unity-MCP-Plugin/.claude/skills/unity-skill-generate/SKILL.md
@@ -1,9 +1,19 @@
 ---
 name: unity-skill-generate
-description: Generate all skills from the existed Tools in the Unity Project.
+description: "Regenerate every `SKILL.md` from the project's currently-registered MCP tools into the configured skills folder (or a project-relative override path). Writes the YAML `description:` from `[McpPluginSkillDescription]` and the body from `[McpPluginSkillBody]`."
 ---
 
 # Skill (Tool) / Generate All
+
+Generate all skills from the existed Tools in the Unity Project.
+
+## Inputs
+
+- `path` (optional) — project-relative skills folder (e.g. `.claude/skills`). Absolute paths and `..` traversal segments are rejected. When null/empty, the editor's configured `SkillsRootFolderAbsolutePath` is used.
+
+## Behavior
+
+Creates the destination folder if missing, then invokes `McpPluginInstance.GenerateSkillFiles(...)` to emit a `SKILL.md` per registered MCP tool. The plugin's `SkillsPath` is temporarily swapped to the target folder and restored in `finally` so the on-disk configuration is unchanged after the call returns.
 
 ## How to Call
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Ping.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Ping.cs
@@ -26,6 +26,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             ToolType = McpToolType.System
         )]
+        [McpPluginSkillDescription("Lightweight readiness probe. Returns the input `message` echoed back, or `'pong'` " +
+            "when omitted. Useful for CLI health checks and SignalR connectivity smoke tests.")]
+        [McpPluginSkillBody("Lightweight readiness probe. Returns the input message or 'pong' if omitted.\n\n" +
+            "## Inputs\n\n" +
+            "- `message` (optional) — when present, echoed back verbatim.\n\n" +
+            "## Behavior\n\n" +
+            "No I/O, no Unity API calls — pure echo. Ideal for measuring round-trip latency or confirming the MCP " +
+            "transport is alive before invoking a heavier tool.")]
         [Description("Lightweight readiness probe. Returns the input message or 'pong' if omitted.")]
         public string Ping
         (

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Generate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Generate.cs
@@ -29,6 +29,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Enabled = false,
             ToolType = McpToolType.System
         )]
+        [McpPluginSkillDescription("Regenerate every `SKILL.md` from the project's currently-registered MCP tools into " +
+            "the configured skills folder (or a project-relative override path). " +
+            "Writes the YAML `description:` from `[McpPluginSkillDescription]` and the body from `[McpPluginSkillBody]`.")]
+        [McpPluginSkillBody("Generate all skills from the existed Tools in the Unity Project.\n\n" +
+            "## Inputs\n\n" +
+            "- `path` (optional) — project-relative skills folder (e.g. `.claude/skills`). Absolute paths and `..` " +
+            "traversal segments are rejected. When null/empty, the editor's configured `SkillsRootFolderAbsolutePath` " +
+            "is used.\n\n" +
+            "## Behavior\n\n" +
+            "Creates the destination folder if missing, then invokes `McpPluginInstance.GenerateSkillFiles(...)` to " +
+            "emit a `SKILL.md` per registered MCP tool. The plugin's `SkillsPath` is temporarily swapped to the target " +
+            "folder and restored in `finally` so the on-disk configuration is unchanged after the call returns.")]
         [Description("Generate all skills from the existed Tools in the Unity Project.")]
         public void GenerateAll
         (

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Copy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Copy.cs
@@ -28,6 +28,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Assets / Copy",
             Enabled = false
         )]
+        [McpPluginSkillDescription("Copy assets at given paths and store them at new paths. " +
+            "Refreshes the AssetDatabase at the end. " +
+            "Use '" + AssetsFindToolId + "' to locate the source assets first.")]
+        [McpPluginSkillBody("Copy assets at given paths and store them at new paths. " +
+            "Does AssetDatabase.Refresh() at the end. " +
+            "Use '" + AssetsFindToolId + "' tool to find assets before copying.\n\n" +
+            "## Inputs\n\n" +
+            "- `sourcePaths` — paths of the assets to copy.\n" +
+            "- `destinationPaths` — paths to store the copied assets (must match `sourcePaths` length).\n\n" +
+            "## Behavior\n\n" +
+            "Each source/destination pair is copied in order. Per-pair errors are accumulated in the response " +
+            "instead of throwing, so a single bad pair does not abort the whole batch.")]
         [Description("Copy assets at given paths and store them at new paths. " +
             "Does AssetDatabase.Refresh() at the end. " +
             "Use '" + AssetsFindToolId + "' tool to find assets before copying.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.CreateFolders.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.CreateFolders.cs
@@ -40,6 +40,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Assets / Create Folder",
             Enabled = false
         )]
+        [McpPluginSkillDescription("Create a new folder under a parent folder inside 'Assets/'. " +
+            "The parent path must start with 'Assets/' and every intermediate folder in it must already exist. " +
+            "Refreshes the AssetDatabase at the end and returns the GUID(s) of the created folder(s).")]
+        [McpPluginSkillBody("Creates a new folder in the specified parent folder. " +
+            "The parent folder string must start with the 'Assets' folder, and all folders within the parent folder string must already exist. " +
+            "For example, when specifying 'Assets/ParentFolder1/ParentFolder2/', the new folder will be created in 'ParentFolder2' only if ParentFolder1 and ParentFolder2 already exist. " +
+            "Use it to organize scripts and assets in the project. " +
+            "Does AssetDatabase.Refresh() at the end. " +
+            "Returns the GUID of the newly created folder, if successful.\n\n" +
+            "## Inputs\n\n" +
+            "- `inputs` — list of `{ParentFolderPath, NewFolderName}` entries. Each entry is processed independently; " +
+            "per-entry errors are collected in the response so a single bad input does not abort the batch.\n\n" +
+            "## Validation\n\n" +
+            "- `NewFolderName` must be non-empty and must not contain any of `/`, `\\`, `<`, `>`, `:`, `\"`, `|`, `?`, `*`, or control characters (these checks are cross-platform even on Linux/Mac).\n" +
+            "- `ParentFolderPath` must already exist as an `AssetDatabase.IsValidFolder` path.\n" +
+            "- A folder with the same target name must not already exist under the parent.")]
         [Description("Creates a new folder in the specified parent folder. " +
             "The parent folder string must start with the 'Assets' folder, and all folders within the parent folder string must already exist. " +
             "For example, when specifying 'Assets/ParentFolder1/ParentFolder2/', the new folder will be created in 'ParentFolder2' only if ParentFolder1 and ParentFolder2 already exist. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Delete.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Delete.cs
@@ -31,6 +31,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             DestructiveHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Delete the assets at the given project paths. " +
+            "Refreshes the AssetDatabase at the end. " +
+            "Use '" + AssetsFindToolId + "' to locate the assets first.")]
+        [McpPluginSkillBody("Delete the assets at paths from the project. " +
+            "Does AssetDatabase.Refresh() at the end. " +
+            "Use '" + AssetsFindToolId + "' tool to find assets before deleting.\n\n" +
+            "## Inputs\n\n" +
+            "- `paths` — project-relative asset paths to delete. Must be non-empty.\n\n" +
+            "## Behavior\n\n" +
+            "Routes through `AssetDatabase.DeleteAssets`, which deletes the batch atomically. " +
+            "Paths Unity reports as failed are surfaced in `response.Errors`; successfully deleted paths " +
+            "are surfaced in `response.DeletedPaths`. The tool is destructive (removes files from disk).")]
         [Description("Delete the assets at paths from the project. " +
             "Does AssetDatabase.Refresh() at the end. " +
             "Use '" + AssetsFindToolId + "' tool to find assets before deleting.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Find.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Find.cs
@@ -28,6 +28,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Search the Unity asset database using a search filter string. " +
+            "The filter accepts names, labels (`l:`), types (`t:`), AssetBundles (`b:`), areas (`a:`), and globs (`glob:`). " +
+            "See the body for the full filter syntax.")]
+        [McpPluginSkillBody("Search the asset database using the search filter string. " +
+            "Allows you to search for Assets. The string argument can provide names, labels or types (classnames).\n\n" +
+            "## Filter syntax\n\n" +
+            "- **Name** — filter assets by their filename (without extension). Words separated by whitespace are " +
+            "treated as separate name searches.\n" +
+            "- **Labels (`l:`)** — assets can have labels attached. Use `l:` before each label.\n" +
+            "- **Types (`t:`)** — find assets based on explicitly identified types. Available types include " +
+            "AnimationClip, AudioClip, AudioMixer, ComputeShader, Font, GUISkin, Material, Mesh, Model, " +
+            "PhysicMaterial, Prefab, Scene, Script, Shader, Sprite, Texture, VideoClip, VisualEffectAsset, " +
+            "VisualEffectSubgraph.\n" +
+            "- **AssetBundles (`b:`)** — find assets which are part of an Asset bundle.\n" +
+            "- **Area (`a:`)** — find assets in a specific area. Valid values: `all`, `assets`, `packages`.\n" +
+            "- **Globbing (`glob:`)** — use globbing to match specific rules.\n\n" +
+            "Searching is case-insensitive. Use `searchInFolders` to restrict the search scope. " +
+            "`maxResults` caps the returned list (default 10) — results beyond it are truncated.")]
         [Description("Search the asset database using the search filter string. " +
             "Allows you to search for Assets. The string argument can provide names, labels or types (classnames).")]
         public List<AssetObjectRef> Find

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.FindBuiltIn.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.FindBuiltIn.cs
@@ -32,6 +32,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Search the built-in assets of the Unity Editor (located at " +
+            ExtensionsRuntimeObject.UnityEditorBuiltInResourcesPath + "). " +
+            "Filters by name and/or type; built-in assets have no GUID so GUID-based lookups are not supported.")]
+        [McpPluginSkillBody("Search the built-in assets of the Unity Editor located in the built-in resources: " +
+            ExtensionsRuntimeObject.UnityEditorBuiltInResourcesPath + ". " +
+            "Doesn't support GUIDs since built-in assets do not have them.\n\n" +
+            "## Inputs\n\n" +
+            "- `name` (optional) — case-insensitive name fragment. Underscores, hyphens, spaces, and periods " +
+            "delimit search words so partial-word matching works.\n" +
+            "- `type` (optional) — restrict results to assets assignable to this type (e.g. `UnityEngine.Texture2D`).\n" +
+            "- `maxResults` — cap on returned list size (default 10).\n\n" +
+            "## Ranking\n\n" +
+            "Results are sorted by descending match quality: exact match → substring match → all-words match → " +
+            "partial-words match. Within a rank, results are sorted alphabetically by filename for stable ordering.")]
         [Description("Search the built-in assets of the Unity Editor located in the built-in resources: " +
             ExtensionsRuntimeObject.UnityEditorBuiltInResourcesPath + ". " +
             "Doesn't support GUIDs since built-in assets do not have them.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
@@ -33,6 +33,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Get asset data from the asset file in the Unity project — every serializable " +
+            "field and property. Supports token-saving path-scoped reads via `paths` or `viewQuery`. " +
+            "Use '" + AssetsFindToolId + "' to find the asset first.")]
+        [McpPluginSkillBody("Get asset data from the asset file in the Unity project. " +
+            "It includes all serializable fields and properties of the asset. " +
+            "Use '" + AssetsFindToolId + "' tool to find asset before using this tool.\n\n" +
+            "## Path-scoped reads (token-saving)\n\n" +
+            "Supply `paths` (a list of paths) to read only the listed fields/elements via " +
+            "`Reflector.TryReadAt`, or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by " +
+            "name regex / max depth / type via `Reflector.View`. These two parameters are mutually exclusive — " +
+            "supply at most one. When neither is supplied the full asset is serialized (backwards compatible).\n\n" +
+            "## Path syntax\n\n" +
+            "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.")]
         [Description("Get asset data from the asset file in the Unity project. " +
             "It includes all serializable fields and properties of the asset. " +
             "Use '" + AssetsFindToolId + "' tool to find asset before using this tool.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Material.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Material.Create.cs
@@ -28,6 +28,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             AssetsMaterialCreateToolId,
             Title = "Assets / Create Material"
         )]
+        [McpPluginSkillDescription("Create a new Material asset with default parameters at a given 'Assets/'-rooted " +
+            "path ending in '.mat'. Creates intermediate folders if missing. Use '" +
+            Tool_Assets_Shader.AssetsShaderListAllToolId + "' to find a valid `shaderName`.")]
+        [McpPluginSkillBody("Create new material asset with default parameters. " +
+            "Creates folders recursively if they do not exist. " +
+            "Provide proper 'shaderName' - use '" + Tool_Assets_Shader.AssetsShaderListAllToolId + "' tool to find available shaders.\n\n" +
+            "## Inputs\n\n" +
+            "- `assetPath` — must start with `Assets/` and end with `.mat`.\n" +
+            "- `shaderName` — name resolvable via `UnityEngine.Shader.Find`.\n\n" +
+            "## Behavior\n\n" +
+            "Throws if the path is empty, malformed, or the shader cannot be resolved. " +
+            "Creates a default Material from the resolved shader, saves it, refreshes the AssetDatabase, " +
+            "and returns an `AssetObjectRef` pointing at the new asset.")]
         [Description("Create new material asset with default parameters. " +
             "Creates folders recursively if they do not exist. " +
             "Provide proper 'shaderName' - use '" + Tool_Assets_Shader.AssetsShaderListAllToolId + "' tool to find available shaders.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Move.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Move.cs
@@ -29,6 +29,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Assets / Move",
             Enabled = false
         )]
+        [McpPluginSkillDescription("Move or rename assets at the given project paths. " +
+            "Refreshes the AssetDatabase at the end. " +
+            "Use '" + AssetsFindToolId + "' to locate the assets first.")]
+        [McpPluginSkillBody("Move the assets at paths in the project. " +
+            "Should be used for asset rename. " +
+            "Does AssetDatabase.Refresh() at the end. " +
+            "Use '" + AssetsFindToolId + "' tool to find assets before moving.\n\n" +
+            "## Inputs\n\n" +
+            "- `sourcePaths` — paths of the assets to move.\n" +
+            "- `destinationPaths` — target paths (must match `sourcePaths` length).\n\n" +
+            "## Behavior\n\n" +
+            "Each pair is moved independently via `AssetDatabase.MoveAsset`. " +
+            "Per-pair failures (Unity's `MoveAsset` returns a non-empty error string) are surfaced in " +
+            "`response.Errors`; successful moves accumulate into `response.MovedPaths`.")]
         [Description("Move the assets at paths in the project. " +
             "Should be used for asset rename. " +
             "Does AssetDatabase.Refresh() at the end. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
@@ -28,6 +28,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             AssetsPrefabCloseToolId,
             Title = "Assets / Prefab / Close"
         )]
+        [McpPluginSkillDescription("Close the currently opened prefab edit stage. " +
+            "Optionally saves changes back to the prefab asset before closing. " +
+            "Pair with '" + AssetsPrefabOpenToolId + "' to enter the edit mode first.")]
+        [McpPluginSkillBody("Close currently opened prefab. " +
+            "Use it when you are in prefab editing mode in Unity Editor. " +
+            "Use '" + AssetsPrefabOpenToolId + "' tool to open a prefab first.\n\n" +
+            "## Inputs\n\n" +
+            "- `save` (default `true`) — when `true`, calls `PrefabUtility.SaveAsPrefabAsset` before exiting the stage; " +
+            "when `false`, the prefab stage's dirtiness is cleared and changes are discarded.\n\n" +
+            "## Behavior\n\n" +
+            "Throws when no prefab stage is currently open. Returns an `AssetObjectRef` for the closed prefab asset.")]
         [Description("Close currently opened prefab. " +
             "Use it when you are in prefab editing mode in Unity Editor. " +
             "Use '" + AssetsPrefabOpenToolId + "' tool to open a prefab first.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
@@ -36,7 +36,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "Use '" + AssetsPrefabOpenToolId + "' tool to open a prefab first.\n\n" +
             "## Inputs\n\n" +
             "- `save` (default `true`) — when `true`, calls `PrefabUtility.SaveAsPrefabAsset` before exiting the stage; " +
-            "when `false`, the prefab stage's dirtiness is cleared and changes are discarded.\n\n" +
+            "when `false`, the save is skipped. The prefab stage's dirtiness is always cleared at the end, so any " +
+            "unsaved changes are discarded when `save` is `false`.\n\n" +
             "## Behavior\n\n" +
             "Throws when no prefab stage is currently open. Returns an `AssetObjectRef` for the closed prefab asset.")]
         [Description("Close currently opened prefab. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
@@ -28,6 +28,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             AssetsPrefabCreateToolId,
             Title = "Assets / Prefab / Create"
         )]
+        [McpPluginSkillDescription("Create a Prefab (or Prefab Variant) at a project asset path. " +
+            "Source can be a scene GameObject (`gameObjectRef`) or an existing prefab asset (`sourcePrefabAssetPath`). " +
+            "Creates intermediate folders if missing. Use '" + Tool_GameObject.GameObjectFindToolId +
+            "' to locate the source GameObject first.")]
+        [McpPluginSkillBody("Create a prefab from a GameObject in the current active scene. " +
+            "The prefab will be saved in the project assets at the specified path. " +
+            "Creates folders recursively if they do not exist. " +
+            "If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. " +
+            "To create a Prefab Variant from an existing prefab asset, provide 'sourcePrefabAssetPath' instead of 'gameObjectRef'. " +
+            "Use '" + Tool_GameObject.GameObjectFindToolId + "' tool to find the target GameObject first.\n\n" +
+            "## Inputs (mutually exclusive sources)\n\n" +
+            "- `prefabAssetPath` — required. Must start with `Assets/` and end with `.prefab`.\n" +
+            "- `gameObjectRef` — scene GameObject to convert (or to seed a Prefab Variant from when it is already a prefab instance).\n" +
+            "- `sourcePrefabAssetPath` — existing prefab asset to seed a Prefab Variant from. Cannot be combined with `gameObjectRef`.\n" +
+            "- `connectGameObjectToPrefab` (default `true`) — when sourcing from a scene GameObject, connect the scene object to the new prefab asset (becoming a prefab instance). Ignored for `sourcePrefabAssetPath` (always creates a variant).\n\n" +
+            "## Behavior\n\n" +
+            "Creates intermediate folders along `prefabAssetPath` if they don't already exist. Returns an `AssetObjectRef` " +
+            "pointing at the new prefab asset.")]
         [Description("Create a prefab from a GameObject in the current active scene. " +
             "The prefab will be saved in the project assets at the specified path. " +
             "Creates folders recursively if they do not exist. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Instantiate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Instantiate.cs
@@ -29,6 +29,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             AssetsPrefabInstantiateToolId,
             Title = "Assets / Prefab / Instantiate"
         )]
+        [McpPluginSkillDescription("Instantiate a prefab into the currently active scene at an optional position/rotation/scale, " +
+            "parented under an optional scene GameObject path. " +
+            "Use '" + Tool_Assets.AssetsFindToolId + "' to locate the prefab asset first.")]
+        [McpPluginSkillBody("Instantiates prefab in the current active scene. " +
+            "Use '" + Tool_Assets.AssetsFindToolId + "' tool to find prefab assets in the project.\n\n" +
+            "## Inputs\n\n" +
+            "- `prefabAssetPath` — project asset path of the prefab to instantiate.\n" +
+            "- `gameObjectPath` — destination path in the scene; the last segment becomes the new GameObject's name, " +
+            "any prefix is looked up as the parent (must already exist).\n" +
+            "- `position` / `rotation` / `scale` — optional transform; default to zero / zero / one.\n" +
+            "- `isLocalSpace` — when `true`, applies the transform in local space relative to the parent.")]
         [Description("Instantiates prefab in the current active scene. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool to find prefab assets in the project.")]
         public GameObjectRef Instantiate

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Open.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Open.cs
@@ -28,6 +28,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             AssetsPrefabOpenToolId,
             Title = "Assets / Prefab / Open"
         )]
+        [McpPluginSkillDescription("Open the prefab edit stage for a prefab instance or prefab asset GameObject. " +
+            "Modifications inside the edit stage propagate to all instances. " +
+            "Pair with '" + AssetsPrefabCloseToolId + "' to exit the stage when done.")]
+        [McpPluginSkillBody("Open prefab edit mode for a specific GameObject. " +
+            "In the Edit mode you can modify the prefab. " +
+            "The modification will be applied to all instances of the prefab across the project. " +
+            "Note: Please use '" + AssetsPrefabCloseToolId + "' tool later to exit prefab editing mode.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — reference to a scene prefab instance OR a prefab asset GameObject. The tool resolves " +
+            "the prefab asset path via `PrefabUtility.GetPrefabAssetPathOfNearestInstanceRoot` and opens the appropriate " +
+            "prefab stage.\n\n" +
+            "## Behavior\n\n" +
+            "Asset-side GameObjects open via the simple `OpenPrefab(path)` overload. Scene-instance GameObjects open " +
+            "via `OpenPrefab(path, gameObject)` so the editor remembers which instance prompted the edit. Editor windows " +
+            "are repainted before returning. Throws when the GameObject cannot be resolved or the stage fails to open.")]
         [Description("Open prefab edit mode for a specific GameObject. " +
             "In the Edit mode you can modify the prefab. " +
             "The modification will be applied to all instances of the prefab across the project. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
@@ -29,6 +29,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Assets / Prefab / Save",
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Save the currently opened prefab edit stage back to its prefab asset without exiting the stage. " +
+            "Pair with '" + AssetsPrefabOpenToolId + "' to enter the edit mode first.")]
+        [McpPluginSkillBody("Save a prefab. " +
+            "Use it when you are in prefab editing mode in Unity Editor. " +
+            "Use '" + AssetsPrefabOpenToolId + "' tool to open a prefab first.\n\n" +
+            "## Behavior\n\n" +
+            "Calls `PrefabUtility.SaveAsPrefabAsset` on the current prefab stage's contents root, clears the stage's " +
+            "dirtiness flag, repaints editor windows, and returns an `AssetObjectRef` to the saved prefab. " +
+            "Throws when no prefab stage is currently open.")]
         [Description("Save a prefab. " +
             "Use it when you are in prefab editing mode in Unity Editor. " +
             "Use '" + AssetsPrefabOpenToolId + "' tool to open a prefab first.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Refresh.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Refresh.cs
@@ -28,6 +28,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Assets / Refresh",
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Refresh the Unity AssetDatabase. " +
+            "Use after files were added or updated outside of the Unity API, or to force script recompilation " +
+            "when a '.cs' file changed. Returns a processing/success response and waits for compilation when triggered.")]
+        [McpPluginSkillBody("Refreshes the AssetDatabase. " +
+            "Use it if any file was added or updated in the project outside of Unity API. " +
+            "Use it if need to force scripts recompilation when '.cs' file changed.\n\n" +
+            "## Inputs\n\n" +
+            "- `options` — `ImportAssetOptions` flag (default `ForceSynchronousImport`).\n" +
+            "- `requestId` — required for processing-mode responses; the tool returns `Processing` immediately and " +
+            "delivers a follow-up completion when compilation finishes.\n\n" +
+            "## Behavior\n\n" +
+            "Runs `AssetDatabase.Refresh(options)`. If `EditorApplication.isCompiling` is true after the refresh, " +
+            "schedules a post-compilation notification and returns a `Processing` response. If compilation already " +
+            "failed (`EditorUtility.scriptCompilationFailed`), returns `Success` with the compilation error details. " +
+            "Otherwise returns a plain `Success`.")]
         [Description("Refreshes the AssetDatabase. " +
             "Use it if any file was added or updated in the project outside of Unity API. " +
             "Use it if need to force scripts recompilation when '.cs' file changed.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
@@ -45,7 +45,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "Returns shader properties, subshaders, passes, compilation errors, and supported status. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool with filter 't:Shader' to find shaders, " +
             "or '" + AssetsShaderListAllToolId + "' tool to list all shader names.\n\n" +
-            "## Toggles (default off to keep responses small)\n\n" +
+            "## Toggles (most default off to keep responses small)\n\n" +
             "- `includeMessages` (default `true`) — shader compilation messages.\n" +
             "- `includeProperties` (default `false`) — uniforms list.\n" +
             "- `includeSubshaders` (default `false`) — subshader and pass structure.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
@@ -37,6 +37,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Get detailed data about a shader asset — properties, subshaders, passes, " +
+            "compilation messages, and supported status. Supports token-saving path-scoped reads via `paths` or " +
+            "`viewQuery`. Use '" + Tool_Assets.AssetsFindToolId + "' with `t:Shader` or '" +
+            AssetsShaderListAllToolId + "' to locate the shader first.")]
+        [McpPluginSkillBody("Get detailed data about a shader asset in the Unity project. " +
+            "Returns shader properties, subshaders, passes, compilation errors, and supported status. " +
+            "Use '" + Tool_Assets.AssetsFindToolId + "' tool with filter 't:Shader' to find shaders, " +
+            "or '" + AssetsShaderListAllToolId + "' tool to list all shader names.\n\n" +
+            "## Toggles (default off to keep responses small)\n\n" +
+            "- `includeMessages` (default `true`) — shader compilation messages.\n" +
+            "- `includeProperties` (default `false`) — uniforms list.\n" +
+            "- `includeSubshaders` (default `false`) — subshader and pass structure.\n" +
+            "- `includeSourceCode` (default `false`) — pass source code. Implies `includeSubshaders` and can produce very large responses.\n\n" +
+            "## Path-scoped reads (token-saving)\n\n" +
+            "Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, " +
+            "or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type " +
+            "via `Reflector.View`. The result populates `View` on the returned `ShaderData`. " +
+            "These two parameters are mutually exclusive.\n\n" +
+            "## Path syntax\n\n" +
+            "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.")]
         [Description("Get detailed data about a shader asset in the Unity project. " +
             "Returns shader properties, subshaders, passes, compilation errors, and supported status. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool with filter 't:Shader' to find shaders, " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.ListAll.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.ListAll.cs
@@ -28,6 +28,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("List all shaders available in the project assets and packages, sorted by name. " +
+            "Use this to discover a valid `shaderName` for '" + Tool_Assets.AssetsMaterialCreateToolId + "'.")]
+        [McpPluginSkillBody("List all available shaders in the project assets and packages. " +
+            "Returns their names. " +
+            "Use this to find a shader name for '" + Tool_Assets.AssetsMaterialCreateToolId + "' tool.\n\n" +
+            "## Behavior\n\n" +
+            "Enumerates shaders via `ShaderUtils.GetAllShaders`, filters out nulls, and returns the names alphabetically sorted.")]
         [Description("List all available shaders in the project assets and packages. " +
             "Returns their names. " +
             "Use this to find a shader name for '" + Tool_Assets.AssetsMaterialCreateToolId + "' tool.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.ClearLogs.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.ClearLogs.cs
@@ -28,6 +28,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             DestructiveHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Clear the MCP log cache (used by '" + ConsoleGetLogsToolId + "') and the Unity Editor Console window. " +
+            "Useful for isolating logs to a specific action by clearing the slate first.")]
+        [McpPluginSkillBody("Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. " +
+            "Useful for isolating errors related to a specific action by clearing logs before performing the action.\n\n" +
+            "## Behavior\n\n" +
+            "Calls `Debug.ClearDeveloperConsole()` to wipe the Editor Console, then clears the MCP-side `LogCollector` " +
+            "cache so subsequent '" + ConsoleGetLogsToolId + "' calls only see new entries.")]
         [Description("Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. " +
             "Useful for isolating errors related to a specific action by clearing logs before performing the action.")]
         public void ClearLogs(string? nothing = null)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.GetLogs.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.GetLogs.cs
@@ -26,6 +26,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Retrieve Unity Editor logs from the MCP plugin's `LogCollector`, " +
+            "optionally filtered by log type or time window. Useful for debugging and monitoring Editor activity.")]
+        [McpPluginSkillBody("Retrieves Unity Editor logs. " +
+            "Useful for debugging and monitoring Unity Editor activity.\n\n" +
+            "## Inputs\n\n" +
+            "- `maxEntries` (default 100, minimum 1) — caps the size of the returned array.\n" +
+            "- `logTypeFilter` — Unity `LogType` filter; `null` returns all severities.\n" +
+            "- `includeStackTrace` (default `false`) — include stack-trace strings in each entry.\n" +
+            "- `lastMinutes` (default 0) — when non-zero, only logs from the last N minutes are returned.")]
         [Description("Retrieves Unity Editor logs. " +
             "Useful for debugging and monitoring Unity Editor activity.")]
         public LogEntry[] GetLogs

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.GetState.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.GetState.cs
@@ -27,6 +27,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Return the current state of `UnityEditor.EditorApplication` — playmode, " +
+            "paused state, compilation state, and related flags.")]
+        [McpPluginSkillBody("Returns available information about 'UnityEditor.EditorApplication'. " +
+            "Use it to get information about the current state of the Unity Editor application. " +
+            "Such as: playmode, paused state, compilation state, etc.\n\n" +
+            "## Behavior\n\n" +
+            "Snapshots Editor state via `EditorStatsData.FromEditor()` on the main thread and returns the result.")]
         [Description("Returns available information about 'UnityEditor.EditorApplication'. " +
             "Use it to get information about the current state of the Unity Editor application. " +
             "Such as: playmode, paused state, compilation state, etc.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.SetState.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.SetState.cs
@@ -39,7 +39,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "- `isPlaying` (default `false`) — sets `EditorApplication.isPlaying`.\n" +
             "- `isPaused` (default `false`) — sets `EditorApplication.isPaused`.\n\n" +
             "## Behavior\n\n" +
-            "Refuses to switch into play mode while `EditorUtility.scriptCompilationFailed` is true — instead throws with " +
+            "Refuses any state change while `EditorUtility.scriptCompilationFailed` is true — instead throws with " +
             "the compilation error details so the caller can fix them first. On success returns the post-change " +
             "`EditorStatsData` snapshot.")]
         [Description("Control the Unity Editor application state. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.SetState.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.SetState.cs
@@ -29,6 +29,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Start / stop / pause the Unity Editor 'playmode'. " +
+            "Use '" + EditorApplicationGetStateToolId + "' to inspect the current state first. " +
+            "Throws if the project currently has compilation errors.")]
+        [McpPluginSkillBody("Control the Unity Editor application state. " +
+            "You can start, stop, or pause the 'playmode'. " +
+            "Use '" + EditorApplicationGetStateToolId + "' tool to get the current state first.\n\n" +
+            "## Inputs\n\n" +
+            "- `isPlaying` (default `false`) — sets `EditorApplication.isPlaying`.\n" +
+            "- `isPaused` (default `false`) — sets `EditorApplication.isPaused`.\n\n" +
+            "## Behavior\n\n" +
+            "Refuses to switch into play mode while `EditorUtility.scriptCompilationFailed` is true — instead throws with " +
+            "the compilation error details so the caller can fix them first. On success returns the post-change " +
+            "`EditorStatsData` snapshot.")]
         [Description("Control the Unity Editor application state. " +
             "You can start, stop, or pause the 'playmode'. " +
             "Use '" + EditorApplicationGetStateToolId + "' tool to get the current state first.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.cs
@@ -30,6 +30,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription(GetSkill.Description)]
+        [McpPluginSkillBody(GetSkill.Body)]
         [Description("Get information about the current Selection in the Unity Editor. " +
             "Use '" + EditorSelectionSetToolId + "' tool to set the selection.")]
         public SelectionData Get(

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.pre-Unity.6.5.cs
@@ -30,6 +30,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription(GetSkill.Description)]
+        [McpPluginSkillBody(GetSkill.Body)]
         [Description("Get information about the current Selection in the Unity Editor. " +
             "Use '" + EditorSelectionSetToolId + "' tool to set the selection.")]
         public SelectionData Get(

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.cs
@@ -30,6 +30,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription(SetSkill.Description)]
+        [McpPluginSkillBody(SetSkill.Body)]
         [Description("Set the current Selection in the Unity Editor to the provided objects. " +
             "Use '" + EditorSelectionGetToolId + "' tool to get the current selection first.")]
         public SelectionData Set(ObjectRef[] select)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.pre-Unity.6.5.cs
@@ -30,6 +30,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription(SetSkill.Description)]
+        [McpPluginSkillBody(SetSkill.Body)]
         [Description("Set the current Selection in the Unity Editor to the provided objects. " +
             "Use '" + EditorSelectionGetToolId + "' tool to get the current selection first.")]
         public SelectionData Set(ObjectRef[] select)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.cs
@@ -27,6 +27,48 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 => "Script path is empty. Please provide a valid path. Sample: \"Assets/Scripts/MyScript.cs\".";
         }
 
+        // Shared skill metadata for `editor-selection-get`. The Unity 6.5+ and pre-6.5 implementations
+        // diverge in behavioral code (different Selection API surfaces) but their SKILL.md
+        // description/body are identical, so we keep the strings here once.
+        internal static class GetSkill
+        {
+            public const string Description =
+                "Get information about the current Selection in the Unity Editor — active object, active transform, " +
+                "selected GameObjects, transforms, instance IDs, and asset GUIDs (each enrichment is opt-in). " +
+                "Pair with 'editor-selection-set' to change the selection.";
+
+            public const string Body =
+                "Get information about the current Selection in the Unity Editor. " +
+                "Use 'editor-selection-set' tool to set the selection.\n\n" +
+                "## Toggles (default off where indicated to keep responses small)\n\n" +
+                "- `includeGameObjects` (default `false`) — populate `GameObjects[]`.\n" +
+                "- `includeTransforms` (default `false`) — populate `Transforms[]` as `ComponentRef`s.\n" +
+                "- `includeInstanceIDs` (default `false`) — populate `InstanceIDs[]`.\n" +
+                "- `includeAssetGUIDs` (default `false`) — populate `AssetGUIDs[]` from project-window selection.\n" +
+                "- `includeActiveObject` (default `true`) — populate `ActiveObject` as a generic `ObjectRef`.\n" +
+                "- `includeActiveTransform` (default `true`) — populate `ActiveTransform` as a `ComponentRef`.\n\n" +
+                "`ActiveGameObject` and `ActiveInstanceID` are always populated.";
+        }
+
+        // Shared skill metadata for `editor-selection-set`. See GetSkill above for rationale.
+        internal static class SetSkill
+        {
+            public const string Description =
+                "Set the current Selection in the Unity Editor to the provided objects. " +
+                "All `ObjectRef`s must resolve to existing Unity objects; otherwise the call throws. " +
+                "Use 'editor-selection-get' to inspect the current selection first.";
+
+            public const string Body =
+                "Set the current Selection in the Unity Editor to the provided objects. " +
+                "Use 'editor-selection-get' tool to get the current selection first.\n\n" +
+                "## Inputs\n\n" +
+                "- `select` — array of `ObjectRef`. Every entry MUST resolve via `FindObject()`; otherwise the tool throws " +
+                "before touching `Selection.objects`.\n\n" +
+                "## Behavior\n\n" +
+                "Assigns the resolved array to `Selection.objects`, then calls " +
+                "`UnityEditorInternal.InternalEditorUtility.RepaintAllViews()` so Hierarchy/Inspector reflect the change. " +
+                "Returns the post-change `SelectionData` snapshot.";
+        }
     }
 }
 #endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.pre-Unity.6.5.cs
@@ -27,6 +27,47 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 => "Script path is empty. Please provide a valid path. Sample: \"Assets/Scripts/MyScript.cs\".";
         }
 
+        // Shared skill metadata for `editor-selection-get`. Mirrors the Unity 6.5+ partial
+        // (Editor.Selection.cs) so the SKILL.md generation is identical for both builds.
+        internal static class GetSkill
+        {
+            public const string Description =
+                "Get information about the current Selection in the Unity Editor — active object, active transform, " +
+                "selected GameObjects, transforms, instance IDs, and asset GUIDs (each enrichment is opt-in). " +
+                "Pair with 'editor-selection-set' to change the selection.";
+
+            public const string Body =
+                "Get information about the current Selection in the Unity Editor. " +
+                "Use 'editor-selection-set' tool to set the selection.\n\n" +
+                "## Toggles (default off where indicated to keep responses small)\n\n" +
+                "- `includeGameObjects` (default `false`) — populate `GameObjects[]`.\n" +
+                "- `includeTransforms` (default `false`) — populate `Transforms[]` as `ComponentRef`s.\n" +
+                "- `includeInstanceIDs` (default `false`) — populate `InstanceIDs[]`.\n" +
+                "- `includeAssetGUIDs` (default `false`) — populate `AssetGUIDs[]` from project-window selection.\n" +
+                "- `includeActiveObject` (default `true`) — populate `ActiveObject` as a generic `ObjectRef`.\n" +
+                "- `includeActiveTransform` (default `true`) — populate `ActiveTransform` as a `ComponentRef`.\n\n" +
+                "`ActiveGameObject` and `ActiveInstanceID` are always populated.";
+        }
+
+        // Shared skill metadata for `editor-selection-set`. Mirrors Editor.Selection.cs.
+        internal static class SetSkill
+        {
+            public const string Description =
+                "Set the current Selection in the Unity Editor to the provided objects. " +
+                "All `ObjectRef`s must resolve to existing Unity objects; otherwise the call throws. " +
+                "Use 'editor-selection-get' to inspect the current selection first.";
+
+            public const string Body =
+                "Set the current Selection in the Unity Editor to the provided objects. " +
+                "Use 'editor-selection-get' tool to get the current selection first.\n\n" +
+                "## Inputs\n\n" +
+                "- `select` — array of `ObjectRef`. Every entry MUST resolve via `FindObject()`; otherwise the tool throws " +
+                "before touching `Selection.objects`.\n\n" +
+                "## Behavior\n\n" +
+                "Assigns the resolved array to `Selection.objects`, then calls " +
+                "`UnityEditorInternal.InternalEditorUtility.RepaintAllViews()` so Hierarchy/Inspector reflect the change. " +
+                "Returns the post-change `SelectionData` snapshot.";
+        }
     }
 }
 #endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Add.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Add.cs
@@ -28,6 +28,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             GameObjectComponentAddToolId,
             Title = "GameObject / Component / Add"
         )]
+        [McpPluginSkillDescription("Add one or more Components to a GameObject in the opened Prefab or active Scene. " +
+            "Component types are looked up by full name (with namespace) or by class-name fallback. " +
+            "Use '" + GameObjectFindToolId + "' to locate the host GameObject and '" + ComponentListToolId +
+            "' to discover valid component type names.")]
+        [McpPluginSkillBody("Add Component to GameObject in opened Prefab or in a Scene. " +
+            "Use '" + GameObjectFindToolId + "' tool to find the target GameObject first. " +
+            "Use '" + ComponentListToolId + "' tool to find the component type names to add.\n\n" +
+            "## Inputs\n\n" +
+            "- `componentNames` — list of component type names. Each entry may be a fully-qualified type name (preferred) " +
+            "or a bare class name (resolved via fallback to `AllComponentTypes`).\n" +
+            "- `gameObjectRef` — the target GameObject. Required.\n\n" +
+            "## Behavior\n\n" +
+            "Per-name errors (unknown type, type not assignable to `UnityEngine.Component`, add-failed/duplicate) are " +
+            "accumulated in `response.Errors` / `response.Warnings` instead of throwing, so a single bad name does not " +
+            "abort the whole batch. Successful additions populate `response.AddedComponents` with `ComponentDataShallow` " +
+            "snapshots.")]
         [Description("Add Component to GameObject in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject first. " +
             "Use '" + ComponentListToolId + "' tool to find the component type names to add.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Destroy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Destroy.cs
@@ -28,6 +28,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "GameObject / Component / Destroy",
             DestructiveHint = true
         )]
+        [McpPluginSkillDescription("Destroy one or more Components from a target GameObject. Missing (null) components " +
+            "are skipped — they cannot be destroyed. " +
+            "Use '" + GameObjectFindToolId + "' and '" + GameObjectComponentGetToolId +
+            "' to identify the components first.")]
+        [McpPluginSkillBody("Destroy one or many components from target GameObject. Can't destroy missed components. " +
+            "Use '" + GameObjectFindToolId + "' tool to find the target GameObject and '" + GameObjectComponentGetToolId + "' to get component details first.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRef` — the host GameObject.\n" +
+            "- `destroyComponentRefs` — `ComponentRefList` of components to destroy (matched against the GameObject's components).\n\n" +
+            "## Behavior\n\n" +
+            "Iterates `go.GetComponents<Component>()`, skipping null entries (missing scripts). For each non-null component " +
+            "that matches one of `destroyComponentRefs`, the tool snapshots a `ComponentRef`, calls `Object.DestroyImmediate`, " +
+            "and records the destroyed reference. If no component matches at all, throws with the help text from " +
+            "`Error.NotFoundComponents` (which includes a preview of all available components on the GameObject).")]
         [Description("Destroy one or many components from target GameObject. Can't destroy missed components. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject and '" + GameObjectComponentGetToolId + "' to get component details first.")]
         public DestroyComponentsResponse DestroyComponents

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
@@ -35,6 +35,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription(ComponentGetSkill.Description)]
+        [McpPluginSkillBody(ComponentGetSkill.Body)]
         [Description("Get detailed information about a specific Component on a GameObject. " +
             "Returns component type, enabled state, and optionally serialized fields and properties. " +
             "Use this to inspect component data before modifying it. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
@@ -35,6 +35,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription(ComponentGetSkill.Description)]
+        [McpPluginSkillBody(ComponentGetSkill.Body)]
         [Description("Get detailed information about a specific Component on a GameObject. " +
             "Returns component type, enabled state, and optionally serialized fields and properties. " +
             "Use this to inspect component data before modifying it. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.ListAll.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.ListAll.cs
@@ -34,6 +34,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("List the fully-qualified C# type names of every concrete `UnityEngine.Component` " +
+            "subclass available in the project. Paginated (default 5/page, max 500). " +
+            "Use this to find a valid `componentName` for '" + GameObjectComponentAddToolId + "'.")]
+        [McpPluginSkillBody("List C# class names extended from UnityEngine.Component. " +
+            "Use this to find component type names for '" + GameObjectComponentAddToolId + "' tool. " +
+            "Results are paginated to avoid overwhelming responses.\n\n" +
+            "## Inputs\n\n" +
+            "- `search` (optional) — case-insensitive substring filter on type names.\n" +
+            "- `page` (default 0, 0-based) — page index.\n" +
+            "- `pageSize` (default 5, range 1..500) — items per page.\n\n" +
+            "## Behavior\n\n" +
+            "Enumerates `AllComponentTypes` (every non-abstract subclass of `UnityEngine.Component`), filters by " +
+            "`search` if supplied, then returns a `ComponentListResult` containing the requested page plus " +
+            "`TotalCount` / `TotalPages` so the caller can iterate.")]
         [Description("List C# class names extended from UnityEngine.Component. " +
             "Use this to find component type names for '" + GameObjectComponentAddToolId + "' tool. " +
             "Results are paginated to avoid overwhelming responses.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Create.cs
@@ -30,6 +30,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             GameObjectCreateToolId,
             Title = "GameObject / Create"
         )]
+        [McpPluginSkillDescription("Create a new GameObject in the currently opened Prefab or active Scene, optionally " +
+            "parented under another GameObject and pre-positioned. Pass `primitiveType` to spawn a Unity primitive " +
+            "(Cube, Sphere, etc.) instead of an empty GameObject.")]
+        [McpPluginSkillBody("Create a new GameObject in opened Prefab or in a Scene. " +
+            "If needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.\n\n" +
+            "## Inputs\n\n" +
+            "- `name` — required non-empty name.\n" +
+            "- `parentGameObjectRef` (optional) — when provided, the new GameObject is parented under this one " +
+            "(`SetParent(parent, false)`); otherwise it's created at scene/prefab root.\n" +
+            "- `position` / `rotation` / `scale` — optional transform; default to zero / zero / one.\n" +
+            "- `isLocalSpace` — when `true`, applies the transform in local space relative to the parent.\n" +
+            "- `primitiveType` (optional) — when set, the GameObject is created via `GameObject.CreatePrimitive` " +
+            "(adds the appropriate renderer/collider for the primitive shape).")]
         [Description("Create a new GameObject in opened Prefab or in a Scene. " +
             "If needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.")]
         public GameObjectRef Create

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Create.cs
@@ -38,7 +38,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "## Inputs\n\n" +
             "- `name` — required non-empty name.\n" +
             "- `parentGameObjectRef` (optional) — when provided, the new GameObject is parented under this one " +
-            "(`SetParent(parent, false)`); otherwise it's created at scene/prefab root.\n" +
+            "(`SetParent(parent, worldPositionStays: false)`); otherwise it's created at scene/prefab root.\n" +
             "- `position` / `rotation` / `scale` — optional transform; default to zero / zero / one.\n" +
             "- `isLocalSpace` — when `true`, applies the transform in local space relative to the parent.\n" +
             "- `primitiveType` (optional) — when set, the GameObject is created via `GameObject.CreatePrimitive` " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.cs
@@ -32,6 +32,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "GameObject / Destroy",
             DestructiveHint = true
         )]
+        [McpPluginSkillDescription(DestroySkill.Description)]
+        [McpPluginSkillBody(DestroySkill.Body)]
         [Description("Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject first.")]
         public DestroyGameObjectResult Destroy(GameObjectRef gameObjectRef)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.pre-Unity.6.5.cs
@@ -32,6 +32,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "GameObject / Destroy",
             DestructiveHint = true
         )]
+        [McpPluginSkillDescription(DestroySkill.Description)]
+        [McpPluginSkillBody(DestroySkill.Body)]
         [Description("Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject first.")]
         public DestroyGameObjectResult Destroy(GameObjectRef gameObjectRef)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Duplicate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Duplicate.cs
@@ -30,6 +30,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             GameObjectDuplicateToolId,
             Title = "GameObject / Duplicate"
         )]
+        [McpPluginSkillDescription("Duplicate a batch of GameObjects in the currently opened Prefab or active Scene. " +
+            "Marks each affected scene as dirty after duplication. " +
+            "Use '" + GameObjectFindToolId + "' to locate the source GameObjects first.")]
+        [McpPluginSkillBody("Duplicate GameObjects in opened Prefab or in a Scene. " +
+            "Use '" + GameObjectFindToolId + "' tool to find the target GameObjects first.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRefs` — `GameObjectRefList` of source GameObjects.\n\n" +
+            "## Behavior\n\n" +
+            "Resolves every input ref on the main thread (throwing on any unresolved entry to keep the batch atomic). " +
+            "Sets `Selection.entityIds`/`instanceIDs` to the sources and invokes " +
+            "`Unsupported.DuplicateGameObjectsUsingPasteboard()` (Unity's canonical duplicate routine). " +
+            "Marks every distinct affected scene dirty so the duplicated objects are saved with the scene. " +
+            "Returns refs to the sources (the duplicates are reachable via the post-call `Selection`).")]
         [Description("Duplicate GameObjects in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObjects first.")]
         public List<GameObjectRef> Duplicate(GameObjectRefList gameObjectRefs)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
@@ -32,6 +32,28 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Find a specific GameObject in the opened Prefab (preferred when present) or the " +
+            "active Scene. Optionally include editable data, components preview, bounds, and limited hierarchy. " +
+            "Supports token-saving path-scoped reads via `paths` or `viewQuery`.")]
+        [McpPluginSkillBody("Finds specific GameObject by provided information in opened Prefab or in a Scene. " +
+            "First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. " +
+            "If no opened Prefab it looks into current active scene. " +
+            "Returns GameObject information and its children. " +
+            "Also, it returns Components preview just for the target GameObject.\n\n" +
+            "## Toggles (all default `false` to keep responses small)\n\n" +
+            "- `includeData` — full editable GameObject data (tag, layer, etc.).\n" +
+            "- `includeComponents` — attached components references.\n" +
+            "- `includeBounds` — 3D bounds.\n" +
+            "- `includeHierarchy` — hierarchy metadata.\n" +
+            "- `hierarchyDepth` (default 0) — depth of the hierarchy to include. `0` = target only, `1` = one layer below, etc.\n\n" +
+            "## Path-scoped reads (token-saving)\n\n" +
+            "Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, " +
+            "or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type via " +
+            "`Reflector.View`. When either is supplied, the result populates `Data` on the returned `GameObjectData` " +
+            "and overrides `includeData` (which would otherwise produce a full recursive serialization). " +
+            "These two parameters are mutually exclusive — supply at most one.\n\n" +
+            "## Path syntax\n\n" +
+            "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.")]
         [Description("Finds specific GameObject by provided information in opened Prefab or in a Scene. " +
             "First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. " +
             "If no opened Prefab it looks into current active scene. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.SetParent.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.SetParent.cs
@@ -29,6 +29,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "GameObject / Set Parent",
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Reparent a batch of GameObjects under a new parent in the currently opened Prefab " +
+            "or active Scene. Per-item failures are reported in the returned status string instead of aborting the batch. " +
+            "Use '" + GameObjectFindToolId + "' to locate the GameObjects first.")]
+        [McpPluginSkillBody("Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. " +
+            "Use '" + GameObjectFindToolId + "' tool to find the target GameObjects first.\n\n" +
+            "## Inputs\n\n" +
+            "- `gameObjectRefs` — list of children to reparent.\n" +
+            "- `parentGameObjectRef` — new parent. Must resolve, otherwise the call returns early with an error string.\n" +
+            "- `worldPositionStays` (default `true`) — preserve world-space transform when reparenting (passed to " +
+            "`Transform.SetParent`).\n\n" +
+            "## Behavior\n\n" +
+            "Iterates `gameObjectRefs` and reparents each one independently; per-item resolve errors are appended to " +
+            "the returned status string instead of throwing. After the loop, if at least one reparent succeeded, marks " +
+            "the active scene dirty and repaints editor windows.")]
         [Description("Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObjects first.")]
         public string SetParent

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.cs
@@ -64,6 +64,53 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             public static string InvalidInstanceID(Type holderType, string fieldName)
                 => $"Invalid instanceID '{fieldName}' for '{holderType.GetTypeId()}'. It should be a valid field name.";
         }
+
+        // Shared skill metadata for `gameobject-destroy`. The Unity 6.5+ and pre-6.5 implementations diverge
+        // on EntityId vs InstanceID but their SKILL.md description/body are identical, so we keep them here once.
+        internal static class DestroySkill
+        {
+            public const string Description =
+                "Destroy a GameObject (and all nested children) in the currently opened Prefab or active Scene. " +
+                "Returns the destroyed GameObject's name, path, and instance ID for confirmation. " +
+                "Use 'gameobject-find' to locate the target first.";
+
+            public const string Body =
+                "Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. " +
+                "Use 'gameobject-find' tool to find the target GameObject first.\n\n" +
+                "## Behavior\n\n" +
+                "Validates the `gameObjectRef`, resolves it on the main thread, then calls `Object.DestroyImmediate` " +
+                "(the immediate variant is required for Editor-mode operations). Returns a `DestroyGameObjectResult` " +
+                "containing `DestroyedName`, `DestroyedPath`, and `DestroyedInstanceId` so the caller has a record of " +
+                "what was removed.";
+        }
+
+        // Shared skill metadata for `gameobject-component-get`. Same Unity-version sibling pattern.
+        internal static class ComponentGetSkill
+        {
+            public const string Description =
+                "Get detailed information about a specific Component on a GameObject — type, enabled state, and " +
+                "(optionally) serialized fields and properties. Supports token-saving path-scoped reads via `paths` or " +
+                "`viewQuery`. Use 'gameobject-find' to list components first.";
+
+            public const string Body =
+                "Get detailed information about a specific Component on a GameObject. " +
+                "Returns component type, enabled state, and optionally serialized fields and properties. " +
+                "Use this to inspect component data before modifying it. " +
+                "Use 'gameobject-find' tool to get the list of all components on the GameObject.\n\n" +
+                "## Inputs\n\n" +
+                "- `gameObjectRef` — the host GameObject.\n" +
+                "- `componentRef` — the specific component to inspect (matched by index or instance ID).\n" +
+                "- `includeFields` (default `true`) — populate the legacy `Fields` list.\n" +
+                "- `includeProperties` (default `true`) — populate the legacy `Properties` list.\n" +
+                "- `deepSerialization` (default `false`) — when populating legacy lists, recurse into nested members.\n\n" +
+                "## Path-scoped reads (token-saving)\n\n" +
+                "Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, " +
+                "or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type " +
+                "via `Reflector.View`. The result is returned in the `View` field of the response, and the legacy " +
+                "`Fields`/`Properties` lists are skipped. These two parameters are mutually exclusive — supply at most one.\n\n" +
+                "## Path syntax\n\n" +
+                "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.";
+        }
     }
 }
 #endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.pre-Unity.6.5.cs
@@ -64,6 +64,53 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             public static string InvalidInstanceID(Type holderType, string fieldName)
                 => $"Invalid instanceID '{fieldName}' for '{holderType.GetTypeId()}'. It should be a valid field name.";
         }
+
+        // Shared skill metadata for `gameobject-destroy`. Mirrors GameObject.cs so the SKILL.md is identical
+        // across both Unity builds (only the underlying EntityId/InstanceID code path differs).
+        internal static class DestroySkill
+        {
+            public const string Description =
+                "Destroy a GameObject (and all nested children) in the currently opened Prefab or active Scene. " +
+                "Returns the destroyed GameObject's name, path, and instance ID for confirmation. " +
+                "Use 'gameobject-find' to locate the target first.";
+
+            public const string Body =
+                "Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. " +
+                "Use 'gameobject-find' tool to find the target GameObject first.\n\n" +
+                "## Behavior\n\n" +
+                "Validates the `gameObjectRef`, resolves it on the main thread, then calls `Object.DestroyImmediate` " +
+                "(the immediate variant is required for Editor-mode operations). Returns a `DestroyGameObjectResult` " +
+                "containing `DestroyedName`, `DestroyedPath`, and `DestroyedInstanceId` so the caller has a record of " +
+                "what was removed.";
+        }
+
+        // Shared skill metadata for `gameobject-component-get`. Mirrors GameObject.cs.
+        internal static class ComponentGetSkill
+        {
+            public const string Description =
+                "Get detailed information about a specific Component on a GameObject — type, enabled state, and " +
+                "(optionally) serialized fields and properties. Supports token-saving path-scoped reads via `paths` or " +
+                "`viewQuery`. Use 'gameobject-find' to list components first.";
+
+            public const string Body =
+                "Get detailed information about a specific Component on a GameObject. " +
+                "Returns component type, enabled state, and optionally serialized fields and properties. " +
+                "Use this to inspect component data before modifying it. " +
+                "Use 'gameobject-find' tool to get the list of all components on the GameObject.\n\n" +
+                "## Inputs\n\n" +
+                "- `gameObjectRef` — the host GameObject.\n" +
+                "- `componentRef` — the specific component to inspect (matched by index or instance ID).\n" +
+                "- `includeFields` (default `true`) — populate the legacy `Fields` list.\n" +
+                "- `includeProperties` (default `true`) — populate the legacy `Properties` list.\n" +
+                "- `deepSerialization` (default `false`) — when populating legacy lists, recurse into nested members.\n\n" +
+                "## Path-scoped reads (token-saving)\n\n" +
+                "Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, " +
+                "or `viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type " +
+                "via `Reflector.View`. The result is returned in the `View` field of the response, and the legacy " +
+                "`Fields`/`Properties` lists are skipped. These two parameters are mutually exclusive — supply at most one.\n\n" +
+                "## Path syntax\n\n" +
+                "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.";
+        }
     }
 }
 #endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
@@ -32,6 +32,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Get serialized data for a Unity `UnityEngine.Object` — all serializable fields " +
+            "and properties. Supports token-saving path-scoped reads via `paths` or `viewQuery`. " +
+            "Pair with '" + ObjectModifyToolId + "' when you need to write back.")]
+        [McpPluginSkillBody("Get data of the specified Unity Object. " +
+            "Returns serialized data of the object including its properties and fields. " +
+            "If need to modify the data use '" + ObjectModifyToolId + "' tool.\n\n" +
+            "## Path-scoped reads (token-saving)\n\n" +
+            "Supply `paths` (a list of paths) to read only the listed fields/elements via `Reflector.TryReadAt`, or " +
+            "`viewQuery` (a `ViewQuery`) to navigate to a subtree and/or filter by name regex / max depth / type via " +
+            "`Reflector.View`. These two parameters are mutually exclusive — supply at most one. When neither is " +
+            "supplied the full object is serialized (backwards compatible).\n\n" +
+            "## Path syntax\n\n" +
+            "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.")]
         [Description("Get data of the specified Unity Object. " +
             "Returns serialized data of the object including its properties and fields. " +
             "If need to modify the data use '" + ObjectModifyToolId + "' tool.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
@@ -32,6 +32,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Object / Modify",
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Modify a Unity `UnityEngine.Object`'s serializable fields/properties. " +
+            "Three modification surfaces are available (`objectDiff`, `pathPatches`, `jsonPatch`) — see the skill body. " +
+            "Use '" + ObjectGetDataToolId + "' first to inspect the object structure.")]
+        [McpPluginSkillBody("Modify the specified Unity Object. " +
+            "Allows direct modification of object fields and properties. " +
+            "Use '" + ObjectGetDataToolId + "' first to inspect the object structure before modifying.\n\n" +
+            "## Three modification surfaces\n\n" +
+            "Use whichever fits the task:\n\n" +
+            "1. `objectDiff` — full `SerializedMember` diff (legacy, backwards compatible).\n" +
+            "2. `pathPatches` — list of `{path, value}` pairs routed through `Reflector.TryModifyAt`; atomic per-path " +
+            "modification, multiple entries can target different depths.\n" +
+            "3. `jsonPatch` — a JSON Merge Patch (RFC 7396, extended with `[i]`/`[key]` notation) routed through " +
+            "`Reflector.TryPatch`; multiple fields at any depth in a single call.\n\n" +
+            "When more than one is supplied they run in this order: `jsonPatch` → `pathPatches` → `objectDiff`. " +
+            "At least one is required.\n\n" +
+            "## Path syntax\n\n" +
+            "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped.")]
         [Description("Modify the specified Unity Object. " +
             "Allows direct modification of object fields and properties. " +
             "Use '" + ObjectGetDataToolId + "' first to inspect the object structure before modifying.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Add.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Add.cs
@@ -29,6 +29,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             OpenWorldHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Install a Unity package from the registry, a Git URL, or a local path. " +
+            "Modifies `manifest.json` and triggers package resolution; may also trigger a domain reload — the final " +
+            "result is delivered after the reload via the request's `requestId`. " +
+            "Use '" + PackageSearchToolId + "' / '" + PackageListToolId + "' for discovery first.")]
+        [McpPluginSkillBody("Install a package from the Unity Package Manager registry, Git URL, or local path. " +
+            "This operation modifies the project's manifest.json and triggers package resolution. " +
+            "Note: Package installation may trigger a domain reload. The result will be sent after the reload completes. " +
+            "Use '" + PackageSearchToolId + "' tool to search for packages and '" + PackageListToolId + "' to list installed packages.\n\n" +
+            "## `packageId` formats\n\n" +
+            "- Plain package ID: `com.unity.textmeshpro` (installs latest compatible version).\n" +
+            "- Pinned version: `com.unity.textmeshpro@3.0.6`.\n" +
+            "- Git URL: `https://github.com/user/repo.git`.\n" +
+            "- Git URL with branch/tag: `https://github.com/user/repo.git#v1.0.0`.\n" +
+            "- Local path: `file:../MyPackage`.\n\n" +
+            "## Processing model\n\n" +
+            "Returns `Processing` immediately with the supplied `requestId`. Once `Client.Add` completes, a follow-up " +
+            "result is delivered: success → `SchedulePostDomainReloadNotification` (delivers after the reload finishes), " +
+            "failure → an immediate error notification with the underlying Unity error message.")]
         [Description("Install a package from the Unity Package Manager registry, Git URL, or local path. " +
             "This operation modifies the project's manifest.json and triggers package resolution. " +
             "Note: Package installation may trigger a domain reload. The result will be sent after the reload completes. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.List.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.List.cs
@@ -57,6 +57,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("List all UPM packages installed in the Unity project — name, version, source, " +
+            "description. Optionally filter by source (registry, embedded, local, git, built-in, local tarball), " +
+            "by name/display/description substring, and by direct-dependency-only.")]
+        [McpPluginSkillBody("List all packages installed in the Unity project (UPM packages). " +
+            "Returns information about each installed package including name, version, source, and description. " +
+            "Use this to check which packages are currently installed before adding or removing packages.\n\n" +
+            "## Inputs\n\n" +
+            "- `sourceFilter` (default `All`) — restrict by Unity `PackageSource`: `All`, `Registry`, `Embedded`, " +
+            "`Local`, `Git`, `BuiltIn`, `LocalTarball`.\n" +
+            "- `nameFilter` (optional) — case-insensitive substring filter over name / displayName / description. " +
+            "Results are prioritized: exact name → exact displayName → name substring → displayName substring → " +
+            "description substring.\n" +
+            "- `directDependenciesOnly` (default `false`) — when true, return only packages listed in `manifest.json` " +
+            "(no transitive dependencies).")]
         [Description("List all packages installed in the Unity project (UPM packages). " +
             "Returns information about each installed package including name, version, source, and description. " +
             "Use this to check which packages are currently installed before adding or removing packages.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Remove.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Remove.cs
@@ -30,6 +30,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             DestructiveHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Uninstall a UPM package from the Unity project. Modifies `manifest.json` and may " +
+            "trigger a domain reload — the final result is delivered after the reload via the request's `requestId`. " +
+            "Built-in packages and packages that are dependencies of others cannot be removed. " +
+            "Use '" + PackageListToolId + "' to list installed packages first.")]
+        [McpPluginSkillBody("Remove (uninstall) a package from the Unity project. " +
+            "This removes the package from the project's manifest.json and triggers package resolution. " +
+            "Note: Built-in packages and packages that are dependencies of other installed packages cannot be removed. " +
+            "Note: Package removal may trigger a domain reload. The result will be sent after the reload completes. " +
+            "Use '" + PackageListToolId + "' tool to list installed packages first.\n\n" +
+            "## Inputs\n\n" +
+            "- `packageId` — package name (e.g. `com.unity.textmeshpro`). A trailing `@<version>` is stripped automatically " +
+            "before being passed to `Client.Remove`, so accidental versioned IDs still work.\n\n" +
+            "## Behavior\n\n" +
+            "First verifies the package is installed via an offline `Client.List` — returns a clear `PackageNotFound` " +
+            "error if not. On removal failure, surfaces Unity's error message. On success, schedules a post-domain-reload " +
+            "notification so the response is delivered after Unity finishes the resolution.")]
         [Description("Remove (uninstall) a package from the Unity project. " +
             "This removes the package from the project's manifest.json and triggers package resolution. " +
             "Note: Built-in packages and packages that are dependencies of other installed packages cannot be removed. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Search.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Search.cs
@@ -34,6 +34,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             OpenWorldHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Search Unity's package registry plus locally installed packages (Git, local, " +
+            "embedded sources) by query string. Returns available versions and installation status. " +
+            "Online mode fetches exact matches from the live registry then supplements with cached substring matches.")]
+        [McpPluginSkillBody("Search for packages in both Unity Package Manager registry and installed packages. " +
+            "Use this to find packages by name before installing them. Returns available versions and installation status. " +
+            "Searches both the Unity registry and locally installed packages (including Git, local, and embedded sources). " +
+            "Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. " +
+            "Note: Online mode fetches exact matches from live registry, then supplements with cached substring matches.\n\n" +
+            "## Inputs\n\n" +
+            "- `query` — package id, name, display name, or description keyword (case-insensitive). Required.\n" +
+            "- `maxResults` (default 10) — caps the returned list.\n" +
+            "- `offlineMode` (default `true`) — when `false`, hits the live registry for exact matches; cached registry " +
+            "data still backs the substring matches in both modes.\n\n" +
+            "## Result composition\n\n" +
+            "Each entry includes name, display name, latest version, truncated description, install status, installed " +
+            "version (if any), and the top-5 compatible versions.")]
         [Description("Search for packages in both Unity Package Manager registry and installed packages. " +
             "Use this to find packages by name before installing them. Returns available versions and installation status. " +
             "Searches both the Unity registry and locally installed packages (including Git, local, and embedded sources). " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodCall.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodCall.cs
@@ -30,6 +30,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Method C# / Call",
             Enabled = false
         )]
+        [McpPluginSkillDescription("Call a C# method by reflection — including private methods. " +
+            "Requires a method schema obtained via '" + ReflectionMethodFindToolId + "'. " +
+            "Supports static methods, instance methods (with optional target deserialization), and main-thread / " +
+            "off-thread execution.")]
+        [McpPluginSkillBody("Call C# method. Any method could be called, even private methods. " +
+            "It requires to receive proper method schema. " +
+            "Use '" + ReflectionMethodFindToolId + "' to find available method before using it. " +
+            "Receives input parameters and returns result.\n\n" +
+            "## Match levels (apply to `typeName`, `MethodName`, `Parameters`)\n\n" +
+            "- `typeNameMatchLevel` / `methodNameMatchLevel` (default 1 — contains ignoring case): " +
+            "`0` ignore filter, `1` contains-ic, `2` contains-cs, `3` starts-with-ic, `4` starts-with-cs, " +
+            "`5` equals-ic, `6` equals-cs.\n" +
+            "- `parametersMatchLevel` (default 2 — equals): `0` ignore filter, `1` count matches, `2` equals.\n\n" +
+            "## Inputs\n\n" +
+            "- `targetObject` (optional) — for instance methods. When null, a new instance is created from the declaring " +
+            "type. Required shape: `{ type, value }` (value is deserialized to `type`).\n" +
+            "- `inputParameters` (optional) — list of `{ type, name, value }`. Names are enhanced against the resolved " +
+            "method signature if omitted.\n" +
+            "- `executeInMainThread` (default `true`) — Unity API calls should keep this true; set false only for " +
+            "thread-safe pure logic.")]
         [Description("Call C# method. Any method could be called, even private methods. " +
             "It requires to receive proper method schema. " +
             "Use '" + ReflectionMethodFindToolId + "' to find available method before using it. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodFind.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodFind.cs
@@ -30,6 +30,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Find C# methods across every loaded assembly by name / type / parameters — " +
+            "including private methods. Returns serialized `MethodData` entries usable as schemas for '" +
+            ReflectionMethodCallToolId + "'.")]
+        [McpPluginSkillBody("Find method in the project using C# Reflection. " +
+            "It looks for all assemblies in the project and finds method by its name, class name and parameters. " +
+            "Even private methods are available. " +
+            "Use '" + ReflectionMethodCallToolId + "' to call the method after finding it.\n\n" +
+            "## Match levels (apply to `typeName`, `MethodName`, `Parameters`)\n\n" +
+            "- `typeNameMatchLevel` / `methodNameMatchLevel` (default 1 — contains ignoring case): " +
+            "`0` ignore filter, `1` contains-ic, `2` contains-cs, `3` starts-with-ic, `4` starts-with-cs, " +
+            "`5` equals-ic, `6` equals-cs.\n" +
+            "- `parametersMatchLevel` (default 0 — ignore filter): `0` ignore, `1` count matches, `2` equals.\n\n" +
+            "## Output\n\n" +
+            "On match, returns a `[Success] Found N method(s):` line followed by a JSON dump of every method's " +
+            "`MethodData`. Pass any single entry to '" + ReflectionMethodCallToolId + "' as its `filter`.")]
         [Description("Find method in the project using C# Reflection. " +
             "It looks for all assemblies in the project and finds method by its name, class name and parameters. " +
             "Even private methods are available. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Create.cs
@@ -25,6 +25,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             SceneCreateToolId,
             Title = "Scene / Create"
         )]
+        [McpPluginSkillDescription("Create a new Unity scene asset and save it at the given `.unity` path. " +
+            "Use '" + SceneListOpenedToolId + "' to inspect the resulting opened-scene set afterwards.")]
+        [McpPluginSkillBody("Create new scene in the project assets. " +
+            "Use '" + SceneListOpenedToolId + "' tool to list all opened scenes after creation.\n\n" +
+            "## Inputs\n\n" +
+            "- `path` — must end with `.unity`. Non-empty.\n" +
+            "- `newSceneSetup` (default `DefaultGameObjects`) — Unity's `NewSceneSetup` flag (`EmptyScene` or `DefaultGameObjects`).\n" +
+            "- `newSceneMode` (default `Single`) — `Single` closes other scenes, `Additive` keeps them open.\n\n" +
+            "## Behavior\n\n" +
+            "Calls `EditorSceneManager.NewScene` + `SaveScene(path)` on the main thread, repaints editor windows, " +
+            "and returns a `SceneDataShallow` for the newly created scene.")]
         [Description("Create new scene in the project assets. " +
             "Use '" + SceneListOpenedToolId + "' tool to list all opened scenes after creation.")]
         public SceneDataShallow Create

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
@@ -31,6 +31,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Retrieve the list of root GameObjects in the specified opened scene " +
+            "(or the active scene when `openedSceneName` is empty). Supports token-saving path-scoped reads over the " +
+            "root-GameObjects array via `paths` or `viewQuery`. Use '" + SceneListOpenedToolId + "' to enumerate scenes.")]
+        [McpPluginSkillBody("This tool retrieves the list of root GameObjects in the specified scene. " +
+            "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
+            "## Toggles (all default `false` to keep responses small)\n\n" +
+            "- `includeRootGameObjects` — include root GameObjects in the scene data.\n" +
+            "- `includeChildrenDepth` (default 3) — depth of the hierarchy to include.\n" +
+            "- `includeBounds` — include 3D bounds for GameObjects.\n" +
+            "- `includeData` — include serialized component data for GameObjects.\n\n" +
+            "## Path-scoped reads (token-saving)\n\n" +
+            "Supply `paths` to read only the listed fields/elements from the scene's root-GameObjects array via " +
+            "`Reflector.TryReadAt`, or `viewQuery` to navigate/filter the same array via `Reflector.View`. " +
+            "The result populates `Data` on the returned `SceneData`. These two parameters are mutually exclusive.\n\n" +
+            "## Path syntax\n\n" +
+            "`fieldName`, `nested/field`, `arrayField/[i]`, `dictField/[key]`. Leading `#/` is stripped. " +
+            "Example: `paths=['[0]/name']` reads the name of the first root GameObject.")]
         [Description("This tool retrieves the list of root GameObjects in the specified scene. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
             "Path-scoped reads (token-saving): supply '" + "paths" + "' (a list of paths) to read only the listed " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.ListOpened.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.ListOpened.cs
@@ -27,6 +27,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("List every scene currently opened in the Unity Editor as a shallow snapshot " +
+            "(name, path, build flags). Use '" + SceneGetDataToolId + "' for the deep view of a specific scene.")]
+        [McpPluginSkillBody("Returns the list of currently opened scenes in Unity Editor. " +
+            "Use '" + SceneGetDataToolId + "' tool to get detailed information about a specific scene.\n\n" +
+            "## Behavior\n\n" +
+            "Maps `OpenedScenes` through `ToSceneDataShallow()` on the main thread and returns the resulting array. " +
+            "No filtering or pagination — every opened scene is included.")]
         [Description("Returns the list of currently opened scenes in Unity Editor. " +
             "Use '" + SceneGetDataToolId + "' tool to get detailed information about a specific scene.")]
         public SceneDataShallow[] ListOpened(string? nothing = null)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Open.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Open.cs
@@ -27,6 +27,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             SceneOpenToolId,
             Title = "Scene / Open"
         )]
+        [McpPluginSkillDescription("Open a Unity scene asset in Single or Additive mode. " +
+            "Returns the post-open list of all opened scenes. " +
+            "Use '" + Tool_Assets.AssetsFindToolId + "' to locate the scene asset first.")]
+        [McpPluginSkillBody("Open scene from the project asset file. " +
+            "Use '" + Tool_Assets.AssetsFindToolId + "' tool to find the scene asset first.\n\n" +
+            "## Inputs\n\n" +
+            "- `sceneRef` — `AssetObjectRef` pointing at a `SceneAsset`. Throws if the asset cannot be resolved or " +
+            "is not a `SceneAsset`.\n" +
+            "- `loadSceneMode` (default `Single`):\n" +
+            "  - `Single` — closes the currently opened scenes and opens this one.\n" +
+            "  - `Additive` — keeps the currently opened scenes and opens this one alongside them.")]
         [Description("Open scene from the project asset file. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool to find the scene asset first.")]
         public SceneDataShallow[] Open

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Save.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Save.cs
@@ -28,6 +28,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Scene / Save",
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Save an opened scene back to its asset file (or to a new path when `path` is " +
+            "provided). When `openedSceneName` is empty, saves the currently active scene. " +
+            "Use '" + SceneListOpenedToolId + "' to find the scene name first.")]
+        [McpPluginSkillBody("Save Opened scene to the asset file. " +
+            "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
+            "## Inputs\n\n" +
+            "- `openedSceneName` (optional) — name of an opened scene to save. Empty/null = active scene.\n" +
+            "- `path` (optional) — destination `.unity` path. Empty/null = save back to the scene's existing path.\n\n" +
+            "## Validation\n\n" +
+            "Throws if the scene cannot be resolved, has no existing path AND no override path was supplied, or the " +
+            "supplied path does not end with `.unity`. On `EditorSceneManager.SaveScene` failure, surfaces an error " +
+            "with the current opened-scenes list for diagnosis.")]
         [Description("Save Opened scene to the asset file. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.")]
         public void Save

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.SetActive.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.SetActive.cs
@@ -28,6 +28,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Scene / Set Active",
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("Mark an opened scene as the Editor's active scene (the one new GameObjects are " +
+            "added to and that's used as the default for many operations). " +
+            "Use '" + SceneListOpenedToolId + "' to enumerate opened scenes first.")]
+        [McpPluginSkillBody("Set the specified opened scene as the active scene. " +
+            "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
+            "## Inputs\n\n" +
+            "- `sceneRef` — `AssetObjectRef` pointing at a `SceneAsset`. The scene must already be opened.\n\n" +
+            "## Behavior\n\n" +
+            "Resolves the `SceneAsset`, finds the matching opened scene (by name then by path), and calls " +
+            "`EditorSceneManager.SetActiveScene`. No-op if the scene is already active. Returns the post-call " +
+            "snapshot of opened scenes.")]
         [Description("Set the specified opened scene as the active scene. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.")]
         public SceneDataShallow[] SetActive(AssetObjectRef sceneRef)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Unload.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Unload.cs
@@ -31,6 +31,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             SceneUnloadToolId,
             Title = "Scene / Unload"
         )]
+        [McpPluginSkillDescription("Unload an opened scene from the Unity Editor (asynchronously via " +
+            "`SceneManager.UnloadSceneAsync`). " +
+            "Use '" + SceneListOpenedToolId + "' to find the scene name first.")]
+        [McpPluginSkillBody("Unload scene from the Opened scenes in Unity Editor. " +
+            "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
+            "## Inputs\n\n" +
+            "- `name` — required non-empty scene name. Must match an opened scene; otherwise throws.\n\n" +
+            "## Behavior\n\n" +
+            "Runs `SceneManager.UnloadSceneAsync` on the main thread and awaits completion. Returns an " +
+            "`UnloadSceneResult` containing the scene name and an `AssetObjectRef` to its asset (or `null` if the " +
+            "scene was not backed by an asset on disk).")]
         [Description("Unload scene from the Opened scenes in Unity Editor. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.")]
         public Task<UnloadSceneResult> Unload

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Camera.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Camera.cs
@@ -31,6 +31,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Capture a screenshot from a Unity `Camera` and return it as a PNG image " +
+            "for direct LLM inspection. Falls back to `Camera.main` (then any active camera) when `cameraRef` is null. " +
+            "Width and height are capped to keep response size manageable.")]
+        [McpPluginSkillBody("Captures a screenshot from a camera and returns it as an image. " +
+            "If no camera is specified, uses the Main Camera. " +
+            "Returns the image directly for visual inspection by the LLM.\n\n" +
+            "## Inputs\n\n" +
+            "- `cameraRef` (optional) — reference to a GameObject hosting a `Camera`. When null, " +
+            "`Camera.main` is used; if there is no main camera, the first entry of `Camera.allCameras` is used.\n" +
+            "- `width` (default 1920) / `height` (default 1080) — output pixels. Must be > 0 and ≤ `MaxDimension`.\n\n" +
+            "## Behavior\n\n" +
+            "Allocates a temporary `RenderTexture`, swaps it onto the chosen camera, calls `Camera.Render`, reads back " +
+            "via `Texture2D.ReadPixels`, encodes as PNG, and restores the camera's prior `targetTexture`. Returns a " +
+            "`ResponseCallTool.Image` with `image/png` MIME and a descriptive caption.")]
         [Description("Captures a screenshot from a camera and returns it as an image. " +
             "If no camera is specified, uses the Main Camera. " +
             "Returns the image directly for visual inspection by the LLM.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
@@ -31,6 +31,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Capture a screenshot of the Unity Editor's Game View by reading its internal " +
+            "render texture directly. Image size matches the current Game View resolution; the tool corrects Y-flip on " +
+            "DirectX / Metal so the output is always upright. Requires an open Game View window.")]
+        [McpPluginSkillBody("Captures a screenshot from the Unity Editor Game View and returns it as an image. " +
+            "Reads the Game View's own render texture directly via the Unity Editor API. " +
+            "The image size matches the current Game View resolution. " +
+            "Returns the image directly for visual inspection by the LLM.\n\n" +
+            "## Behavior\n\n" +
+            "Locates `UnityEditor.GameView`, repaints it, then reflects the `m_RenderTexture` field and reads back via " +
+            "`Texture2D.ReadPixels`. On graphics APIs whose UV origin is top-left (`SystemInfo.graphicsUVStartsAtTop`), " +
+            "the read-back pixels are vertically flipped before encoding so the orientation matches what the user sees. " +
+            "Returns a PNG image with the resolution baked into the caption.")]
         [Description("Captures a screenshot from the Unity Editor Game View and returns it as an image. " +
             "Reads the Game View's own render texture directly via the Unity Editor API. " +
             "The image size matches the current Game View resolution. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -97,6 +97,35 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = true
         )]
+        [McpPluginSkillDescription("Render a target GameObject from a chosen camera angle with optional layer-based " +
+            "isolation, configurable background (solid/skybox/transparent), multi-light setup via JSON, and Composite " +
+            "(2x2 Front/Right/Back/Top) mode. Returns a PNG image. When isolated=true, inactive children may briefly " +
+            "fire OnEnable — see the body for side-effect notes.")]
+        [McpPluginSkillBody("Renders a screenshot of a target GameObject with configurable isolation, background, "
+                   + "camera angle, and lighting. When isolated=true (default), only the target object is "
+                   + "visible via layer-based culling and inactive children of the target are temporarily "
+                   + "activated for the render (their OnEnable callbacks may fire — restored in finally, but "
+                   + "side effects like audio/network/animation events are not undoable). When isolated=false, "
+                   + "the existing scene state is rendered as-is without activating inactive objects. Supports "
+                   + "custom multi-light setups via JSON. Returns a base64-encoded PNG.\n\n" +
+            "## Camera views\n\n" +
+            "`Front` (-Z), `Back` (+Z), `Left` (-X), `Right` (+X), `Top` (+Y), `Bottom` (-Y). " +
+            "`Composite` produces a single 2x2 image (Front, Right, Back, Top) where each sub-view uses the requested " +
+            "`resolution`, so the final image is `resolution*2 x resolution*2`.\n\n" +
+            "## Background modes\n\n" +
+            "- `SolidColor` — flat color from `backgroundColor` (hex string).\n" +
+            "- `Skybox` — current scene skybox.\n" +
+            "- `Transparent` — alpha-zero (ARGB32 PNG; useful for compositing).\n\n" +
+            "## Lights\n\n" +
+            "`lights` is an optional JSON array of `IsolatedLightConfig` objects (type, color, intensity, rotation, " +
+            "position, range, spotAngle, innerSpotAngle, shadows, shadowStrength, bounceIntensity, colorTemperature, " +
+            "cookieSize, cullingMask, renderMode). When `null`, a default 1.0-intensity white directional light at " +
+            "rotation `(50, -30, 0)` is used. Empty array `[]` explicitly disables extra lights.\n\n" +
+            "## Side-effect caveat\n\n" +
+            "Isolation temporarily activates inactive child GameObjects so their renderers participate in the cull. " +
+            "Activation state is restored in `finally`, but OnEnable-triggered side effects (audio, networking, " +
+            "animation events) are not rewindable. Set `isolated=false` if your scene contains scripts that must not " +
+            "fire OnEnable during the capture.")]
         [Description("Renders a screenshot of a target GameObject with configurable isolation, background, "
                    + "camera angle, and lighting. When isolated=true (default), only the target object is "
                    + "visible via layer-based culling and inactive children of the target are temporarily "

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.SceneView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.SceneView.cs
@@ -29,6 +29,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Capture a screenshot from the Unity Editor Scene View at the requested size. " +
+            "Renders via the Scene View's active camera onto a temporary `RenderTexture`. Requires an open Scene View.")]
+        [McpPluginSkillBody("Captures a screenshot from the Unity Editor Scene View and returns it as an image. " +
+            "Returns the image directly for visual inspection by the LLM.\n\n" +
+            "## Inputs\n\n" +
+            "- `width` (default 1920) / `height` (default 1080) — output pixels. Must be > 0 and ≤ `MaxDimension`.\n\n" +
+            "## Behavior\n\n" +
+            "Uses `SceneView.lastActiveSceneView` (falls back to the first window in `SceneView.sceneViews`). Allocates " +
+            "a temporary `RenderTexture`, swaps it onto the Scene View's camera, calls `Render`, reads back with " +
+            "`Texture2D.ReadPixels`, encodes PNG, and restores the camera's prior `targetTexture`. Throws/errors when " +
+            "no Scene View is open or the Scene View camera is null.")]
         [Description("Captures a screenshot from the Unity Editor Scene View and returns it as an image. " +
             "Returns the image directly for visual inspection by the LLM.")]
         public ResponseCallTool ScreenshotSceneView

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Delete.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Delete.cs
@@ -31,6 +31,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             DestructiveHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Delete one or more `.cs` script files from disk, refresh the AssetDatabase, and " +
+            "wait for Unity compilation to settle before delivering the final result via the request's `requestId`. " +
+            "Pair with '" + ScriptReadToolId + "' to inspect files before deletion.")]
+        [McpPluginSkillBody("Delete the script file(s). " +
+            "Does AssetDatabase.Refresh() and waits for Unity compilation to complete before reporting results. " +
+            "Use '" + ScriptReadToolId + "' tool to read existing script files first.\n\n" +
+            "## Inputs\n\n" +
+            "- `files` — non-empty array of `.cs` paths. Every entry must exist on disk.\n" +
+            "- `requestId` — required for the processing/delivered-later contract.\n\n" +
+            "## Behavior\n\n" +
+            "Validates the array (non-empty, every entry ends with `.cs`, every entry exists). Deletes each file plus " +
+            "its sibling `.meta` (when present). Calls `AssetDatabase.Refresh` and schedules a post-compilation " +
+            "notification — the final response is delivered after Unity finishes the recompile triggered by the delete.")]
         [Description("Delete the script file(s). " +
             "Does AssetDatabase.Refresh() and waits for Unity compilation to complete before reporting results. " +
             "Use '" + ScriptReadToolId + "' tool to read existing script files first.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Read.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Read.cs
@@ -28,6 +28,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Read a `.cs` script file and return its content as a string. " +
+            "Supports a 1-based `lineFrom`/`lineTo` slice for partial reads. " +
+            "Pair with '" + ScriptUpdateOrCreateToolId + "' to write back.")]
+        [McpPluginSkillBody("Reads the content of a script file and returns it as a string. " +
+            "Use '" + ScriptUpdateOrCreateToolId + "' tool to update or create script files.\n\n" +
+            "## Inputs\n\n" +
+            "- `filePath` — required `.cs` path. Throws if missing on disk.\n" +
+            "- `lineFrom` (default 1, 1-based) — start line; clamped into valid range.\n" +
+            "- `lineTo` (default -1 = end-of-file, 1-based) — inclusive end line; clamped into valid range.\n\n" +
+            "## Behavior\n\n" +
+            "Reads the file with `File.ReadAllLines` and slices `[lineFrom..lineTo]` (inclusive). The slice indices are " +
+            "clamped — passing out-of-range `lineFrom`/`lineTo` is forgiving (read returns at-most the whole file).")]
         [Description("Reads the content of a script file and returns it as a string. " +
             "Use '" + ScriptUpdateOrCreateToolId + "' tool to update or create script files.")]
         public static string Read

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.UpdateOrCreate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.UpdateOrCreate.cs
@@ -31,6 +31,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             OpenWorldHint = false,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Write a `.cs` script file (create or overwrite) with the provided C# code. " +
+            "Validates syntax via Roslyn before write — invalid code is rejected with error details and the file is left " +
+            "untouched. Refreshes the AssetDatabase and delivers the final result via `requestId` after Unity finishes " +
+            "the triggered compilation. Use '" + ScriptReadToolId + "' to inspect existing content first.")]
+        [McpPluginSkillBody("Updates or creates script file with the provided C# code. " +
+            "Does AssetDatabase.Refresh() at the end. " +
+            "Provides compilation error details if the code has syntax errors. " +
+            "Use '" + ScriptReadToolId + "' tool to read existing script files first.\n\n" +
+            "## Inputs\n\n" +
+            "- `filePath` — required `.cs` path.\n" +
+            "- `content` — C# source. MUST pass `ScriptUtils.IsValidCSharpSyntax`.\n" +
+            "- `requestId` — required for the processing/delivered-later contract.\n\n" +
+            "## Behavior\n\n" +
+            "Creates any missing parent directories, writes the file, then calls `AssetDatabase.Refresh` and schedules " +
+            "a post-compilation notification so the final response is delivered after Unity finishes the recompile.")]
         [Description("Updates or creates script file with the provided C# code. " +
             "Does AssetDatabase.Refresh() at the end. " +
             "Provides compilation error details if the code has syntax errors. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
@@ -35,6 +35,31 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Tests / Run",
             Enabled = true
         )]
+        [McpPluginSkillDescription("Execute Unity tests (`EditMode` or `PlayMode`) and return per-test results. " +
+            "Supports filtering by test assembly, namespace, class, and method. " +
+            "Refreshes the AssetDatabase first; defers execution across domain reloads if scripts changed. " +
+            "Precondition: every open scene must be saved — dirty scenes abort the run.")]
+        [McpPluginSkillBody("Execute Unity tests and return detailed results. " +
+            "Supports filtering by test mode, assembly, namespace, class, and method. " +
+            "Recommended to use '" + nameof(TestMode.EditMode) + "' for faster iteration during development. " +
+            "Precondition: every open scene MUST be saved (no unsaved changes). If any open scene is dirty, " +
+            "this tool throws an InvalidOperationException listing the dirty scenes; save them and retry.\n\n" +
+            "## Filters\n\n" +
+            "- `testMode` (default `EditMode`) — `EditMode` or `PlayMode`. EditMode is faster; prefer it during iteration.\n" +
+            "- `testAssembly` / `testNamespace` / `testClass` / `testMethod` — optional, layered filters. Namespace and " +
+            "class filters become regex `groupNames` so the validation count and Unity's execution stay in sync. " +
+            "`testMethod` must be fully qualified (`Namespace.FixtureName.TestName`).\n\n" +
+            "## Response toggles\n\n" +
+            "- `includePassingTests` (default `false`) — include details for passing tests; otherwise only failing test details are returned.\n" +
+            "- `includeMessages` (default `true`) — include per-test result messages.\n" +
+            "- `includeStacktrace` (default `false`) — include stack traces for failing tests.\n" +
+            "- `includeLogs` (default `false`) — include console logs captured during the run.\n" +
+            "- `logType` (default `Warning`) — minimum log severity to include.\n" +
+            "- `includeLogsStacktrace` (default `false`) — include log stack traces (large payload; use sparingly).\n\n" +
+            "## Domain reloads\n\n" +
+            "If the AssetDatabase refresh triggers compilation, the tool persists the run parameters to `SessionState`, " +
+            "returns `Processing`, and resumes the run automatically after the reload completes. Pre-existing " +
+            "compilation errors short-circuit the run and return the error details so the caller can fix the project first.")]
         [Description("Execute Unity tests and return detailed results. " +
             "Supports filtering by test mode, assembly, namespace, class, and method. " +
             "Recommended to use '" + nameof(TestMode.EditMode) + "' for faster iteration during development. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.List.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.List.cs
@@ -48,6 +48,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
+        [McpPluginSkillDescription("List all MCP tools registered with this plugin. " +
+            "Optional regex filter matches against tool name, description, and argument names/descriptions. " +
+            "Use the `includeDescription` / `includeInputs` toggles to control the response size.")]
+        [McpPluginSkillBody("List all available MCP tools. " +
+            "Optionally filter by regex across tool names, descriptions, and arguments.\n\n" +
+            "## Inputs\n\n" +
+            "- `regexSearch` (optional) — case-insensitive regex with a 200ms execution-timeout guard. " +
+            "Invalid regex throws an `ArgumentException`. Matches name → description → input names → input descriptions.\n" +
+            "- `includeDescription` (default `false`) — populate each tool's `Description` field.\n" +
+            "- `includeInputs` (default `None`) — one of `None`, `Inputs` (names only), `InputsWithDescription` (names + descriptions).\n\n" +
+            "## Behavior\n\n" +
+            "Iterates `UnityMcpPluginEditor.Instance.Tools.GetAllTools()`, evaluates the filter (if any), and projects " +
+            "each surviving tool into a `ToolInfoData` honoring the verbosity toggles.")]
         [Description("List all available MCP tools. " +
             "Optionally filter by regex across tool names, descriptions, and arguments.")]
         public ToolInfoData[] List

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.SetEnabledState.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.SetEnabledState.cs
@@ -30,6 +30,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Title = "Tool / Set Enabled State",
             Enabled = false
         )]
+        [McpPluginSkillDescription("Enable or disable MCP tools by name in batch. " +
+            "Persists the change via `UnityMcpPluginEditor.Instance.Save()` only when at least one tool actually flipped. " +
+            "Returns per-input success flags plus optional operation logs.")]
+        [McpPluginSkillBody("Enable or disable MCP tools by name. " +
+            "Allows controlling which tools are available for the AI agent.\n\n" +
+            "## Inputs\n\n" +
+            "- `tools` — array of `ToolToggleInput { Name, Enabled }`. Non-empty.\n" +
+            "- `includeLogs` (default `false`) — when true, returns per-step operation logs alongside the success map.\n\n" +
+            "## Behavior\n\n" +
+            "Each entry is resolved against the tool manager's exact-name and case-insensitive lookups. " +
+            "Already-correct state short-circuits as success without writing. The plugin's config is saved once at the " +
+            "end iff at least one tool actually changed state.")]
         [Description("Enable or disable MCP tools by name. " +
             "Allows controlling which tools are available for the AI agent.")]
         public ToolToggleResult SetEnabledState

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Type.GetJsonSchema.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Type.GetJsonSchema.cs
@@ -31,6 +31,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
+        [McpPluginSkillDescription("Generate a JSON Schema for a C# type name via reflection. " +
+            "Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. " +
+            "Knobs control inclusion of nested `$defs` and whether type-level / property-level descriptions are emitted.")]
+        [McpPluginSkillBody("Generates a JSON Schema for a given C# type name using reflection. " +
+            "Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. " +
+            "The type must be present in any loaded assembly. " +
+            "Use the full type name (e.g. 'UnityEngine.Vector3') for best results.\n\n" +
+            "## Inputs\n\n" +
+            "- `typeName` — full type name preferred (e.g. `UnityEngine.Vector3`, `System.Collections.Generic.List<System.Int32>`). " +
+            "Simple names work when unambiguous.\n" +
+            "- `descriptionMode` (default `Ignore`) — controls type-level `description`: `Include` keeps it on the target only, " +
+            "`IncludeRecursively` also keeps it inside `$defs`, `Ignore` strips all.\n" +
+            "- `propertyDescriptionMode` (default `Ignore`) — controls property/field/item `description`: `Include` keeps " +
+            "on the target's own properties/items only, `IncludeRecursively` also keeps inside `$defs`, `Ignore` strips all.\n" +
+            "- `includeNestedTypes` (default `false`) — when true, complex nested types are extracted into `$defs` and " +
+            "referenced via `$ref`. Useful for recursive or large types.\n" +
+            "- `writeIndented` (default `false`) — pretty-print the output JSON.")]
         [Description("Generates a JSON Schema for a given C# type name using reflection. " +
             "Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. " +
             "The type must be present in any loaded assembly. " +


### PR DESCRIPTION
## Summary

Continuation of #751 — extends the 5-tool pilot to the remaining ~63 `[McpPluginTool]` declarations in Unity-MCP-Plugin. Every generated `SKILL.md` now carries a concise YAML `description:` (from `[McpPluginSkillDescription]`) and a complete long-form markdown body (from `[McpPluginSkillBody]`).

## Approach

- Applied `[McpPluginSkillDescription]` + `[McpPluginSkillBody]` to every remaining tool method under `Editor/Scripts/API/{Tool,SystemTool}/`. The 5 tools already done in #751 (`unity-skill-create`, `assets-modify`, `gameobject-modify`, `gameobject-component-modify`, `script-execute`) were left untouched.
- Kept every `[Description]` attribute byte-identical to `main`, so the MCP wire payload (`tools/list`) is unchanged.
- For Unity-version sibling pairs (`Editor.Selection.Get/Set`, `GameObject.Destroy`, `GameObject.Component.Get`), the shared SKILL.md strings live as `internal static class <Verb>Skill` constants inside both type-level partials (gated by `#if`/`#else`), mirroring the `Tool_Assets.ModifySkill` pattern PR #751 established. The Unity 6.5+ and pre-6.5 code paths diverge at the API surface (EntityId vs InstanceID, etc.) but their generated SKILL.md is byte-identical.
- Regenerated the SKILL.md set via `unity-skill-generate` and committed it alongside the source-code changes (same round-trip-and-commit pattern as PR #751 commit `57334844`).

## Verification

- `[Description]` payloads unchanged vs `main` (acceptance criterion 1 of #729) — wire `tools/list` is byte-stable.
- Generated `SKILL.md` YAML `description:` length cap satisfied (acceptance criterion 4 of #729): every emitted file is ≤ 1024 chars; max length across 66 skills is 635 (`unity-skill-create/SKILL.md`, unchanged from #751).
- Unity EditMode tests: **911 / 911 passed, 0 failed** (`tests-run` with `testMode=EditMode` on `Unity 2022.3.62f3`, ~21.6 s).
- `unity-skill-generate` round-trip verified — every regenerated `SKILL.md` is checked into this PR.
- Both Unity-version sibling paths (`#if UNITY_6000_5_OR_NEWER` and `#if !UNITY_6000_5_OR_NEWER`) carry identical shared skill constants in their type-level partials, so the SKILL.md generation produces the same output on every matrix build.

## Out of scope (follow-on work)

Acceptance criterion 5 of #729 (\"Coverage includes both Unity-MCP and related Unity-MCP.extensions tool projects\") is intentionally partial-scoped to this run. The four extension repos under [`IvanMurzak/Unity-MCP.extensions`](https://github.com/IvanMurzak/Unity-MCP.extensions) — `Unity-AI-Animation`, `Unity-AI-ParticleSystem`, `Unity-AI-ProBuilder`, `Unity-AI-Tools-Template` — will each get their own follow-on PR after this merges. They are independent repos with their own release cycles, so bundling them into one PR would conflate review surfaces.

Refs #729

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>