### PR TITLE
fix: 64-bit EntityId precision loss in JSON wire format (#759)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/CHANGELOG.md
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`EntityId` wire format moved from JSON number to JSON string of decimal digits**
+  (Unity 6.5+ paths only). Closes #759, resolves #754. JS-based MCP clients
+  (Claude Agent SDK, etc.) parse JSON numbers as IEEE-754 doubles, so any
+  `EntityId` raw ulong past `2^53 - 1` was rounded on the JS side and the
+  rounded value sent back to Unity could not resolve the original object.
+  Serialising the value as an opaque JSON string preserves full 64-bit
+  precision across any language boundary. Inbound still accepts both forms
+  (string preferred, number accepted for back-compat); outbound is always a
+  string. Schema is now `{ "type": "string", "pattern": "^[0-9]+$" }`. Affects
+  every Unity 6.5+ converter that writes `EntityId` or an `instanceID` field:
+  `EntityIdConverter`, `ObjectRefConverter`, `GameObjectRefConverter`,
+  `AssetObjectRefConverter`, `ComponentRefConverter`, `SceneRefConverter`,
+  and the `Tool_Assets.Modify` `instanceID` injection. Pre-Unity-6.5 paths
+  (legacy `int InstanceID`, safely inside the JS-safe range) are untouched.
+
 ### Changed (BREAKING)
 
 - **Namespace flattened to `AIGD`**: AI-facing data model namespace renamed from

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
@@ -13,6 +13,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -123,7 +124,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     // on a String-valued JsonElement (the value left there by the serializer).
                     content!.valueJsonElement.SetProperty(
                         ObjectRef.ObjectRefProperty.InstanceID,
-                        UnityEngine.EntityId.ToULong(asset.GetEntityId()).ToString(System.Globalization.CultureInfo.InvariantCulture));
+                        UnityEngine.EntityId.ToULong(asset.GetEntityId()).ToString(CultureInfo.InvariantCulture));
 
                     if (reflector.TryModify(ref obj, data: content!, logs: logs, logger: logger))
                         anySuccess = true;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
@@ -116,8 +116,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 if (hasContent)
                 {
-                    // Fixing instanceID - inject expected instance ID into the valueJsonElement
-                    content!.valueJsonElement.SetProperty(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(asset.GetEntityId()));
+                    // Fixing instanceID - inject expected instance ID into the valueJsonElement.
+                    // Written as a JSON string of decimal digits to match the #759 EntityId
+                    // wire contract (see EntityIdConverter top-of-file). Calling the ulong
+                    // overload here would throw because TryGetUInt64 throws InvalidOperationException
+                    // on a String-valued JsonElement (the value left there by the serializer).
+                    content!.valueJsonElement.SetProperty(
+                        ObjectRef.ObjectRefProperty.InstanceID,
+                        UnityEngine.EntityId.ToULong(asset.GetEntityId()).ToString(System.Globalization.CultureInfo.InvariantCulture));
 
                     if (reflector.TryModify(ref obj, data: content!, logs: logs, logger: logger))
                         anySuccess = true;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Structures/EntityIdConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Structures/EntityIdConverter.cs
@@ -54,24 +54,17 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             if (reader.TokenType == JsonTokenType.Null)
                 return EntityId.None;
 
-            // Inbound accepts both forms so JS-side clients that already
-            // post strings AND legacy clients that still post numbers both
-            // round-trip correctly.
-            if (reader.TokenType == JsonTokenType.String)
-            {
-                var stringValue = reader.GetString();
-                return EntityIdUtils.FromString(stringValue!);
-            }
-
-            if (reader.TokenType != JsonTokenType.Number)
+            if (reader.TokenType != JsonTokenType.String && reader.TokenType != JsonTokenType.Number)
                 throw new JsonException($"Expected string or number token for {nameof(EntityId)}, got {reader.TokenType}.");
 
             return ReadEntityIdValue(ref reader);
         }
 
-        // Accept both JSON representations so handwritten JSON (legacy int form
-        // from EntityId.ToString) and machine-serialized JSON (full raw ulong
-        // from EntityId.ToULong) both round-trip correctly.
+        // Accept three JSON representations:
+        //   1. String token — the new on-wire format (decimal digits, see top-of-file).
+        //   2. Legacy int form from EntityId.ToString (handwritten JSON).
+        //   3. Raw ulong from EntityId.ToULong (machine-serialized JSON).
+        // All three round-trip correctly.
         internal static EntityId ReadEntityIdValue(ref Utf8JsonReader reader)
         {
             // String token — the new on-wire format.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Structures/EntityIdConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Structures/EntityIdConverter.cs
@@ -71,7 +71,13 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             if (reader.TokenType == JsonTokenType.String)
             {
                 var stringValue = reader.GetString();
-                return EntityIdUtils.FromString(stringValue!);
+                // Reject empty string up-front: the schema regex "^[0-9]+$" requires
+                // one or more digits, but EntityIdUtils.FromString("") returns
+                // EntityId.None silently. Throw here so the runtime matches the
+                // published schema (see #759 wire contract at top-of-file).
+                if (string.IsNullOrEmpty(stringValue))
+                    throw new JsonException($"{nameof(EntityId)} string must be one or more decimal digits, got empty string.");
+                return EntityIdUtils.FromString(stringValue);
             }
 
             if (reader.TryGetInt64(out var signedValue))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Structures/EntityIdConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Structures/EntityIdConverter.cs
@@ -8,9 +8,26 @@
 └──────────────────────────────────────────────────────────────────┘
 */
 
+// Wire contract for EntityId (Unity 6.5+):
+//   On the wire: JSON string of decimal digits, e.g. "568105584918935294".
+//                No sign, no leading zeros, no exponent.
+//   Schema:      { "type": "string", "pattern": "^[0-9]+$" }.
+//
+//   Outbound: always emitted as a JSON string (via WriteStringValue).
+//   Inbound:  accepts both a JSON string (preferred) and a JSON number
+//             (back-compat — legacy clients pre-#759 wrote a number).
+//
+// Rationale: Unity 6.5's EntityId is a 64-bit ulong. JS-based MCP clients
+// (Claude Agent SDK, etc.) parse JSON numbers as IEEE-754 doubles, so any
+// value past 2^53 - 1 rounds. Serializing as a string makes the value
+// opaque to every JSON parser, preserving full precision through any
+// language boundary. This is the same pattern used by Twitter, YouTube,
+// Discord, Stripe, and gRPC-JSON for 64-bit IDs. See #759 / #754.
+
 #nullable enable
 #if UNITY_6000_5_OR_NEWER
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using com.IvanMurzak.ReflectorNet.Json;
@@ -24,7 +41,8 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
     {
         public override JsonNode GetSchema() => new JsonObject
         {
-            [JsonSchema.Type] = JsonSchema.Integer
+            [JsonSchema.Type] = JsonSchema.String,
+            [JsonSchema.Pattern] = "^[0-9]+$"
         };
         public override JsonNode GetSchemaRef() => new JsonObject
         {
@@ -36,8 +54,17 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             if (reader.TokenType == JsonTokenType.Null)
                 return EntityId.None;
 
+            // Inbound accepts both forms so JS-side clients that already
+            // post strings AND legacy clients that still post numbers both
+            // round-trip correctly.
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString();
+                return EntityIdUtils.FromString(stringValue!);
+            }
+
             if (reader.TokenType != JsonTokenType.Number)
-                throw new JsonException($"Expected number token for {nameof(EntityId)}, got {reader.TokenType}.");
+                throw new JsonException($"Expected string or number token for {nameof(EntityId)}, got {reader.TokenType}.");
 
             return ReadEntityIdValue(ref reader);
         }
@@ -47,6 +74,13 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
         // from EntityId.ToULong) both round-trip correctly.
         internal static EntityId ReadEntityIdValue(ref Utf8JsonReader reader)
         {
+            // String token — the new on-wire format.
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString();
+                return EntityIdUtils.FromString(stringValue!);
+            }
+
             if (reader.TryGetInt64(out var signedValue))
                 return EntityIdUtils.FromNumber(signedValue);
 
@@ -77,7 +111,10 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
         public override void Write(Utf8JsonWriter writer, EntityId value, JsonSerializerOptions options)
         {
-            writer.WriteNumberValue(EntityId.ToULong(value));
+            // Outbound: always a JSON string of decimal digits so JS clients
+            // can JSON.parse the payload without IEEE-754 precision loss
+            // (see top-of-file wire contract).
+            writer.WriteStringValue(EntityId.ToULong(value).ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/AssetObjectRefConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/AssetObjectRefConverter.cs
@@ -11,6 +11,7 @@
 #nullable enable
 #if UNITY_6000_5_OR_NEWER
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using com.IvanMurzak.McpPlugin;
@@ -72,8 +73,10 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             {
                 writer.WriteStartObject();
 
-                // Write the "instanceID" property
-                writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, 0);
+                // Write the "instanceID" property — see EntityIdConverter
+                // top-of-file wire contract (#759): outbound is always a
+                // JSON string of decimal digits, never a number.
+                writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, "0");
 
                 writer.WriteEndObject();
                 return;
@@ -81,8 +84,8 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
             writer.WriteStartObject();
 
-            // Write the "instanceID" property
-            writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID));
+            // Write the "instanceID" property (JSON string — see #759).
+            writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID).ToString(CultureInfo.InvariantCulture));
 
             // Write the "assetType" property
             if (value.AssetType != null)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/ComponentRefConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/ComponentRefConverter.cs
@@ -79,6 +79,7 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
             writer.WriteStartObject();
 
+            // Write the "instanceID" property (JSON string — see #759).
             writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID).ToString(CultureInfo.InvariantCulture));
 
             if (value.Index != -1)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/ComponentRefConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/ComponentRefConverter.cs
@@ -11,6 +11,7 @@
 #nullable enable
 #if UNITY_6000_5_OR_NEWER
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using com.IvanMurzak.McpPlugin;
@@ -67,8 +68,10 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             {
                 writer.WriteStartObject();
 
-                // Write the "instanceID" property
-                writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, 0);
+                // Write the "instanceID" property — see EntityIdConverter
+                // top-of-file wire contract (#759): outbound is always a
+                // JSON string of decimal digits, never a number.
+                writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, "0");
 
                 writer.WriteEndObject();
                 return;
@@ -76,7 +79,7 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
             writer.WriteStartObject();
 
-            writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID));
+            writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID).ToString(CultureInfo.InvariantCulture));
 
             if (value.Index != -1)
                 writer.WriteNumber(ComponentRef.ComponentRefProperty.Index, value.Index);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/GameObjectRefConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/GameObjectRefConverter.cs
@@ -90,6 +90,7 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
             writer.WriteStartObject();
 
+            // Write the "instanceID" property (JSON string — see #759).
             writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID).ToString(CultureInfo.InvariantCulture));
 
             if (!string.IsNullOrEmpty(value.Path))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/GameObjectRefConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/GameObjectRefConverter.cs
@@ -11,6 +11,7 @@
 #nullable enable
 #if UNITY_6000_5_OR_NEWER
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using com.IvanMurzak.McpPlugin;
@@ -78,8 +79,10 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             {
                 writer.WriteStartObject();
 
-                // Write the "instanceID" property
-                writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, 0);
+                // Write the "instanceID" property — see EntityIdConverter
+                // top-of-file wire contract (#759): outbound is always a
+                // JSON string of decimal digits, never a number.
+                writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, "0");
 
                 writer.WriteEndObject();
                 return;
@@ -87,7 +90,7 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
             writer.WriteStartObject();
 
-            writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID));
+            writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID).ToString(CultureInfo.InvariantCulture));
 
             if (!string.IsNullOrEmpty(value.Path))
                 writer.WriteString(GameObjectRef.GameObjectRefProperty.Path, value.Path);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/ObjectRefConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/ObjectRefConverter.cs
@@ -11,6 +11,7 @@
 #nullable enable
 #if UNITY_6000_5_OR_NEWER
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using AIGD;
@@ -60,8 +61,10 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             {
                 writer.WriteStartObject();
 
-                // Write the "instanceID" property
-                writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, 0);
+                // Write the "instanceID" property — see EntityIdConverter
+                // top-of-file wire contract (#759): outbound is always a
+                // JSON string of decimal digits, never a number.
+                writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, "0");
 
                 writer.WriteEndObject();
                 return;
@@ -69,8 +72,8 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
             writer.WriteStartObject();
 
-            // Write the "instanceID" property
-            writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID));
+            // Write the "instanceID" property (JSON string — see #759).
+            writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID).ToString(CultureInfo.InvariantCulture));
 
             writer.WriteEndObject();
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/SceneRefConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Json/Types/SceneRefConverter.cs
@@ -11,6 +11,7 @@
 #nullable enable
 #if UNITY_6000_5_OR_NEWER
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using com.IvanMurzak.McpPlugin;
@@ -67,8 +68,10 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
             {
                 writer.WriteStartObject();
 
-                // Write the "instanceID" property
-                writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, 0);
+                // Write the "instanceID" property — see EntityIdConverter
+                // top-of-file wire contract (#759): outbound is always a
+                // JSON string of decimal digits, never a number.
+                writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, "0");
 
                 writer.WriteEndObject();
                 return;
@@ -76,8 +79,8 @@ namespace com.IvanMurzak.Unity.MCP.JsonConverters
 
             writer.WriteStartObject();
 
-            // Write the "instanceID" property
-            writer.WriteNumber(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID));
+            // Write the "instanceID" property (JSON string — see #759).
+            writer.WriteString(ObjectRef.ObjectRefProperty.InstanceID, UnityEngine.EntityId.ToULong(value.InstanceID).ToString(CultureInfo.InvariantCulture));
 
             // Write the "path" property
             if (!string.IsNullOrEmpty(value.Path))

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/JsonConverters/GameObjectRefConverterTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/JsonConverters/GameObjectRefConverterTests.cs
@@ -225,6 +225,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests.JsonConverter
                 $"InstanceID '\"0\"' must deserialize to EntityId.None. JSON: {Json}");
         }
 
+        // Negative cases: empty string violates the schema ("^[0-9]+$" requires
+        // one or more digits), and non-numeric garbage cannot be parsed at all.
+        // Both MUST surface as a deserialization-time exception so a malformed
+        // payload fails loudly rather than silently coercing to EntityId.None.
+        // (Whitespace, signed-int, and decimal-with-trailing-zero variants are
+        // intentionally NOT in this list — see EntityIdUtils.FromString's doc
+        // comment for the accepted forms.)
+        [TestCase("\"\"")]
+        [TestCase("\"abc\"")]
+        public void GameObjectRef_InstanceID_FromJsonString_MalformedString_Throws(string instanceIdJsonValue)
+        {
+            var json = $"{{\"instanceID\":{instanceIdJsonValue}}}";
+
+            var reflector = UnityMcpPluginEditor.Instance.Reflector
+                ?? throw new Exception("Reflector is not available.");
+
+            Assert.Catch(() => reflector.JsonSerializer.Deserialize<GameObjectRef>(json),
+                $"Malformed instanceID string must surface as a deserialization exception. JSON: {json}");
+        }
+
         [Test]
         public void EntityIdConverter_Schema_DeclaresString()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/JsonConverters/GameObjectRefConverterTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/JsonConverters/GameObjectRefConverterTests.cs
@@ -12,7 +12,11 @@
 #if UNITY_6000_5_OR_NEWER
 using System;
 using System.Collections;
+using System.Globalization;
+using System.Text.Json;
 using AIGD;
+using com.IvanMurzak.Unity.MCP.JsonConverters;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -136,6 +140,119 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests.JsonConverter
                 UnityEngine.Object.DestroyImmediate(go);
             }
             yield return null;
+        }
+
+        // ── #759 wire-format tests ────────────────────────────────────
+        // Outbound: instanceID must be a JSON string (not a JSON number),
+        // so JS clients can JSON.parse without IEEE-754 precision loss.
+        // Inbound: accepts both string (preferred) and number (back-compat).
+
+        [Test]
+        public void GameObjectRef_InstanceID_BeyondJsSafeInteger_SurvivesJsParse()
+        {
+            // Pick a value > 2^53 - 1 (the JS safe-integer ceiling) so any
+            // number-based serialization would round it. Build an EntityId
+            // whose raw ulong is exactly this magnitude to prove the wire
+            // emits decimal digits unmodified.
+            const ulong RawId = 568_105_584_918_935_294UL;
+            var entityId = UnityEngine.EntityId.FromULong(RawId);
+            var source = new GameObjectRef(entityId);
+
+            var reflector = UnityMcpPluginEditor.Instance.Reflector
+                ?? throw new Exception("Reflector is not available.");
+            var json = reflector.JsonSerializer.Serialize(source);
+            Assert.IsFalse(string.IsNullOrEmpty(json), "Serialized JSON should not be empty.");
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("instanceID", out var instanceIdElement),
+                $"Serialized JSON must contain 'instanceID' property. JSON: {json}");
+            Assert.AreEqual(JsonValueKind.String, instanceIdElement.ValueKind,
+                $"'instanceID' must serialize as a JSON string (the #759 wire contract), not {instanceIdElement.ValueKind}. JSON: {json}");
+
+            var stringValue = instanceIdElement.GetString();
+            Assert.AreEqual(RawId.ToString(CultureInfo.InvariantCulture), stringValue,
+                $"'instanceID' string must be the exact decimal representation of the raw EntityId ulong. JSON: {json}");
+        }
+
+        [Test]
+        public void GameObjectRef_InstanceID_FromJsonString_Parses()
+        {
+            // Inbound: a JSON string value of decimal digits must deserialize
+            // back to the original raw ulong with no precision loss.
+            const ulong RawId = 568_105_584_918_935_294UL;
+            var json = $"{{\"instanceID\":\"{RawId.ToString(CultureInfo.InvariantCulture)}\"}}";
+
+            var reflector = UnityMcpPluginEditor.Instance.Reflector
+                ?? throw new Exception("Reflector is not available.");
+            var deserialized = reflector.JsonSerializer.Deserialize<GameObjectRef>(json);
+            Assert.IsNotNull(deserialized, $"Deserialized GameObjectRef should not be null. JSON: {json}");
+
+            Assert.AreEqual(UnityEngine.EntityId.FromULong(RawId), deserialized!.InstanceID,
+                $"InstanceID must round-trip exactly when read from a JSON string. JSON: {json}");
+        }
+
+        [Test]
+        public void GameObjectRef_InstanceID_FromJsonNumber_StillParses()
+        {
+            // Inbound back-compat: legacy clients pre-#759 may still post a
+            // JSON number for instanceID. That path MUST still round-trip,
+            // even past the JS-safe-integer boundary (the .NET STJ parser
+            // itself is precision-clean; the rounding only happens in JS).
+            const ulong RawId = 568_105_584_918_935_294UL;
+            var json = $"{{\"instanceID\":{RawId.ToString(CultureInfo.InvariantCulture)}}}";
+
+            var reflector = UnityMcpPluginEditor.Instance.Reflector
+                ?? throw new Exception("Reflector is not available.");
+            var deserialized = reflector.JsonSerializer.Deserialize<GameObjectRef>(json);
+            Assert.IsNotNull(deserialized, $"Deserialized GameObjectRef should not be null. JSON: {json}");
+
+            Assert.AreEqual(UnityEngine.EntityId.FromULong(RawId), deserialized!.InstanceID,
+                $"InstanceID must round-trip exactly when read from a JSON number (back-compat). JSON: {json}");
+        }
+
+        [Test]
+        public void GameObjectRef_InstanceID_FromJsonString_WithZero_Parses()
+        {
+            // The string "0" represents the null entity (EntityId.None) —
+            // same convention as legacy number 0.
+            const string Json = "{\"instanceID\":\"0\"}";
+
+            var reflector = UnityMcpPluginEditor.Instance.Reflector
+                ?? throw new Exception("Reflector is not available.");
+            var deserialized = reflector.JsonSerializer.Deserialize<GameObjectRef>(Json);
+            Assert.IsNotNull(deserialized, $"Deserialized GameObjectRef should not be null. JSON: {Json}");
+
+            Assert.AreEqual(UnityEngine.EntityId.None, deserialized!.InstanceID,
+                $"InstanceID '\"0\"' must deserialize to EntityId.None. JSON: {Json}");
+        }
+
+        [Test]
+        public void EntityIdConverter_Schema_DeclaresString()
+        {
+            // Schema MUST advertise the new string wire format so AI clients
+            // that consume the schema (Claude Agent SDK, etc.) generate
+            // correctly-typed tool calls and validators reject any number-
+            // shaped payload.
+            var converter = new EntityIdConverter();
+            var schema = converter.GetSchema();
+
+            Assert.IsNotNull(schema, "GetSchema() must not return null.");
+            var schemaJson = schema.ToJsonString();
+
+            using var doc = JsonDocument.Parse(schemaJson);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("type", out var typeElement),
+                $"Schema must declare a 'type' field. Schema: {schemaJson}");
+            Assert.AreEqual(JsonValueKind.String, typeElement.ValueKind,
+                $"Schema 'type' must be a JSON string. Schema: {schemaJson}");
+            Assert.AreEqual("string", typeElement.GetString(),
+                $"Schema 'type' must be 'string' (the #759 wire contract). Schema: {schemaJson}");
+
+            Assert.IsTrue(doc.RootElement.TryGetProperty("pattern", out var patternElement),
+                $"Schema must declare a 'pattern' field for the string format. Schema: {schemaJson}");
+            Assert.AreEqual(JsonValueKind.String, patternElement.ValueKind,
+                $"Schema 'pattern' must be a JSON string. Schema: {schemaJson}");
+            Assert.IsFalse(string.IsNullOrEmpty(patternElement.GetString()),
+                $"Schema 'pattern' must not be empty. Schema: {schemaJson}");
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/JsonConverters/GameObjectRefConverterTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/JsonConverters/GameObjectRefConverterTests.cs
@@ -16,7 +16,6 @@ using System.Globalization;
 using System.Text.Json;
 using AIGD;
 using com.IvanMurzak.Unity.MCP.JsonConverters;
-using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -251,8 +250,47 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests.JsonConverter
                 $"Schema must declare a 'pattern' field for the string format. Schema: {schemaJson}");
             Assert.AreEqual(JsonValueKind.String, patternElement.ValueKind,
                 $"Schema 'pattern' must be a JSON string. Schema: {schemaJson}");
-            Assert.IsFalse(string.IsNullOrEmpty(patternElement.GetString()),
-                $"Schema 'pattern' must not be empty. Schema: {schemaJson}");
+            Assert.AreEqual("^[0-9]+$", patternElement.GetString(),
+                $"Schema 'pattern' must pin the exact #759 wire-contract regex. Schema: {schemaJson}");
+        }
+
+        // Cross-converter smoke test for the #759 wire contract. The five
+        // *RefConverter writers all delegate the EntityId conversion to the
+        // central EntityIdConverter, so the behavior is shared — but a future
+        // refactor that bypasses the central converter on one of them would
+        // silently regress only that path. This guard re-asserts the JSON
+        // string shape per converter so any such drift fails CI.
+        [TestCase("ObjectRef")]
+        [TestCase("GameObjectRef")]
+        [TestCase("AssetObjectRef")]
+        [TestCase("ComponentRef")]
+        [TestCase("SceneRef")]
+        public void AllRefConverters_InstanceID_EmitsJsonString_BeyondJsSafeInteger(string refKind)
+        {
+            const ulong RawId = 568_105_584_918_935_294UL;
+            var entityId = UnityEngine.EntityId.FromULong(RawId);
+            var reflector = UnityMcpPluginEditor.Instance.Reflector
+                ?? throw new Exception("Reflector is not available.");
+
+            string json = refKind switch
+            {
+                "ObjectRef" => reflector.JsonSerializer.Serialize(new ObjectRef(entityId)),
+                "GameObjectRef" => reflector.JsonSerializer.Serialize(new GameObjectRef(entityId)),
+                "AssetObjectRef" => reflector.JsonSerializer.Serialize(new AssetObjectRef(entityId)),
+                "ComponentRef" => reflector.JsonSerializer.Serialize(new ComponentRef(entityId)),
+                "SceneRef" => reflector.JsonSerializer.Serialize(new SceneRef(entityId)),
+                _ => throw new ArgumentOutOfRangeException(nameof(refKind), refKind, "Unknown ref kind.")
+            };
+
+            Assert.IsFalse(string.IsNullOrEmpty(json), $"Serialized JSON for {refKind} should not be empty.");
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.IsTrue(doc.RootElement.TryGetProperty("instanceID", out var instanceIdElement),
+                $"{refKind} JSON must contain 'instanceID' property. JSON: {json}");
+            Assert.AreEqual(JsonValueKind.String, instanceIdElement.ValueKind,
+                $"{refKind} 'instanceID' must serialize as a JSON string (the #759 wire contract), not {instanceIdElement.ValueKind}. JSON: {json}");
+            Assert.AreEqual(RawId.ToString(CultureInfo.InvariantCulture), instanceIdElement.GetString(),
+                $"{refKind} 'instanceID' string must be the exact decimal representation of the raw EntityId ulong. JSON: {json}");
         }
     }
 }


### PR DESCRIPTION
## Summary

- Move `EntityId`'s on-the-wire JSON shape from a **number** to a **string** of decimal digits for every Unity 6.5+ converter that writes `EntityId` / `instanceID`. JS-based MCP clients parse JSON numbers as IEEE-754 doubles and were silently rounding any raw ulong past `2^53 - 1`, breaking `EntityId` round-trips through the Node-side MCP layer (issue #754).
- Outbound is always a JSON string. Inbound accepts both string (preferred) and number (back-compat for legacy clients).
- Adds five EditMode tests that gate the new wire shape, including the original repro from #754 (`BeyondJsSafeInteger_SurvivesJsParse`).
- Fixes a follow-on bug in `Tool_Assets.Modify` where the `instanceID` `SetProperty(ulong)` overload was tripping `TryGetUInt64` on the now-String JsonElement.

## Test plan

- [x] Target-specific local tests passed (see profile `test.md`)
  - EditMode suite on Unity `6000.5.0b3` against `Unity-Tests/6000.5.0b3` — only the 2 SO Populate tests were broken by the wire change; both now pass after the `Tool_Assets.Modify` fix. New tests all pass.
  - 5 unrelated `TestToolConsole.ClearLogs*` failures remain on this local machine — they reproduce on `main` without any of these changes and are caused by the local `unity-mcp-server.exe` process holding `Temp/mcp-server/ai-editor-logs.txt` open when the tests try to delete it; not introduced by this PR.

Closes #759