### PR TITLE
fix: persist skillsPath as project-relative for portable shared config

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
@@ -154,6 +154,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             return normalized.StartsWith(root) ? normalized[root.Length..] : normalized;
         }
 
+        /// <summary>
+        /// Resolves a configurator's <see cref="SkillsPath"/> (which is project-relative for
+        /// every built-in configurator — e.g. ".claude/skills") to an absolute filesystem
+        /// path so the UI can show a clickable / copy-pasteable location. Mirrors the logic
+        /// of <see cref="UnityMcpPluginEditor.SkillsRootFolderAbsolutePath"/> but operates on
+        /// the configurator-supplied value rather than the persisted one — this is important
+        /// because the configurator's path can differ from the persisted one until the user
+        /// enables skills for that agent.
+        /// </summary>
+        protected static string ResolveAbsoluteSkillsPath(string folder)
+        {
+            if (string.IsNullOrEmpty(folder))
+                return folder;
+            return Path.IsPathRooted(folder)
+                ? folder
+                : Path.GetFullPath(Path.Combine(ProjectRootPath, folder));
+        }
+
         #endregion
 
         #region Abstract
@@ -557,9 +575,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             // Hide the unsupported label
             unsupportedLabel.style.display = DisplayStyle.None;
 
-            // Show the skills output path
-            pathLabel.text = ToDisplayPath(SkillsPath!);
-            pathLabel.tooltip = SkillsPath;
+            // Show the skills output path. `SkillsPath` is project-relative for the built-in
+            // configurators (e.g. ".claude/skills") so the persisted config is portable across
+            // machines, but the user still wants to see — and click into — the absolute
+            // on-disk location. Resolve via `SkillsRootFolderAbsolutePath`, then strip the
+            // project root for compact display via `ToDisplayPath`.
+            var absoluteSkillsPath = ResolveAbsoluteSkillsPath(SkillsPath!);
+            pathLabel.text = ToDisplayPath(absoluteSkillsPath);
+            pathLabel.tooltip = absoluteSkillsPath;
 
             // Configure toggle (per-agent)
             toggleAutoGenerate.SetValueWithoutNotify(UnityMcpPluginEditor.IsAutoGenerateSkills(AgentId));

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/AntigravityConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/AntigravityConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Antigravity";
         public override string AgentId => "antigravity";
         public override string DownloadUrl => "https://antigravity.google/download";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".agent", "skills"); // https://codelabs.developers.google.com/getting-started-with-antigravity-skills#3
+        public override string? SkillsPath => ".agent/skills"; // https://codelabs.developers.google.com/getting-started-with-antigravity-skills#3
 
         protected override string? IconFileName => "antigravity-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClaudeCodeConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClaudeCodeConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "claude-code";
         public override string DownloadUrl => "https://docs.anthropic.com/en/docs/claude-code/overview";
         public override string TutorialUrl => "https://youtu.be/Sknh2p12W8c";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
+        public override string? SkillsPath => ".claude/skills";
 
         protected override string? IconFileName => "claude-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClineConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClineConfigurator.cs
@@ -27,7 +27,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Cline";
         public override string AgentId => "cline";
         public override string DownloadUrl => "https://cline.bot/";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".cline", "skills"); // https://docs.cline.bot/customization/skills
+        public override string? SkillsPath => ".cline/skills"; // https://docs.cline.bot/customization/skills
 
         protected override string? IconFileName => "cline-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CodexConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CodexConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
     {
         const string EnvVarNameAuthToken = "GAME_DEV_AUTH_TOKEN";
 
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".agents", "skills");
+        public override string? SkillsPath => ".agents/skills";
         public override string AgentName => "Codex";
         public override string AgentId => "codex";
         public override string DownloadUrl => "https://openai.com/codex/";

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CursorConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CursorConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "cursor";
         public override string DownloadUrl => "https://cursor.com/download";
         public override string TutorialUrl => "https://www.youtube.com/watch?v=dyk-4gTolSU";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".cursor", "skills");
+        public override string? SkillsPath => ".cursor/skills";
 
         protected override string? IconFileName => "cursor-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CustomConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CustomConfigurator.cs
@@ -148,6 +148,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             {
                 UnityMcpPluginEditor.SkillsPath = evt.newValue;
                 UnityMcpPluginEditor.Instance.Save();
+
+                // The setter may have normalised the value (absolute-inside-project →
+                // project-relative, backslashes → forward slashes). Reflect that back
+                // into the TextField so the visible content matches what was persisted.
+                var normalized = UnityMcpPluginEditor.SkillsPath;
+                if (normalized != evt.newValue)
+                    inputPath.SetValueWithoutNotify(normalized);
             });
             headerRow.Remove(pathLabel);
             headerRow.Add(inputPath);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CustomConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CustomConfigurator.cs
@@ -135,7 +135,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             // Hide the unsupported label
             unsupportedLabel.style.display = DisplayStyle.None;
 
-            // Replace the read-only path label with an editable TextField for custom configurator
+            // Replace the read-only path label with an editable TextField for custom configurator.
+            // The persisted value is normalised by the SkillsPath setter (absolute-inside-project
+            // → project-relative, backslashes → forward slashes); we feed user input straight
+            // through that setter so the on-disk config stays portable across machines.
             var headerRow = pathLabel.parent;
             var inputPath = new TextField { value = UnityMcpPluginEditor.SkillsPath };
             inputPath.style.flexGrow = 1;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GeminiConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GeminiConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Gemini";
         public override string AgentId => "gemini";
         public override string DownloadUrl => "https://geminicli.com/docs/get-started/installation/";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".gemini", "skills");
+        public override string? SkillsPath => ".gemini/skills";
 
         protected override string? IconFileName => "gemini-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
@@ -28,7 +28,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "GitHub Copilot CLI";
         public override string AgentId => "github-copilot-cli";
         public override string DownloadUrl => "https://github.com/features/copilot/cli";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
+        public override string? SkillsPath => ".claude/skills";
 
         protected override string? IconFileName => "github-copilot-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/KiloCodeConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/KiloCodeConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Kilo Code";
         public override string AgentId => "kilo-code";
         public override string DownloadUrl => "https://app.kilo.ai/get-started";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".kilocode", "skills"); // https://kilo.ai/docs/customize/skills
+        public override string? SkillsPath => ".kilocode/skills"; // https://kilo.ai/docs/customize/skills
 
         protected override string? IconFileName => "kilo-code-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/OpenCodeConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/OpenCodeConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Open Code";
         public override string AgentId => "open-code";
         public override string DownloadUrl => "https://opencode.ai/download";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".opencode", "skills"); // https://opencode.ai/docs/skills/
+        public override string? SkillsPath => ".opencode/skills"; // https://opencode.ai/docs/skills/
 
         protected override string? IconFileName => "open-code-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/RiderConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/RiderConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Rider (Junie)";
         public override string AgentId => "rider-junie";
         public override string DownloadUrl => "https://www.jetbrains.com/rider/download/";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".junie", "skills");
+        public override string? SkillsPath => ".junie/skills";
 
         protected override string? IconFileName => "rider-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCodeCopilotConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCodeCopilotConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "vscode-copilot";
         public override string DownloadUrl => "https://code.visualstudio.com/download";
         public override string TutorialUrl => "https://www.youtube.com/watch?v=ZhP7Ju91mOE";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
+        public override string? SkillsPath => ".claude/skills";
 
         protected override string? IconFileName => "vs-code-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCopilotConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCopilotConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "vs-copilot";
         public override string DownloadUrl => "https://visualstudio.microsoft.com/downloads/";
         public override string TutorialUrl => "https://www.youtube.com/watch?v=RGdak4T69mc";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".github", "skills");
+        public override string? SkillsPath => ".github/skills";
 
         protected override string? IconFileName => "visual-studio-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Config.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Config.cs
@@ -113,6 +113,26 @@ namespace com.IvanMurzak.Unity.MCP
                     wasCreated = true;
                 }
 
+                // Auto-heal a legacy absolute `SkillsPath` that points inside the project root.
+                // Committing `UserSettings/AI-Game-Developer-Config.json` is supposed to be portable
+                // across machines; a machine-specific absolute path breaks every other team member.
+                // The normaliser also flips backslashes to forward slashes for cross-platform diff
+                // stability. Absolute paths OUTSIDE the project root are intentional user choices
+                // and are left untouched. Re-saving runs only when normalisation actually changed
+                // the value, so a project with an already-relative SkillsPath does not get touched.
+                if (!string.IsNullOrEmpty(config.SkillsPath))
+                {
+                    var normalizedSkills = NormalizeSkillsPath(config.SkillsPath);
+                    if (!string.Equals(normalizedSkills, config.SkillsPath, StringComparison.Ordinal))
+                    {
+                        _logger.LogInformation(
+                            "{method}: migrating SkillsPath from <i>{old}</i> to <i>{new}</i>",
+                            nameof(GetOrCreateConfig), config.SkillsPath, normalizedSkills);
+                        config.SkillsPath = normalizedSkills;
+                        wasCreated = true;
+                    }
+                }
+
                 return config;
             }
             catch (Exception e)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
@@ -209,9 +210,52 @@ namespace com.IvanMurzak.Unity.MCP
             get => Instance.unityConnectionConfig.SkillsPath;
             set
             {
-                Instance.unityConnectionConfig.SkillsPath = value;
+                Instance.unityConnectionConfig.SkillsPath = NormalizeSkillsPath(value);
                 NotifyChanged(Instance.unityConnectionConfig);
             }
+        }
+
+        /// <summary>
+        /// Normalises a user-supplied or configurator-supplied skills path so the on-disk
+        /// `UserSettings/AI-Game-Developer-Config.json` stays portable across machines and
+        /// across path-separator conventions. Rules:
+        /// <list type="bullet">
+        /// <item>null / empty / whitespace → returned verbatim (caller decides what to do).</item>
+        /// <item>Absolute path inside <see cref="ProjectRootPath"/> → rewritten to a project-relative
+        /// path with forward slashes (e.g. <c>"C:\proj\.claude\skills"</c> → <c>".claude/skills"</c>).
+        /// This is the path-portability fix for committing the config file to version control.</item>
+        /// <item>Absolute path outside the project → returned unchanged (the user has explicitly
+        /// chosen an external location; we do not rewrite it).</item>
+        /// <item>Already-relative path → backslashes converted to forward slashes for cross-platform
+        /// diff stability; no other change.</item>
+        /// </list>
+        /// </summary>
+        public static string NormalizeSkillsPath(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return value;
+
+            // Always use forward slashes in the persisted form for cross-platform diff stability.
+            var normalized = value.Replace('\\', '/');
+
+            if (!Path.IsPathRooted(normalized))
+                return normalized;
+
+            // Absolute path — check whether it lives inside the project root. If yes, make it relative.
+            var root = ProjectRootPath.Replace('\\', '/').TrimEnd('/');
+            // Compare case-insensitively on Windows because paths there are not case-sensitive.
+            var comparison = Environment.OSVersion.Platform == PlatformID.Win32NT
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (normalized.StartsWith(root + "/", comparison))
+                return normalized.Substring(root.Length + 1);
+
+            if (normalized.Equals(root, comparison))
+                return string.Empty;
+
+            // Absolute path outside the project root — leave as-is.
+            return normalized;
         }
 
         // 'new' is intentional: static dispatch on the subtype, instance logic lives in the base.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
@@ -10,7 +10,9 @@
 
 #nullable enable
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin;
@@ -230,7 +232,8 @@ namespace com.IvanMurzak.Unity.MCP
         /// diff stability; no other change.</item>
         /// </list>
         /// </summary>
-        public static string NormalizeSkillsPath(string value)
+        [return: NotNullIfNotNull("value")]
+        public static string? NormalizeSkillsPath(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
                 return value;
@@ -244,7 +247,10 @@ namespace com.IvanMurzak.Unity.MCP
             // Absolute path — check whether it lives inside the project root. If yes, make it relative.
             var root = ProjectRootPath.Replace('\\', '/').TrimEnd('/');
             // Compare case-insensitively on Windows because paths there are not case-sensitive.
-            var comparison = Environment.OSVersion.Platform == PlatformID.Win32NT
+            // macOS APFS is also case-insensitive by default, but that is an accepted gap here;
+            // the typical AI-Game-Developer-Config.json is committed from Windows machines and
+            // the legacy values we auto-heal originate from Windows in practice.
+            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? StringComparison.OrdinalIgnoreCase
                 : StringComparison.Ordinal;
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/SkillsPathNormalizationTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/SkillsPathNormalizationTests.cs
@@ -1,0 +1,222 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="UnityMcpPluginEditor.NormalizeSkillsPath"/> and the
+    /// <see cref="UnityMcpPluginEditor.SkillsPath"/> setter's persistence behaviour.
+    ///
+    /// Regression coverage for issue #761: `skillsPath` persisted as an absolute path
+    /// breaks shared `UserSettings/AI-Game-Developer-Config.json` across machines.
+    /// The setter now normalises absolute-inside-project paths to project-relative
+    /// form (with forward slashes), and the load-time path in
+    /// <see cref="UnityMcpPluginEditor.GetOrCreateConfig"/> auto-heals legacy values.
+    /// </summary>
+    [TestFixture]
+    public class SkillsPathNormalizationTests
+    {
+        private string _originalSkillsPath = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UnityMcpPluginEditor.InitSingletonIfNeeded();
+            _originalSkillsPath = UnityMcpPluginEditor.SkillsPath;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Restore so unrelated tests / Editor state are unaffected.
+            UnityMcpPluginEditor.SkillsPath = _originalSkillsPath;
+        }
+
+        // ----- NormalizeSkillsPath pure-function tests --------------------------------
+
+        [Test]
+        public void NormalizeSkillsPath_KeepsRelativeValue()
+        {
+            // Relative path stays relative.
+            var normalized = UnityMcpPluginEditor.NormalizeSkillsPath(".claude/skills");
+            Assert.AreEqual(".claude/skills", normalized);
+        }
+
+        [Test]
+        public void NormalizeSkillsPath_KeepsRelativeNestedValue()
+        {
+            // Multi-segment relative paths survive.
+            var normalized = UnityMcpPluginEditor.NormalizeSkillsPath("nested/sub/skills");
+            Assert.AreEqual("nested/sub/skills", normalized);
+        }
+
+        [Test]
+        public void NormalizeSkillsPath_NormalizesBackslashesToForwardSlashes()
+        {
+            // Cross-platform diff stability — backslashes always flip to forward.
+            var normalized = UnityMcpPluginEditor.NormalizeSkillsPath(".claude\\skills");
+            Assert.AreEqual(".claude/skills", normalized);
+        }
+
+        [Test]
+        public void NormalizeSkillsPath_AbsoluteInsideProject_BecomesRelative()
+        {
+            // The path-portability fix for issue #761: an absolute path inside the project
+            // root must be rewritten to a project-relative form with forward slashes.
+            var projectRoot = UnityMcpPluginEditor.ProjectRootPath;
+            var absInside = Path.Combine(projectRoot, ".claude", "skills");
+
+            var normalized = UnityMcpPluginEditor.NormalizeSkillsPath(absInside);
+
+            Assert.IsFalse(Path.IsPathRooted(normalized),
+                $"Expected relative path but got rooted: {normalized}");
+            Assert.AreEqual(".claude/skills", normalized);
+        }
+
+        [Test]
+        public void NormalizeSkillsPath_AbsoluteInsideProject_WithBackslashes_BecomesRelative()
+        {
+            // Same as above but verify the backslash form is also recognised — this is the
+            // exact shape `Path.Combine(...)` produces on Windows.
+            var projectRoot = UnityMcpPluginEditor.ProjectRootPath;
+            var absInsideBackslash = projectRoot.Replace('/', '\\') + "\\.claude\\skills";
+
+            var normalized = UnityMcpPluginEditor.NormalizeSkillsPath(absInsideBackslash);
+
+            Assert.IsFalse(Path.IsPathRooted(normalized),
+                $"Expected relative path but got rooted: {normalized}");
+            Assert.AreEqual(".claude/skills", normalized);
+        }
+
+        [Test]
+        public void NormalizeSkillsPath_AbsoluteOutsideProject_RemainsAbsolute()
+        {
+            // The user has explicitly chosen an external location — we must not rewrite
+            // it. Use a path that is guaranteed to be outside the project root.
+            string outsideAbsolute;
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                // Pick a drive root that the project is not on, or a temp path that is
+                // definitely not under the project root. `Path.GetTempPath()` is a safe
+                // bet because the worktree project root never lives under the temp dir.
+                var tempRoot = Path.GetTempPath().TrimEnd('\\', '/');
+                outsideAbsolute = Path.Combine(tempRoot, "external-skills");
+            }
+            else
+            {
+                outsideAbsolute = "/tmp/external-skills";
+            }
+
+            // Sanity check the assumption — if this fires, pick a different fixture path.
+            var projectRoot = UnityMcpPluginEditor.ProjectRootPath.Replace('\\', '/').TrimEnd('/') + "/";
+            Assume.That(outsideAbsolute.Replace('\\', '/').StartsWith(projectRoot, StringComparison.OrdinalIgnoreCase),
+                Is.False, "Test fixture must be outside the project root.");
+
+            var normalized = UnityMcpPluginEditor.NormalizeSkillsPath(outsideAbsolute);
+
+            // The path stayed absolute. Backslashes may have been flipped to forward
+            // slashes (for diff stability) — that is intentional and not a portability
+            // issue because the path is already a user-chosen external location.
+            Assert.IsTrue(Path.IsPathRooted(normalized),
+                $"Expected rooted path but got: {normalized}");
+            Assert.AreEqual(outsideAbsolute.Replace('\\', '/'), normalized);
+        }
+
+        [Test]
+        public void NormalizeSkillsPath_NullOrEmpty_ReturnedVerbatim()
+        {
+            // Defensive: pass-through for empty/null/whitespace. The caller decides what
+            // to do; we do not synthesise a default here.
+            Assert.AreEqual(string.Empty, UnityMcpPluginEditor.NormalizeSkillsPath(string.Empty));
+            Assert.AreEqual("   ", UnityMcpPluginEditor.NormalizeSkillsPath("   "));
+        }
+
+        // ----- Setter persistence tests -----------------------------------------------
+
+        [Test]
+        public void SkillsPath_Setter_PersistsRelativeForm_WhenGivenAbsoluteInsideProject()
+        {
+            var projectRoot = UnityMcpPluginEditor.ProjectRootPath;
+            var absInside = Path.Combine(projectRoot, ".claude", "skills");
+
+            UnityMcpPluginEditor.SkillsPath = absInside;
+
+            Assert.AreEqual(".claude/skills", UnityMcpPluginEditor.SkillsPath,
+                "Setter must normalise absolute-inside-project to forward-slash relative.");
+        }
+
+        [Test]
+        public void SkillsPath_Setter_PersistsRelativeForm_WhenGivenAlreadyRelative()
+        {
+            UnityMcpPluginEditor.SkillsPath = ".cursor/skills";
+
+            Assert.AreEqual(".cursor/skills", UnityMcpPluginEditor.SkillsPath);
+        }
+
+        [Test]
+        public void SkillsPath_Setter_PersistsForwardSlashes_WhenGivenBackslashRelative()
+        {
+            UnityMcpPluginEditor.SkillsPath = ".cursor\\skills";
+
+            Assert.AreEqual(".cursor/skills", UnityMcpPluginEditor.SkillsPath);
+        }
+
+        [Test]
+        public void SkillsPath_RoundTripsThroughSave_AsRelative()
+        {
+            // End-to-end: set an absolute-inside-project path, save, read the on-disk JSON,
+            // and confirm the persisted value is the relative form. This is the contract
+            // teams need so committing `UserSettings/AI-Game-Developer-Config.json` works.
+            var projectRoot = UnityMcpPluginEditor.ProjectRootPath;
+            var absInside = Path.Combine(projectRoot, ".claude", "skills");
+
+            UnityMcpPluginEditor.SkillsPath = absInside;
+            UnityMcpPluginEditor.Instance.Save();
+
+            var json = File.ReadAllText(UnityMcpPluginEditor.AssetsFileAbsolutePath);
+
+            // Persisted JSON uses camelCase: `"skillsPath": ".claude/skills"`.
+            Assert.That(json, Does.Contain("\".claude/skills\""),
+                $"Persisted JSON must contain the relative skillsPath. Got:\n{json}");
+            Assert.That(json, Does.Not.Contain(projectRoot.Replace("\\", "\\\\")),
+                $"Persisted JSON must not contain the machine-specific absolute project root. Got:\n{json}");
+        }
+
+        [Test]
+        public void SkillsPath_Setter_LeavesExternalAbsoluteAlone()
+        {
+            string outsideAbsolute;
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                var tempRoot = Path.GetTempPath().TrimEnd('\\', '/');
+                outsideAbsolute = Path.Combine(tempRoot, "external-skills");
+            }
+            else
+            {
+                outsideAbsolute = "/tmp/external-skills";
+            }
+
+            var projectRoot = UnityMcpPluginEditor.ProjectRootPath.Replace('\\', '/').TrimEnd('/') + "/";
+            Assume.That(outsideAbsolute.Replace('\\', '/').StartsWith(projectRoot, StringComparison.OrdinalIgnoreCase),
+                Is.False, "Test fixture must be outside the project root.");
+
+            UnityMcpPluginEditor.SkillsPath = outsideAbsolute;
+
+            // The user explicitly chose an external location — the setter MUST NOT rewrite
+            // it to a relative path. Forward-slash normalisation is acceptable.
+            Assert.AreEqual(outsideAbsolute.Replace('\\', '/'), UnityMcpPluginEditor.SkillsPath);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/SkillsPathNormalizationTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/SkillsPathNormalizationTests.cs
@@ -139,6 +139,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             // Defensive: pass-through for empty/null/whitespace. The caller decides what
             // to do; we do not synthesise a default here.
+            Assert.IsNull(UnityMcpPluginEditor.NormalizeSkillsPath(null));
             Assert.AreEqual(string.Empty, UnityMcpPluginEditor.NormalizeSkillsPath(string.Empty));
             Assert.AreEqual("   ", UnityMcpPluginEditor.NormalizeSkillsPath("   "));
         }
@@ -179,19 +180,38 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             // End-to-end: set an absolute-inside-project path, save, read the on-disk JSON,
             // and confirm the persisted value is the relative form. This is the contract
             // teams need so committing `UserSettings/AI-Game-Developer-Config.json` works.
+            //
+            // This test mutates the real on-disk config file via Save(); snapshot the
+            // original bytes up front and restore them after the assertions so the test
+            // does not leave the developer's config in a test-only state. TearDown only
+            // restores the in-memory value, not the file.
             var projectRoot = UnityMcpPluginEditor.ProjectRootPath;
             var absInside = Path.Combine(projectRoot, ".claude", "skills");
+            var configPath = UnityMcpPluginEditor.AssetsFileAbsolutePath;
+            var originalJson = File.Exists(configPath) ? File.ReadAllBytes(configPath) : null;
 
-            UnityMcpPluginEditor.SkillsPath = absInside;
-            UnityMcpPluginEditor.Instance.Save();
+            try
+            {
+                UnityMcpPluginEditor.SkillsPath = absInside;
+                UnityMcpPluginEditor.Instance.Save();
 
-            var json = File.ReadAllText(UnityMcpPluginEditor.AssetsFileAbsolutePath);
+                var json = File.ReadAllText(configPath);
 
-            // Persisted JSON uses camelCase: `"skillsPath": ".claude/skills"`.
-            Assert.That(json, Does.Contain("\".claude/skills\""),
-                $"Persisted JSON must contain the relative skillsPath. Got:\n{json}");
-            Assert.That(json, Does.Not.Contain(projectRoot.Replace("\\", "\\\\")),
-                $"Persisted JSON must not contain the machine-specific absolute project root. Got:\n{json}");
+                // Persisted JSON uses camelCase: `"skillsPath": ".claude/skills"`.
+                Assert.That(json, Does.Contain("\".claude/skills\""),
+                    $"Persisted JSON must contain the relative skillsPath. Got:\n{json}");
+                // Guard against both backslash-encoded and forward-slash forms of the
+                // project root leaking into the persisted JSON.
+                Assert.That(json, Does.Not.Contain(projectRoot.Replace("\\", "\\\\")),
+                    $"Persisted JSON must not contain the machine-specific absolute project root (backslash form). Got:\n{json}");
+                Assert.That(json, Does.Not.Contain(projectRoot.Replace('\\', '/')),
+                    $"Persisted JSON must not contain the machine-specific absolute project root (forward-slash form). Got:\n{json}");
+            }
+            finally
+            {
+                if (originalJson != null)
+                    File.WriteAllBytes(configPath, originalJson);
+            }
         }
 
         [Test]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/SkillsPathNormalizationTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/SkillsPathNormalizationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa5619da674023a47a83a72f3521969b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- All 12 built-in `AiAgentConfigurator` impls now return a project-relative `SkillsPath` literal (e.g. `.claude/skills`) instead of `Path.Combine(ProjectRootPath, ...)`. The persisted `UserSettings/AI-Game-Developer-Config.json` is now portable across machines, so teams that commit it (to share `LogLevel`, etc.) no longer break every other member's checkout.
- `UnityMcpPluginEditor.SkillsPath` setter normalises on write via a new `NormalizeSkillsPath` helper: absolute-inside-project → forward-slash relative form; absolute-outside-project → left as-is; already-relative → backslashes flipped to forward slashes for cross-platform diff stability.
- `GetOrCreateConfig` runs the same normaliser once after deserialise. When the value actually changes it re-saves through the existing `wasCreated` path, so a committed absolute legacy value auto-heals to the relative form on first load.
- UI label/tooltip now resolves the relative `SkillsPath` to its absolute on-disk location via a new `ResolveAbsoluteSkillsPath` helper — users still see (and can copy) the full path.

## Test plan

- [x] New EditMode tests (`SkillsPathNormalizationTests`) cover the normaliser, the setter, the JSON round-trip, and the absolute-outside-project carve-out.
- [x] Full EditMode test suite (923 tests) passes locally, 0 failures.

Closes #761