### PR TITLE
fix(skills): persist SkillsPath as project-relative literal (#761)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfigurator.cs
@@ -557,9 +557,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             // Hide the unsupported label
             unsupportedLabel.style.display = DisplayStyle.None;
 
-            // Show the skills output path
-            pathLabel.text = ToDisplayPath(SkillsPath!);
-            pathLabel.tooltip = SkillsPath;
+            // Show the skills output path. SkillsPath is stored as a project-relative literal
+            // (e.g. ".claude/skills") so it is portable across machines, but the on-screen label
+            // should still display the absolute path the user expects to navigate / copy.
+            var absoluteSkillsPath = Path.IsPathRooted(SkillsPath!)
+                ? SkillsPath!
+                : Path.GetFullPath(Path.Combine(UnityMcpPluginEditor.ProjectRootPath, SkillsPath!));
+            pathLabel.text = ToDisplayPath(absoluteSkillsPath);
+            pathLabel.tooltip = absoluteSkillsPath;
 
             // Configure toggle (per-agent)
             toggleAutoGenerate.SetValueWithoutNotify(UnityMcpPluginEditor.IsAutoGenerateSkills(AgentId));

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/AntigravityConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/AntigravityConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Antigravity";
         public override string AgentId => "antigravity";
         public override string DownloadUrl => "https://antigravity.google/download";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".agent", "skills"); // https://codelabs.developers.google.com/getting-started-with-antigravity-skills#3
+        public override string? SkillsPath => ".agent/skills"; // https://codelabs.developers.google.com/getting-started-with-antigravity-skills#3
 
         protected override string? IconFileName => "antigravity-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClaudeCodeConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClaudeCodeConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "claude-code";
         public override string DownloadUrl => "https://docs.anthropic.com/en/docs/claude-code/overview";
         public override string TutorialUrl => "https://youtu.be/Sknh2p12W8c";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
+        public override string? SkillsPath => ".claude/skills";
 
         protected override string? IconFileName => "claude-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClineConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/ClineConfigurator.cs
@@ -27,7 +27,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Cline";
         public override string AgentId => "cline";
         public override string DownloadUrl => "https://cline.bot/";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".cline", "skills"); // https://docs.cline.bot/customization/skills
+        public override string? SkillsPath => ".cline/skills"; // https://docs.cline.bot/customization/skills
 
         protected override string? IconFileName => "cline-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CodexConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CodexConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
     {
         const string EnvVarNameAuthToken = "GAME_DEV_AUTH_TOKEN";
 
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".agents", "skills");
+        public override string? SkillsPath => ".agents/skills";
         public override string AgentName => "Codex";
         public override string AgentId => "codex";
         public override string DownloadUrl => "https://openai.com/codex/";

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CursorConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/CursorConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "cursor";
         public override string DownloadUrl => "https://cursor.com/download";
         public override string TutorialUrl => "https://www.youtube.com/watch?v=dyk-4gTolSU";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".cursor", "skills");
+        public override string? SkillsPath => ".cursor/skills";
 
         protected override string? IconFileName => "cursor-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GeminiConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GeminiConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Gemini";
         public override string AgentId => "gemini";
         public override string DownloadUrl => "https://geminicli.com/docs/get-started/installation/";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".gemini", "skills");
+        public override string? SkillsPath => ".gemini/skills";
 
         protected override string? IconFileName => "gemini-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/GitHubCopilotCliConfigurator.cs
@@ -28,7 +28,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "GitHub Copilot CLI";
         public override string AgentId => "github-copilot-cli";
         public override string DownloadUrl => "https://github.com/features/copilot/cli";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
+        public override string? SkillsPath => ".claude/skills";
 
         protected override string? IconFileName => "github-copilot-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/KiloCodeConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/KiloCodeConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Kilo Code";
         public override string AgentId => "kilo-code";
         public override string DownloadUrl => "https://app.kilo.ai/get-started";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".kilocode", "skills"); // https://kilo.ai/docs/customize/skills
+        public override string? SkillsPath => ".kilocode/skills"; // https://kilo.ai/docs/customize/skills
 
         protected override string? IconFileName => "kilo-code-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/OpenCodeConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/OpenCodeConfigurator.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Open Code";
         public override string AgentId => "open-code";
         public override string DownloadUrl => "https://opencode.ai/download";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".opencode", "skills"); // https://opencode.ai/docs/skills/
+        public override string? SkillsPath => ".opencode/skills"; // https://opencode.ai/docs/skills/
 
         protected override string? IconFileName => "open-code-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/RiderConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/RiderConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentName => "Rider (Junie)";
         public override string AgentId => "rider-junie";
         public override string DownloadUrl => "https://www.jetbrains.com/rider/download/";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".junie", "skills");
+        public override string? SkillsPath => ".junie/skills";
 
         protected override string? IconFileName => "rider-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCodeCopilotConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCodeCopilotConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "vscode-copilot";
         public override string DownloadUrl => "https://code.visualstudio.com/download";
         public override string TutorialUrl => "https://www.youtube.com/watch?v=ZhP7Ju91mOE";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".claude", "skills");
+        public override string? SkillsPath => ".claude/skills";
 
         protected override string? IconFileName => "vs-code-64.png";
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCopilotConfigurator.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/Impl/VisualStudioCopilotConfigurator.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public override string AgentId => "vs-copilot";
         public override string DownloadUrl => "https://visualstudio.microsoft.com/downloads/";
         public override string TutorialUrl => "https://www.youtube.com/watch?v=RGdak4T69mc";
-        public override string? SkillsPath => Path.Combine(ProjectRootPath, ".github", "skills");
+        public override string? SkillsPath => ".github/skills";
 
         protected override string? IconFileName => "visual-studio-64.png";
 


### PR DESCRIPTION
## Summary

Closes the portability bug from #761: `UserSettings/AI-Game-Developer-Config.json` now stays portable across team members. Previously each built-in `AiAgentConfigurator` returned an absolute `SkillsPath` via `Path.Combine(ProjectRootPath, …)` and every "Generate Skills" / auto-generate cycle wrote that machine-specific path to the config file. Any teammate who committed the file pulled a path like `C:\Users\alice\…` that did not exist on their machine, and manual edits were reverted on the next UI interaction.

The plugin already accepts relative `SkillsPath` on the **read** side — `UnityMcpPluginEditor.Config.cs` `SkillsRootFolderAbsolutePath` resolves non-rooted values against `ProjectRootPath`, the default in `UnityMcpPlugin.Config.cs` is already `".claude/skills"`, and `Skills.Generate` / the CLI both expect relative values. Only the **writers** were wrong. Fixing the configurators in place resolves the bug with no read-path, migration, or test changes.

## Changes

- **11 built-in configurators** (Antigravity, Claude Code, Cline, Codex, Cursor, Gemini, GitHub Copilot CLI, Kilo Code, Open Code, Rider, Visual Studio (Copilot), Visual Studio Code (Copilot)) now return a literal relative path with forward slashes — e.g. `".claude/skills"`, `".cursor/skills"`, `".github/skills"`. Forward slashes match the existing default value and keep the on-disk config diff deterministic across Windows / macOS / Linux.
- **`AiAgentConfigurator.cs` UI label** — `pathLabel.text` and `pathLabel.tooltip` resolve `SkillsPath` to its absolute form before display via `Path.GetFullPath(Path.Combine(ProjectRootPath, SkillsPath))`. The user still sees the full path they expect to copy or navigate, even though the stored value is relative.

## Verification

- Read-side path resolution unchanged — `SkillsRootFolderAbsolutePath` already handled `!Path.IsPathRooted` inputs.
- No tests reference `SkillsPath` or the literal paths we changed (`grep` in `Tests/Editor/` is empty).
- `unity-skill-generate` MCP tool still rejects absolute / `..` traversal user input on the API surface — only the internal "what does the configurator hand to the persisted config" path is touched.
- `CustomConfigurator` is unaffected — it surfaces `UnityMcpPluginEditor.SkillsPath` verbatim, so user-entered values flow through unchanged.

## Out of scope (intentional)

The issue suggests four optional follow-ons; I left them out so this PR stays minimal and reviewable:

- Setter-side normalization in `UnityMcpPluginEditor.SkillsPath` — a safety net only for `CustomConfigurator` users pasting an absolute path inside the project. Can land separately.
- Load-time migration for committed configs that already contain an absolute path. After this PR, one "Generate Skills" click re-saves the value as relative; the in-place migration is a nice-to-have, not a hard requirement.
- UI hint when `CustomConfigurator` input is absolute-and-inside-project.
- New EditMode test fixtures.

Closes #761