### PR TITLE
fix: set ConnectionConfig.ProjectRootPath in BuildMcpPluginIfNeeded

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
@@ -16,10 +16,28 @@ namespace com.IvanMurzak.Unity.MCP
 {
     public partial class UnityMcpPluginEditor
     {
+        /// <summary>
+        /// Editor-only test accessor for the underlying <see cref="UnityConnectionConfig"/>.
+        /// The field is <c>protected</c> on <see cref="UnityMcpPlugin"/>; this accessor exposes
+        /// it to the Editor test assembly (via <c>InternalsVisibleTo</c>) so tests can verify
+        /// state that is written through the plugin's build path.
+        /// </summary>
+        internal UnityConnectionConfig ConnectionConfigForTests => unityConnectionConfig;
+
         public UnityMcpPluginEditor BuildMcpPluginIfNeeded()
         {
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
             var loggerProvider = BuildLoggerProvider();
+
+            // Feed the host project root into the connection config BEFORE the plugin is built.
+            // McpPlugin's ctor calls GenerateSkillFilesIfNeeded() internally; it needs an anchor
+            // for the relative SkillsPath. Without this, the McpPlugin ctor logs an
+            // InvalidOperationException every Editor open / domain reload — see
+            // https://github.com/IvanMurzak/Unity-MCP/issues/766 (host-side cascade of upstream
+            // https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/107 /
+            // https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/108).
+            unityConnectionConfig.ProjectRootPath = ProjectRootPath;
+
             var built = _plugin.BuildOnce(() => BuildMcpPlugin(
                 version: BuildVersion(),
                 reflector: CreateDefaultReflector(),

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
@@ -37,6 +37,7 @@ namespace com.IvanMurzak.Unity.MCP
             // https://github.com/IvanMurzak/MCP-Plugin-dotnet/issues/107 /
             // https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/108).
             unityConnectionConfig.ProjectRootPath = ProjectRootPath;
+            _logger.LogTrace("Seeded ConnectionConfig.ProjectRootPath={path}", ProjectRootPath);
 
             var built = _plugin.BuildOnce(() => BuildMcpPlugin(
                 version: BuildVersion(),

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/BuildMcpPluginIfNeededProjectRootTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/BuildMcpPluginIfNeededProjectRootTests.cs
@@ -1,0 +1,47 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Regression coverage for issue #766: the McpPlugin 6.3.1 upgrade introduced an
+    /// <see cref="System.InvalidOperationException"/> at <see cref="com.IvanMurzak.McpPlugin.McpPlugin"/>
+    /// construction time whenever <c>ConnectionConfig.ProjectRootPath</c> is <c>null</c> and the
+    /// auto-fire skill-generation path is invoked with a relative <c>SkillsPath</c>.
+    ///
+    /// The Unity-MCP host now sets <see cref="UnityMcpPlugin.UnityConnectionConfig.ProjectRootPath"/>
+    /// in <see cref="UnityMcpPluginEditor.BuildMcpPluginIfNeeded"/> — once per build cycle, before
+    /// the underlying <see cref="com.IvanMurzak.McpPlugin.McpPlugin"/> is materialised.
+    ///
+    /// See also: https://github.com/IvanMurzak/Unity-MCP/issues/766,
+    /// https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/108.
+    /// </summary>
+    [TestFixture]
+    public class BuildMcpPluginIfNeededProjectRootTests
+    {
+        [Test]
+        public void BuildMcpPluginIfNeeded_SetsProjectRootPath_OnConnectionConfig()
+        {
+            UnityMcpPluginEditor.InitSingletonIfNeeded();
+            UnityMcpPluginEditor.Instance.BuildMcpPluginIfNeeded();
+
+            var config = UnityMcpPluginEditor.Instance.ConnectionConfigForTests;
+
+            Assert.AreEqual(
+                UnityMcpPluginEditor.ProjectRootPath,
+                config.ProjectRootPath,
+                "ConnectionConfig.ProjectRootPath must be set to UnityMcpPluginEditor.ProjectRootPath " +
+                "so the McpPlugin auto-fire skill-generation path does not throw InvalidOperationException.");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/BuildMcpPluginIfNeededProjectRootTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/BuildMcpPluginIfNeededProjectRootTests.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 {
@@ -29,10 +30,28 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
     [TestFixture]
     public class BuildMcpPluginIfNeededProjectRootTests
     {
+        private string? _originalProjectRootPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            UnityMcpPluginEditor.InitSingletonIfNeeded();
+            // Snapshot the field so unrelated tests / Editor state are unaffected by this
+            // fixture's mutation. Mirrors the pattern used by SkillsPathNormalizationTests
+            // for the SkillsPath field in the same folder.
+            _originalProjectRootPath = UnityMcpPluginEditor.Instance.ConnectionConfigForTests.ProjectRootPath;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Restore so unrelated tests / Editor state are unaffected.
+            UnityMcpPluginEditor.Instance.ConnectionConfigForTests.ProjectRootPath = _originalProjectRootPath;
+        }
+
         [Test]
         public void BuildMcpPluginIfNeeded_SetsProjectRootPath_OnConnectionConfig()
         {
-            UnityMcpPluginEditor.InitSingletonIfNeeded();
             UnityMcpPluginEditor.Instance.BuildMcpPluginIfNeeded();
 
             var config = UnityMcpPluginEditor.Instance.ConnectionConfigForTests;
@@ -42,6 +61,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 config.ProjectRootPath,
                 "ConnectionConfig.ProjectRootPath must be set to UnityMcpPluginEditor.ProjectRootPath " +
                 "so the McpPlugin auto-fire skill-generation path does not throw InvalidOperationException.");
+
+            // Guard the regression contract directly: the whole point of seeding
+            // ProjectRootPath before _plugin.BuildOnce is to prevent McpPlugin's ctor
+            // from logging InvalidOperationException via the relative-SkillsPath path.
+            // A future refactor that moved the assignment AFTER BuildOnce would still
+            // pass the equality assert above (because the field is set by the time we
+            // observe it), but McpPlugin would have logged the exception during the
+            // build. NoUnexpectedReceived() catches that regression — any uncaught log
+            // during the test body fails the test here.
+            LogAssert.NoUnexpectedReceived();
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/BuildMcpPluginIfNeededProjectRootTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Skills/BuildMcpPluginIfNeededProjectRootTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4023ded248d26df4ba50fe5ca6e3aa0e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Set `unityConnectionConfig.ProjectRootPath = UnityMcpPluginEditor.ProjectRootPath` once inside `UnityMcpPluginEditor.BuildMcpPluginIfNeeded()`, before the underlying `McpPlugin` is materialised. This is the chokepoint every (re)build path flows through, so the value is present when the McpPlugin ctor's auto-fire `GenerateSkillFilesIfNeeded` (and the `OnToolsUpdated` subscription) calls the new strict resolver from `MCP-Plugin-dotnet` 6.3.1.
- Adds an EditMode regression test `BuildMcpPluginIfNeeded_SetsProjectRootPath_OnConnectionConfig` plus a tiny `internal` accessor on `UnityMcpPluginEditor` so the test can read `unityConnectionConfig` without touching the Runtime assembly's visibility.
- Runtime path (`UnityMcpPluginRuntime`) intentionally untouched — in player builds there is no project root in the same sense, and the McpPlugin auto-fire wrappers correctly log + skip.

## Test plan

- [x] Target-specific local tests passed (see profile test.md) — EditMode: 924/924 passed, 0 failures. `SkillsPathNormalizationTests` (12) still green; no regression to the `#761` / `#762` persistence-layer fix.
- [x] Console after Editor open / domain reload no longer contains `InvalidOperationException: Cannot resolve relative SkillsPath '.claude/skills': no basePath was supplied and ConnectionConfig.ProjectRootPath is not set`.

Closes #766