### PR TITLE
feat: store team-wide 'do not show again' in ProjectSettings/ + migrate UpdateChecker per-user state to EditorPrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,14 @@ Create metallic golden material and attach it to a new sphere gameObject
 
 > Make sure `Agent` mode is enabled if using VS Code with Copilot
 
+## Disabling update notifications for the whole team
+
+The plugin shows an update popup at Editor startup when a newer version is available on OpenUPM. By default, each team member sees this popup until they individually click *"Do not show again"* (which is a per-user setting stored on their machine).
+
+For multi-person Unity projects where one engineer owns plugin versioning, you can disable the popup for the **entire team** by opening **Edit ▸ Project Settings ▸ AI Game Developer** and enabling *"Disable update notifications for the entire team"*. The setting is persisted to `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` and only needs to be set once per project — commit that file and every team member who pulls the commit will have the popup suppressed.
+
+The same toggle is also reachable via **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** in the menu bar.
+
 ## Advanced Features for LLM
 
 Unity MCP provides advanced tools that enable the LLM to work faster and more effectively, avoiding mistakes and self-correcting when errors occur. Everything is designed to achieve your goals efficiently.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/MenuItems.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/MenuItems.cs
@@ -27,6 +27,23 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         [MenuItem("Tools/AI Game Developer/Check for Updates", priority = 999)]
         public static void CheckForUpdates() => _ = UpdateChecker.CheckForUpdatesAsync(forceCheck: true);
 
+        // Team-shared kill-switch for the update popup. Toggling this writes through to
+        // ProjectSettings/AI-Game-Developer-UpdateSettings.asset (intended to be committed
+        // to VCS). The validate method renders the menu's check-mark to match current state.
+        // See https://github.com/IvanMurzak/Unity-MCP/issues/768.
+        private const string DisableUpdatesMenu = "Tools/AI Game Developer/Disable Update Notifications (Team)";
+
+        [MenuItem(DisableUpdatesMenu, priority = 1005)]
+        public static void ToggleDisableUpdatesForTeam()
+            => UpdateChecker.IsDisabledForProject = !UpdateChecker.IsDisabledForProject;
+
+        [MenuItem(DisableUpdatesMenu, validate = true)]
+        public static bool ToggleDisableUpdatesForTeamValidate()
+        {
+            Menu.SetChecked(DisableUpdatesMenu, UpdateChecker.IsDisabledForProject);
+            return true;
+        }
+
         [MenuItem("Tools/AI Game Developer/Server/Download Binaries", priority = 1000)]
         public static Task DownloadServer() => McpServerManager.DownloadAndUnpackBinary();
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs
@@ -1,0 +1,65 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using com.IvanMurzak.Unity.MCP.Editor.Utils;
+using UnityEditor;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.UI
+{
+    /// <summary>
+    /// Exposes Unity-MCP's team-shared update settings under
+    /// <c>Edit ▸ Project Settings ▸ AI Game Developer</c>.
+    /// </summary>
+    /// <remarks>
+    /// Mutations write through to <see cref="UnityMcpUpdateProjectSettings"/>, whose backing
+    /// asset (<c>ProjectSettings/AI-Game-Developer-UpdateSettings.asset</c>) is intended to be
+    /// committed to VCS. See https://github.com/IvanMurzak/Unity-MCP/issues/768.
+    /// </remarks>
+    internal static class UnityMcpProjectSettingsProvider
+    {
+        private const string SettingsPath = "Project/AI Game Developer";
+
+        [SettingsProvider]
+        public static SettingsProvider Create() => new SettingsProvider(SettingsPath, SettingsScope.Project)
+        {
+            label = "AI Game Developer",
+            guiHandler = _ =>
+            {
+                var settings = UnityMcpUpdateProjectSettings.instance;
+
+                EditorGUILayout.LabelField("Update Notifications", EditorStyles.boldLabel);
+
+                EditorGUI.BeginChangeCheck();
+                var newValue = EditorGUILayout.ToggleLeft(
+                    new GUIContent(
+                        "Disable update notifications for the entire team",
+                        "Stored in ProjectSettings/ and shared with everyone who clones this project. " +
+                        "When enabled, the update popup is suppressed for every team member, regardless " +
+                        "of their per-user 'Do not show again' state."),
+                    settings.DisableUpdateNotificationsForTeam);
+                if (EditorGUI.EndChangeCheck())
+                    settings.DisableUpdateNotificationsForTeam = newValue;
+
+                EditorGUILayout.Space();
+                EditorGUILayout.HelpBox(
+                    "This setting is stored in ProjectSettings/AI-Game-Developer-UpdateSettings.asset " +
+                    "and is shared with everyone who clones this project. The per-user 'Do not show again' " +
+                    "button on the update popup is unaffected by this setting.",
+                    MessageType.Info);
+            },
+            keywords = new HashSet<string> { "AI", "MCP", "Update", "Notifications", "Team", "Game", "Developer" }
+        };
+    }
+}
+#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs
@@ -9,7 +9,6 @@
 */
 
 #nullable enable
-#if UNITY_EDITOR
 using System.Collections.Generic;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using UnityEditor;
@@ -36,8 +35,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             label = "AI Game Developer",
             guiHandler = _ =>
             {
-                var settings = UnityMcpUpdateProjectSettings.instance;
-
                 EditorGUILayout.LabelField("Update Notifications", EditorStyles.boldLabel);
 
                 EditorGUI.BeginChangeCheck();
@@ -47,9 +44,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                         "Stored in ProjectSettings/ and shared with everyone who clones this project. " +
                         "When enabled, the update popup is suppressed for every team member, regardless " +
                         "of their per-user 'Do not show again' state."),
-                    settings.DisableUpdateNotificationsForTeam);
+                    UpdateChecker.IsDisabledForProject);
                 if (EditorGUI.EndChangeCheck())
-                    settings.DisableUpdateNotificationsForTeam = newValue;
+                    UpdateChecker.IsDisabledForProject = newValue;
 
                 EditorGUILayout.Space();
                 EditorGUILayout.HelpBox(
@@ -58,8 +55,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     "button on the update popup is unaffected by this setting.",
                     MessageType.Info);
             },
-            keywords = new HashSet<string> { "AI", "MCP", "Update", "Notifications", "Team", "Game", "Developer" }
+            keywords = new HashSet<string>
+            {
+                "AI", "MCP", "Unity-MCP", "OpenUPM", "Update", "Notifications", "Team", "Game", "Developer"
+            }
         };
     }
 }
-#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d9b5c3f0e7f5a2b9c4d6e8f0a1b2c3d
+guid: 2b246a7c9c48446c872ee2e021cbcfd2
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/UnityMcpProjectSettingsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d9b5c3f0e7f5a2b9c4d6e8f0a1b2c3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
@@ -239,7 +239,12 @@ namespace com.IvanMurzak.Unity.MCP
                 return value;
 
             // Always use forward slashes in the persisted form for cross-platform diff stability.
-            var normalized = value.Replace('\\', '/');
+            // The `!` is required because the Unity Editor C# compiler does not honor
+            // `[NotNullWhen(false)]` on `string.IsNullOrWhiteSpace`, so it does not narrow
+            // `value` (declared `string?`) to non-null after the early-return guard above and
+            // would otherwise emit CS8602 here. The runtime check above already establishes
+            // `value` is non-null at this point.
+            var normalized = value!.Replace('\\', '/');
 
             if (!Path.IsPathRooted(normalized))
                 return normalized;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs
@@ -1,0 +1,60 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using UnityEditor;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Utils
+{
+    /// <summary>
+    /// Team-shared settings for the Unity-MCP update checker, persisted under
+    /// <c>ProjectSettings/AI-Game-Developer-UpdateSettings.asset</c>.
+    /// </summary>
+    /// <remarks>
+    /// Uses Unity's <see cref="ScriptableSingleton{T}"/> + <see cref="FilePathAttribute"/> pattern
+    /// for project-scoped editor settings. The asset file is plain YAML, diff-friendly, and
+    /// lives in the folder teams commit to VCS — so flipping <see cref="DisableUpdateNotificationsForTeam"/>
+    /// once and committing the resulting asset disables the update popup for every team member
+    /// who pulls that commit.
+    ///
+    /// This complements (does not replace) the per-user "Do not show again" flag stored via
+    /// <see cref="EditorPrefs"/>. Precedence is enforced in
+    /// <see cref="UpdateChecker.ShouldCheckForUpdates"/>: the project flag short-circuits
+    /// the check before the per-user flag is consulted.
+    ///
+    /// See <see href="https://github.com/IvanMurzak/Unity-MCP/issues/768"/>.
+    /// </remarks>
+    [FilePath("ProjectSettings/AI-Game-Developer-UpdateSettings.asset", FilePathAttribute.Location.ProjectFolder)]
+    internal sealed class UnityMcpUpdateProjectSettings : ScriptableSingleton<UnityMcpUpdateProjectSettings>
+    {
+        [SerializeField] private bool disableUpdateNotificationsForTeam;
+
+        /// <summary>
+        /// When <c>true</c>, the update popup is suppressed for every team member who has this
+        /// asset in their checkout — regardless of any per-user <see cref="EditorPrefs"/> state.
+        /// </summary>
+        /// <remarks>
+        /// Setter persists immediately via <see cref="ScriptableSingleton{T}.Save"/> with
+        /// <c>saveAsText: true</c> so the resulting asset is YAML (diff-friendly).
+        /// </remarks>
+        public bool DisableUpdateNotificationsForTeam
+        {
+            get => disableUpdateNotificationsForTeam;
+            set
+            {
+                if (disableUpdateNotificationsForTeam == value)
+                    return;
+                disableUpdateNotificationsForTeam = value;
+                Save(true);
+            }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs
@@ -32,6 +32,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
     ///
     /// See <see href="https://github.com/IvanMurzak/Unity-MCP/issues/768"/>.
     /// </remarks>
+    /// <remarks>
+    /// <see cref="FilePathAttribute.Location.ProjectFolder"/> resolves the relative path against
+    /// the Unity project root (the folder that contains <c>Assets/</c>, <c>Packages/</c>, and
+    /// <c>ProjectSettings/</c>) — NOT against <c>Assets/</c>. That places the asset alongside
+    /// other team-shared editor settings such as <c>ProjectSettings/EditorSettings.asset</c>.
+    /// </remarks>
     [FilePath("ProjectSettings/AI-Game-Developer-UpdateSettings.asset", FilePathAttribute.Location.ProjectFolder)]
     internal sealed class UnityMcpUpdateProjectSettings : ScriptableSingleton<UnityMcpUpdateProjectSettings>
     {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c8a4b2e9d6e4f1a8b3c5d7e9f1a2b3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UnityMcpUpdateProjectSettings.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7c8a4b2e9d6e4f1a8b3c5d7e9f1a2b3c
+guid: 984cc7c4404e4b5194c6f03fa57697c2
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -15,9 +15,9 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Editor.UI;
-using Extensions.Unity.PlayerPrefsEx;
 using Microsoft.Extensions.Logging;
 using UnityEditor;
+using UnityEngine;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Utils
@@ -30,6 +30,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
     /// install for end users. GitHub releases are published before the OpenUPM build pipeline
     /// finishes, so polling GitHub releases would prompt users to update to a version that is
     /// not yet installable. See https://github.com/IvanMurzak/Unity-MCP/issues/694.
+    ///
+    /// Two opt-out layers gate the popup, in this order:
+    ///   1. <see cref="IsDisabledForProject"/> — team-shared, stored in
+    ///      <c>ProjectSettings/AI-Game-Developer-UpdateSettings.asset</c> via
+    ///      <see cref="UnityMcpUpdateProjectSettings"/>. Set this once and commit it to
+    ///      disable the popup for every team member who clones the project. See
+    ///      https://github.com/IvanMurzak/Unity-MCP/issues/768.
+    ///   2. <see cref="IsDoNotShowAgain"/> — per-user, stored in <see cref="EditorPrefs"/>
+    ///      (NOT <see cref="PlayerPrefs"/> — clearing in-game <c>PlayerPrefs</c> must not
+    ///      wipe the editor flag). See https://github.com/IvanMurzak/Unity-MCP/issues/755.
     /// </remarks>
     public static class UpdateChecker
     {
@@ -50,9 +60,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         // elsewhere in this package. The 10s timeout covers OpenUPM's slowest realistic responses.
         private static readonly HttpClient HttpClient = CreateHttpClient();
 
-        private static PlayerPrefsBool DoNotShowAgain = new("Unity-MCP.UpdateChecker.DoNotShowAgain");
-        private static PlayerPrefsString NextCheckTime = new("Unity-MCP.UpdateChecker.NextCheckTime");
-        private static PlayerPrefsString SkippedVersion = new("Unity-MCP.UpdateChecker.SkippedVersion");
+        // EditorPrefs is global to the Unity install, so the keys are namespaced by package id
+        // AND by a stable per-project token (Application.dataPath hash) to keep parallel projects
+        // from stomping on each other's state. See #755 for the migration rationale.
+        private static readonly string ProjectKeyPrefix =
+            $"{PackageId}.{Application.dataPath.GetHashCode():X8}.UpdateChecker.";
+        private static readonly string KeyDoNotShowAgain = ProjectKeyPrefix + "DoNotShowAgain";
+        private static readonly string KeyNextCheckTime  = ProjectKeyPrefix + "NextCheckTime";
+        private static readonly string KeySkippedVersion = ProjectKeyPrefix + "SkippedVersion";
 
         private static bool isChecking = false;
         private static string? latestVersion = null;
@@ -66,16 +81,33 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         }
 
         /// <summary>
-        /// Gets whether the user has chosen to never show the update popup again.
+        /// Gets whether the team-wide kill-switch is enabled for this project. When <c>true</c>,
+        /// the popup is suppressed for every team member who has the
+        /// <c>ProjectSettings/AI-Game-Developer-UpdateSettings.asset</c> file in their checkout,
+        /// regardless of their per-user <see cref="IsDoNotShowAgain"/> state.
         /// </summary>
+        /// <remarks>
+        /// Stored in <see cref="UnityMcpUpdateProjectSettings"/> — a <see cref="ScriptableSingleton{T}"/>
+        /// persisted under <c>ProjectSettings/</c>. The asset is intended to be committed to VCS.
+        /// </remarks>
+        public static bool IsDisabledForProject
+        {
+            get => UnityMcpUpdateProjectSettings.instance.DisableUpdateNotificationsForTeam;
+            set => UnityMcpUpdateProjectSettings.instance.DisableUpdateNotificationsForTeam = value;
+        }
+
+        /// <summary>
+        /// Gets whether the user has chosen to never show the update popup again on this machine.
+        /// </summary>
+        /// <remarks>
+        /// Stored in <see cref="EditorPrefs"/> (per-user, per-Unity-install) — not in
+        /// <see cref="PlayerPrefs"/>. Clearing in-game <c>PlayerPrefs</c> must not silently
+        /// reset the editor flag. See https://github.com/IvanMurzak/Unity-MCP/issues/755.
+        /// </remarks>
         public static bool IsDoNotShowAgain
         {
-            get => DoNotShowAgain.Value;
-            set
-            {
-                DoNotShowAgain.Value = value;
-                PlayerPrefsEx.Save();
-            }
+            get => EditorPrefs.GetBool(KeyDoNotShowAgain, false);
+            set => EditorPrefs.SetBool(KeyDoNotShowAgain, value);
         }
 
         /// <summary>
@@ -112,16 +144,27 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         }
 
         /// <summary>
-        /// Determines if we should check for updates based on user preferences and cooldown.
+        /// Determines if we should check for updates based on the team-shared project flag,
+        /// the per-user opt-out, and the cooldown timer.
         /// </summary>
+        /// <remarks>
+        /// Precedence (in order):
+        ///   1. <see cref="IsDisabledForProject"/> — team-wide kill-switch wins over everything.
+        ///   2. <see cref="IsDoNotShowAgain"/> — per-user opt-out.
+        ///   3. The cooldown timestamp stored in <see cref="EditorPrefs"/>.
+        /// </remarks>
         public static bool ShouldCheckForUpdates()
         {
-            // Don't check if user opted out
-            if (DoNotShowAgain.Value)
+            // 1. Team-wide kill-switch — short-circuits before any per-user state is consulted.
+            if (IsDisabledForProject)
                 return false;
 
-            // Check if we're still in cooldown period
-            var nextCheckTimeStr = NextCheckTime.Value;
+            // 2. Per-user opt-out.
+            if (IsDoNotShowAgain)
+                return false;
+
+            // 3. Cooldown.
+            var nextCheckTimeStr = EditorPrefs.GetString(KeyNextCheckTime, string.Empty);
             if (!string.IsNullOrEmpty(nextCheckTimeStr))
             {
                 if (DateTime.TryParse(nextCheckTimeStr, out var nextCheckDateTime))
@@ -139,19 +182,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         /// </summary>
         public static void SkipVersion(string version)
         {
-            SkippedVersion.Value = version;
-            PlayerPrefsEx.Save();
+            EditorPrefs.SetString(KeySkippedVersion, version);
         }
 
         /// <summary>
-        /// Clears all update checker preferences (useful for testing).
+        /// Clears all per-user update-checker preferences (useful for testing and for the
+        /// "Reset Update Preferences" debug menu).
         /// </summary>
+        /// <remarks>
+        /// This intentionally does NOT reset <see cref="IsDisabledForProject"/> — that flag is
+        /// team-shared via <c>ProjectSettings/</c>, and clearing it from a debug menu would
+        /// produce a spurious diff in a committed asset (potentially surprising other team
+        /// members). The team flag is reset only through the Project Settings UI or
+        /// <c>Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)</c>.
+        /// </remarks>
         public static void ClearPreferences()
         {
-            DoNotShowAgain.Value = false;
-            NextCheckTime.Value = string.Empty;
-            SkippedVersion.Value = string.Empty;
-            PlayerPrefsEx.Save();
+            EditorPrefs.DeleteKey(KeyDoNotShowAgain);
+            EditorPrefs.DeleteKey(KeyNextCheckTime);
+            EditorPrefs.DeleteKey(KeySkippedVersion);
         }
 
         /// <summary>
@@ -185,7 +234,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
                 latestVersion = fetched;
 
                 // Check if this version was skipped
-                var skippedVersion = SkippedVersion.Value;
+                var skippedVersion = EditorPrefs.GetString(KeySkippedVersion, string.Empty);
                 if (!string.IsNullOrEmpty(skippedVersion) && skippedVersion == fetched && !forceCheck)
                 {
                     return;
@@ -220,8 +269,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
                 // Set next allowed check time to enforce cooldown (only for automatic checks)
                 if (!forceCheck)
                 {
-                    NextCheckTime.Value = DateTime.UtcNow.AddHours(1).ToString("O");
-                    PlayerPrefsEx.Save();
+                    EditorPrefs.SetString(KeyNextCheckTime, DateTime.UtcNow.AddHours(1).ToString("O"));
                 }
                 isChecking = false;
             }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -61,13 +61,42 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         private static readonly HttpClient HttpClient = CreateHttpClient();
 
         // EditorPrefs is global to the Unity install, so the keys are namespaced by package id
-        // AND by a stable per-project token (Application.dataPath hash) to keep parallel projects
-        // from stomping on each other's state. See #755 for the migration rationale.
+        // AND by a stable per-project token (FNV-1a hash of Application.dataPath) to keep parallel
+        // projects from stomping on each other's state. See #755 for the migration rationale.
+        //
+        // FNV-1a (not string.GetHashCode()) because Unity is migrating to CoreCLR (preview in 6.x),
+        // and on CoreCLR string.GetHashCode() is randomized per process — keys would change on
+        // every editor restart and per-user state (DoNotShowAgain, cooldown, skipped version)
+        // would be silently lost. FNV-1a is byte-stable across runtimes and across machines.
+        //
+        // Caveat: two distinct Unity projects that happen to live at the same Application.dataPath
+        // (e.g. user copies a project folder, deletes the original, and opens the copy at the same
+        // location) will share EditorPrefs state. Acceptable for a "do not show again" flag.
         private static readonly string ProjectKeyPrefix =
-            $"{PackageId}.{Application.dataPath.GetHashCode():X8}.UpdateChecker.";
+            $"{PackageId}.{Fnv1a32(Application.dataPath):X8}.UpdateChecker.";
         private static readonly string KeyDoNotShowAgain = ProjectKeyPrefix + "DoNotShowAgain";
-        private static readonly string KeyNextCheckTime  = ProjectKeyPrefix + "NextCheckTime";
+        private static readonly string KeyNextCheckTime = ProjectKeyPrefix + "NextCheckTime";
         private static readonly string KeySkippedVersion = ProjectKeyPrefix + "SkippedVersion";
+
+        /// <summary>
+        /// Deterministic 32-bit FNV-1a hash of a UTF-16 string. Stable across .NET runtimes
+        /// (Mono and CoreCLR) and across machines — unlike <see cref="string.GetHashCode"/>,
+        /// which is randomized per process under CoreCLR.
+        /// </summary>
+        private static uint Fnv1a32(string input)
+        {
+            const uint offsetBasis = 2166136261u;
+            const uint prime = 16777619u;
+            var hash = offsetBasis;
+            for (int i = 0; i < input.Length; i++)
+            {
+                hash ^= (byte)(input[i] & 0xFF);
+                hash *= prime;
+                hash ^= (byte)((input[i] >> 8) & 0xFF);
+                hash *= prime;
+            }
+            return hash;
+        }
 
         private static bool isChecking = false;
         private static string? latestVersion = null;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/README.md
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/README.md
@@ -410,6 +410,14 @@ Create metallic golden material and attach it to a new sphere gameObject
 
 > Make sure `Agent` mode is enabled if using VS Code with Copilot
 
+## Disabling update notifications for the whole team
+
+The plugin shows an update popup at Editor startup when a newer version is available on OpenUPM. By default, each team member sees this popup until they individually click *"Do not show again"* (which is a per-user setting stored on their machine).
+
+For multi-person Unity projects where one engineer owns plugin versioning, you can disable the popup for the **entire team** by opening **Edit ▸ Project Settings ▸ AI Game Developer** and enabling *"Disable update notifications for the entire team"*. The setting is persisted to `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` and only needs to be set once per project — commit that file and every team member who pulls the commit will have the popup suppressed.
+
+The same toggle is also reachable via **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** in the menu bar.
+
 ## Advanced Features for LLM
 
 Unity MCP provides advanced tools that enable the LLM to work faster and more effectively, avoiding mistakes and self-correcting when errors occur. Everything is designed to achieve your goals efficiently.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
@@ -20,15 +20,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         [SetUp]
         public void SetUp()
         {
-            // Clear all preferences before each test to ensure clean state
+            // Clear all per-user preferences AND the team-shared project flag before each
+            // test. ClearPreferences() intentionally does NOT reset IsDisabledForProject
+            // (see its XML doc) — explicit reset here so the precedence tests start from a
+            // known false state regardless of what a prior test wrote.
             UpdateChecker.ClearPreferences();
+            UpdateChecker.IsDisabledForProject = false;
         }
 
         [TearDown]
         public void TearDown()
         {
-            // Clean up preferences after each test
+            // Mirror SetUp — leave both layers clean for any test that follows. Same rationale
+            // as above: ClearPreferences() does not touch the project flag, so reset it
+            // explicitly to keep tests order-independent.
             UpdateChecker.ClearPreferences();
+            UpdateChecker.IsDisabledForProject = false;
         }
 
         #region Version Comparison Tests
@@ -376,6 +383,57 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             UpdateChecker.ClearPreferences();
 
             Assert.IsTrue(UpdateChecker.ShouldCheckForUpdates());
+        }
+
+        // Team-shared kill-switch tests — see https://github.com/IvanMurzak/Unity-MCP/issues/768.
+        // The project flag must short-circuit ShouldCheckForUpdates() BEFORE the per-user
+        // DoNotShowAgain check, so flipping it on suppresses the popup for the whole team
+        // regardless of individual users' EditorPrefs state.
+
+        [Test]
+        public void ShouldCheckForUpdates_ProjectDisabled_ReturnsFalse()
+        {
+            UpdateChecker.IsDisabledForProject = true;
+
+            Assert.IsFalse(UpdateChecker.ShouldCheckForUpdates());
+        }
+
+        [Test]
+        public void ShouldCheckForUpdates_ProjectDisabled_TakesPrecedenceOverPerUserFlag()
+        {
+            // Project flag ON, per-user flag OFF — popup must still be suppressed.
+            UpdateChecker.IsDisabledForProject = true;
+            UpdateChecker.IsDoNotShowAgain = false;
+
+            Assert.IsFalse(UpdateChecker.ShouldCheckForUpdates());
+        }
+
+        [Test]
+        public void ShouldCheckForUpdates_ProjectEnabled_FallsBackToPerUser()
+        {
+            // Project flag OFF, per-user flag ON — popup is still suppressed by the per-user
+            // layer. Pins the precedence ordering: project flag does NOT mean "force show",
+            // only "force hide".
+            UpdateChecker.IsDisabledForProject = false;
+            UpdateChecker.IsDoNotShowAgain = true;
+
+            Assert.IsFalse(UpdateChecker.ShouldCheckForUpdates());
+        }
+
+        [Test]
+        public void ClearPreferences_DoesNotResetProjectFlag()
+        {
+            // ClearPreferences() is the per-user reset (also wired into the "Reset Update
+            // Preferences" debug menu). It must NOT touch the team-shared project flag —
+            // doing so would produce a spurious diff in a committed asset and surprise other
+            // team members.
+            UpdateChecker.IsDisabledForProject = true;
+
+            UpdateChecker.ClearPreferences();
+
+            Assert.IsTrue(UpdateChecker.IsDisabledForProject,
+                "ClearPreferences() reset the project flag — that flag belongs to ProjectSettings/ and " +
+                "must only be mutated via the Project Settings UI or the Tools menu toggle.");
         }
 
         #endregion

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
@@ -9,6 +9,7 @@
 */
 
 #nullable enable
+using System.IO;
 using NUnit.Framework;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 
@@ -17,6 +18,38 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
     [TestFixture]
     public class UpdateCheckerTests
     {
+        // ProjectSettings/AI-Game-Developer-UpdateSettings.asset is intended to be a deliberate
+        // engineer act (commit it to disable team-wide notifications). If a consumer project runs
+        // the EditMode suite without that asset on disk, none of these tests may leave it behind:
+        // doing so would surface as a spurious "untracked file" diff. Snapshot existence + the
+        // pre-existing value at fixture entry, then restore at fixture exit (delete the asset if
+        // it didn't pre-exist; otherwise reset it to its original value).
+        private const string ProjectSettingsAssetPath =
+            "ProjectSettings/AI-Game-Developer-UpdateSettings.asset";
+
+        private bool _projectSettingsAssetPreExisted;
+        private bool _originalIsDisabledForProject;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _projectSettingsAssetPreExisted = File.Exists(ProjectSettingsAssetPath);
+            _originalIsDisabledForProject = UpdateChecker.IsDisabledForProject;
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            // Restore the user-visible state of the asset to what it was at fixture entry. If the
+            // asset did not pre-exist, force it false (early-exit may or may not fire depending on
+            // the last test) and then delete the file from disk so the consumer's working tree is
+            // clean. If it did pre-exist, just restore the original value via the setter (which
+            // will short-circuit if no test mutated it).
+            UpdateChecker.IsDisabledForProject = _originalIsDisabledForProject;
+            if (!_projectSettingsAssetPreExisted && File.Exists(ProjectSettingsAssetPath))
+                File.Delete(ProjectSettingsAssetPath);
+        }
+
         [SetUp]
         public void SetUp()
         {
@@ -24,8 +57,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             // test. ClearPreferences() intentionally does NOT reset IsDisabledForProject
             // (see its XML doc) — explicit reset here so the precedence tests start from a
             // known false state regardless of what a prior test wrote.
+            //
+            // Guard the project-flag reset behind a read so the setter's early-exit short-circuit
+            // fires when it's already false. Otherwise SetUp would call Save(true) on first run
+            // (when the asset doesn't exist) or after any test that flipped it on, materializing
+            // ProjectSettings/AI-Game-Developer-UpdateSettings.asset on disk and producing a
+            // spurious committed-asset diff in a consumer project that runs the EditMode suite.
             UpdateChecker.ClearPreferences();
-            UpdateChecker.IsDisabledForProject = false;
+            if (UpdateChecker.IsDisabledForProject)
+                UpdateChecker.IsDisabledForProject = false;
         }
 
         [TearDown]
@@ -33,9 +73,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             // Mirror SetUp — leave both layers clean for any test that follows. Same rationale
             // as above: ClearPreferences() does not touch the project flag, so reset it
-            // explicitly to keep tests order-independent.
+            // explicitly to keep tests order-independent. Same early-exit guard as SetUp.
             UpdateChecker.ClearPreferences();
-            UpdateChecker.IsDisabledForProject = false;
+            if (UpdateChecker.IsDisabledForProject)
+                UpdateChecker.IsDisabledForProject = false;
         }
 
         #region Version Comparison Tests

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -410,6 +410,14 @@ Create metallic golden material and attach it to a new sphere gameObject
 
 > Asegúrate de que el modo `Agent` esté activado si usas VS Code con Copilot
 
+## Desactivar las notificaciones de actualización para todo el equipo
+
+El plugin muestra una ventana emergente de actualización al iniciar el Editor cuando hay una versión nueva disponible en OpenUPM. Por defecto, cada miembro del equipo ve esta ventana hasta que pulsa *"No volver a mostrar"* (que es una configuración por usuario almacenada en su máquina).
+
+En proyectos Unity con varios miembros, donde un ingeniero gestiona las versiones del plugin, puedes desactivar la ventana emergente para **todo el equipo** abriendo **Edit ▸ Project Settings ▸ AI Game Developer** y activando *"Disable update notifications for the entire team"*. El ajuste se guarda en `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` y solo debe configurarse una vez por proyecto — al confirmar (commit) ese archivo, todos los miembros del equipo que descarguen el commit verán la ventana suprimida.
+
+El mismo conmutador también está disponible en **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** en la barra de menús.
+
 ## Funcionalidades avanzadas para LLM
 
 Unity MCP proporciona herramientas avanzadas que permiten al LLM trabajar de forma más rápida y efectiva, evitando errores y autocorrigiéndose cuando ocurren. Todo está diseñado para alcanzar tus objetivos de manera eficiente.

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -410,6 +410,14 @@ Create metallic golden material and attach it to a new sphere gameObject
 
 > VS Code で Copilot を使用している場合は、`Agent` モードが有効になっていることを確認してください
 
+## チーム全体の更新通知を無効化する
+
+このプラグインは、OpenUPM 上で新しいバージョンが利用可能になると Editor 起動時にアップデートのポップアップを表示します。デフォルトでは、各チームメンバーが自分で *"Do not show again"* をクリックするまでこのポップアップが表示され続けます（これは各ユーザーのマシン上に保存される個人設定です）。
+
+プラグインのバージョン管理を 1 人のエンジニアが担当している複数人での Unity プロジェクトでは、**Edit ▸ Project Settings ▸ AI Game Developer** を開き *"Disable update notifications for the entire team"* を有効にすることで、**チーム全体**でこのポップアップを無効化できます。設定は `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` に保存され、プロジェクトごとに一度だけ設定すれば十分です — このファイルをコミットすると、そのコミットを取り込んだすべてのチームメンバーでポップアップが抑制されます。
+
+同じ切り替えはメニューバーの **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** からも利用できます。
+
 ## LLM 向け高度な機能
 
 Unity MCP は、LLM がより速く効果的に作業できるよう高度なツールを提供し、ミスを回避し、エラー発生時には自己修正します。すべてがあなたの目標を効率的に達成するために設計されています。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -410,6 +410,14 @@ Create metallic golden material and attach it to a new sphere gameObject
 
 > 如果你在 VS Code 中使用 Copilot，请确保已启用 `Agent` 模式
 
+## 为整个团队关闭更新通知
+
+当 OpenUPM 上有新版本可用时，插件会在 Editor 启动时显示更新弹窗。默认情况下，每位团队成员都会看到这个弹窗，直到他们各自点击 *"Do not show again"*（这是保存在各自机器上的个人设置）。
+
+对于由一位工程师统一管理插件版本的多人 Unity 项目，你可以为**整个团队**关闭这个弹窗：打开 **Edit ▸ Project Settings ▸ AI Game Developer** 并启用 *"Disable update notifications for the entire team"*。该设置会保存到 `ProjectSettings/AI-Game-Developer-UpdateSettings.asset`，每个项目只需设置一次 —— 提交（commit）该文件后，所有拉取该提交的团队成员都将看不到这个弹窗。
+
+同样的开关也可以通过菜单栏中的 **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** 访问。
+
 ## LLM 高级功能
 
 Unity MCP 提供高级工具，使 LLM 能够更快、更有效地工作，避免错误并在出现问题时自我纠正。一切都设计为高效地实现你的目标。


### PR DESCRIPTION
## Summary

- Introduces a team-shared opt-out for the update popup, persisted under `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` via a `ScriptableSingleton<UnityMcpUpdateProjectSettings>` — the asset is YAML (diff-friendly) and intended to be committed to VCS, so a single engineer can disable the popup for the whole team with one commit.
- Migrates the per-user `UpdateChecker` state (`DoNotShowAgain`, `NextCheckTime`, `SkippedVersion`) from `PlayerPrefs` to `EditorPrefs` (closes #755 — clearing in-game `PlayerPrefs` no longer wipes the editor flag). Keys are namespaced by package id + hashed `Application.dataPath` to keep parallel Unity projects from colliding.
- Adds UI surfaces: a Project Settings page at `Edit ▸ Project Settings ▸ AI Game Developer` and a toggleable menu item at `Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)`.
- Precedence in `ShouldCheckForUpdates()`: project flag → per-user flag → cooldown. The project flag short-circuits the per-user check (team-wide kill-switch wins).
- `ClearPreferences()` intentionally does NOT reset the project flag — clearing a committed asset from a debug menu would surprise other team members.
- Docs: short "Disabling update notifications for the whole team" section added to the root README, the package README copy, and the es/ja/zh-CN translations.

## Test plan

- [x] 4 new tests in `UpdateCheckerTests` cover precedence and isolation:
  - `ShouldCheckForUpdates_ProjectDisabled_ReturnsFalse`
  - `ShouldCheckForUpdates_ProjectDisabled_TakesPrecedenceOverPerUserFlag`
  - `ShouldCheckForUpdates_ProjectEnabled_FallsBackToPerUser`
  - `ClearPreferences_DoesNotResetProjectFlag`
- [x] Local EditMode test gate: 928 tests, 0 failures.
- [x] PlayMode tests not applicable — all changes are Editor-only.
- [x] CLI tests not applicable — no `cli/` changes.

Closes #768
Closes #755