### PR TITLE
feat(menu): group Updates submenu under Tools/AI Game Developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ The plugin shows an update popup at Editor startup when a newer version is avail
 
 For multi-person Unity projects where one engineer owns plugin versioning, you can disable the popup for the **entire team** by opening **Edit ▸ Project Settings ▸ AI Game Developer** and enabling *"Disable update notifications for the entire team"*. The setting is persisted to `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` and only needs to be set once per project — commit that file and every team member who pulls the commit will have the popup suppressed.
 
-The same toggle is also reachable via **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** in the menu bar.
+The same toggle is also reachable via **Tools ▸ AI Game Developer ▸ Updates ▸ Disable Update Notifications (Team)** in the menu bar.
 
 ## Advanced Features for LLM
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/MenuItems.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/MenuItems.cs
@@ -24,16 +24,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         [MenuItem("Window/AI Game Developer — MCP %&a", priority = 1006)]
         public static void ShowWindow() => MainWindowEditor.ShowWindow();
 
-        [MenuItem("Tools/AI Game Developer/Check for Updates", priority = 999)]
+        [MenuItem("Tools/AI Game Developer/Updates/Check for Updates", priority = 999)]
         public static void CheckForUpdates() => _ = UpdateChecker.CheckForUpdatesAsync(forceCheck: true);
 
         // Team-shared kill-switch for the update popup. Toggling this writes through to
         // ProjectSettings/AI-Game-Developer-UpdateSettings.asset (intended to be committed
         // to VCS). The validate method renders the menu's check-mark to match current state.
         // See https://github.com/IvanMurzak/Unity-MCP/issues/768.
-        private const string DisableUpdatesMenu = "Tools/AI Game Developer/Disable Update Notifications (Team)";
+        private const string DisableUpdatesMenu = "Tools/AI Game Developer/Updates/Disable Update Notifications (Team)";
 
-        [MenuItem(DisableUpdatesMenu, priority = 1005)]
+        [MenuItem(DisableUpdatesMenu, priority = 1000)]
         public static void ToggleDisableUpdatesForTeam()
             => UpdateChecker.IsDisabledForProject = !UpdateChecker.IsDisabledForProject;
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -223,7 +223,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         /// team-shared via <c>ProjectSettings/</c>, and clearing it from a debug menu would
         /// produce a spurious diff in a committed asset (potentially surprising other team
         /// members). The team flag is reset only through the Project Settings UI or
-        /// <c>Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)</c>.
+        /// <c>Tools ▸ AI Game Developer ▸ Updates ▸ Disable Update Notifications (Team)</c>.
         /// </remarks>
         public static void ClearPreferences()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/README.md
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/README.md
@@ -416,7 +416,7 @@ The plugin shows an update popup at Editor startup when a newer version is avail
 
 For multi-person Unity projects where one engineer owns plugin versioning, you can disable the popup for the **entire team** by opening **Edit ▸ Project Settings ▸ AI Game Developer** and enabling *"Disable update notifications for the entire team"*. The setting is persisted to `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` and only needs to be set once per project — commit that file and every team member who pulls the commit will have the popup suppressed.
 
-The same toggle is also reachable via **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** in the menu bar.
+The same toggle is also reachable via **Tools ▸ AI Game Developer ▸ Updates ▸ Disable Update Notifications (Team)** in the menu bar.
 
 ## Advanced Features for LLM
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -416,7 +416,7 @@ El plugin muestra una ventana emergente de actualización al iniciar el Editor c
 
 En proyectos Unity con varios miembros, donde un ingeniero gestiona las versiones del plugin, puedes desactivar la ventana emergente para **todo el equipo** abriendo **Edit ▸ Project Settings ▸ AI Game Developer** y activando *"Disable update notifications for the entire team"*. El ajuste se guarda en `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` y solo debe configurarse una vez por proyecto — al confirmar (commit) ese archivo, todos los miembros del equipo que descarguen el commit verán la ventana suprimida.
 
-El mismo conmutador también está disponible en **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** en la barra de menús.
+El mismo conmutador también está disponible en **Tools ▸ AI Game Developer ▸ Updates ▸ Disable Update Notifications (Team)** en la barra de menús.
 
 ## Funcionalidades avanzadas para LLM
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -416,7 +416,7 @@ Create metallic golden material and attach it to a new sphere gameObject
 
 プラグインのバージョン管理を 1 人のエンジニアが担当している複数人での Unity プロジェクトでは、**Edit ▸ Project Settings ▸ AI Game Developer** を開き *"Disable update notifications for the entire team"* を有効にすることで、**チーム全体**でこのポップアップを無効化できます。設定は `ProjectSettings/AI-Game-Developer-UpdateSettings.asset` に保存され、プロジェクトごとに一度だけ設定すれば十分です — このファイルをコミットすると、そのコミットを取り込んだすべてのチームメンバーでポップアップが抑制されます。
 
-同じ切り替えはメニューバーの **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** からも利用できます。
+同じ切り替えはメニューバーの **Tools ▸ AI Game Developer ▸ Updates ▸ Disable Update Notifications (Team)** からも利用できます。
 
 ## LLM 向け高度な機能
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -416,7 +416,7 @@ Create metallic golden material and attach it to a new sphere gameObject
 
 对于由一位工程师统一管理插件版本的多人 Unity 项目，你可以为**整个团队**关闭这个弹窗：打开 **Edit ▸ Project Settings ▸ AI Game Developer** 并启用 *"Disable update notifications for the entire team"*。该设置会保存到 `ProjectSettings/AI-Game-Developer-UpdateSettings.asset`，每个项目只需设置一次 —— 提交（commit）该文件后，所有拉取该提交的团队成员都将看不到这个弹窗。
 
-同样的开关也可以通过菜单栏中的 **Tools ▸ AI Game Developer ▸ Disable Update Notifications (Team)** 访问。
+同样的开关也可以通过菜单栏中的 **Tools ▸ AI Game Developer ▸ Updates ▸ Disable Update Notifications (Team)** 访问。
 
 ## LLM 高级功能
 


### PR DESCRIPTION
## Summary

- Group `Tools/AI Game Developer/Check for Updates` and `Tools/AI Game Developer/Disable Update Notifications (Team)` under a new `Tools/AI Game Developer/Updates/` submenu for a cleaner Tools menu.
- Bump the team toggle's priority from 1005 to 1000 so the two items appear as siblings in the submenu in the intended order (`Check for Updates` at 999, `Disable Update Notifications (Team)` at 1000).
- The `validate = true` companion auto-picks up the new path because it references the same `DisableUpdatesMenu` const, so the toggle's check-mark behavior is unchanged.

## Test plan

- [x] Target-specific local tests passed (Unity EditMode: 928/928, 0 failures)

Follows up #769.