### PR TITLE
feat: add Profiler MCP tools (built-in Unity APIs only)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs
@@ -1,0 +1,62 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerCaptureFrameToolId = "profiler-capture-frame";
+        [McpPluginTool
+        (
+            ProfilerCaptureFrameToolId,
+            Title = "Profiler / Capture Frame",
+            ReadOnlyHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Capture the current frame's timing info (delta time, FPS, frame counts, runtime). Snapshot only — historical frames live in Unity's Profiler window.")]
+        [McpPluginSkillBody("Reads `UnityEngine.Time` fields and returns them in a single struct. " +
+            "This tool is intentionally a single-frame snapshot — Unity's runtime API does not expose historical " +
+            "frame-data outside the Profiler window.\n\n" +
+            "## Fields\n\n" +
+            "- `FrameTimeMs` — `Time.deltaTime * 1000f`.\n" +
+            "- `Fps` — `1 / Time.deltaTime` (0 when delta is zero).\n" +
+            "- `TotalFrameCount` — `Time.frameCount` (includes skipped renders).\n" +
+            "- `RealtimeSinceStartup` — `Time.realtimeSinceStartup`.\n" +
+            "- `RenderedFrameCount` — `Time.renderedFrameCount`.\n\n" +
+            "## Behavior\n\n" +
+            "Uses only built-in Unity APIs (`UnityEngine.Time`). No external Unity package is required.")]
+        [Description("Captures current frame timing data (delta time, FPS, total + rendered frame counts, runtime).")]
+        public FrameCaptureData CaptureFrame
+        (
+            [Description("Reserved for future per-N-frames capture. Currently ignored — only the current frame is captured.")]
+            int frameCount = 1
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var delta = Time.deltaTime;
+                return new FrameCaptureData
+                {
+                    FrameTimeMs = delta * 1000f,
+                    Fps = delta > 0f ? 1f / delta : 0f,
+                    TotalFrameCount = Time.frameCount,
+                    RealtimeSinceStartup = Time.realtimeSinceStartup,
+                    RenderedFrameCount = Time.renderedFrameCount
+                };
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs
@@ -39,11 +39,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "## Behavior\n\n" +
             "Uses only built-in Unity APIs (`UnityEngine.Time`). No external Unity package is required.")]
         [Description("Captures current frame timing data (delta time, FPS, total + rendered frame counts, runtime).")]
-        public FrameCaptureData CaptureFrame
-        (
-            [Description("Reserved for future per-N-frames capture. Currently ignored — only the current frame is captured.")]
-            int frameCount = 1
-        )
+        public FrameCaptureData CaptureFrame(string? nothing = null)
         {
             return MainThread.Instance.Run(() =>
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ccedd8c55d0fe54db245af774d905bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ClearData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ClearData.cs
@@ -1,0 +1,46 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityEditorInternal;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerClearDataToolId = "profiler-clear-data";
+        [McpPluginTool
+        (
+            ProfilerClearDataToolId,
+            Title = "Profiler / Clear Data",
+            DestructiveHint = true,
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Discard all frames currently held by the Editor Profiler (UnityEditorInternal.ProfilerDriver.ClearAllFrames). Cannot be undone.")]
+        [McpPluginSkillBody("Invokes `UnityEditorInternal.ProfilerDriver.ClearAllFrames()` on the main thread. " +
+            "`UnityEditorInternal` is a built-in editor namespace — no external Unity package is required.\n\n" +
+            "## Behavior\n\n" +
+            "After this call, the Profiler window's frame history is empty; subsequent recording starts from frame 0. " +
+            "Returns `true` on success.")]
+        [Description("Clears all frames currently held by the Unity Editor Profiler.")]
+        public bool ClearData(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                ProfilerDriver.ClearAllFrames();
+                return true;
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ClearData.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ClearData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da8579b9e06f8624389fc39bb47e435b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs
@@ -1,0 +1,65 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerEnableModuleToolId = "profiler-enable-module";
+        [McpPluginTool
+        (
+            ProfilerEnableModuleToolId,
+            Title = "Profiler / Enable Module",
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Toggle the wrapper's local 'enabled' flag for a named profiler module. Bookkeeping only — Unity's runtime API does not expose direct module control; for real module visibility use the Profiler window.")]
+        [McpPluginSkillBody("Adds or removes the given module name from the wrapper's `EnabledModules` set. " +
+            "This is local bookkeeping consumed by `profiler-get-status` and `profiler-list-modules`; Unity's " +
+            "runtime API does not allow programmatic toggling of Profiler-window modules from a built-in " +
+            "namespace, so this tool intentionally does not pretend to.\n\n" +
+            "## Inputs\n\n" +
+            "- `moduleName` (required) — one of the names returned by `profiler-list-modules`.\n" +
+            "- `enabled` (default `true`) — set to `false` to mark the module disabled.\n\n" +
+            "## Errors\n\n" +
+            "- Returns an `[Error]` string when `moduleName` is empty or unknown.")]
+        [Description("Enables or disables a profiler module name in the wrapper's local bookkeeping set.")]
+        public string EnableModule
+        (
+            [Description("Profiler module name (e.g. 'CPU', 'GPU', 'Memory').")]
+            string moduleName,
+            [Description("True to mark the module enabled in local bookkeeping; false to mark disabled.")]
+            bool enabled = true
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                if (string.IsNullOrEmpty(moduleName))
+                    return Error.ModuleNameIsRequired();
+
+                if (!AvailableModules.Contains(moduleName))
+                    return Error.UnknownModule(moduleName);
+
+                if (enabled)
+                    EnabledModules.Add(moduleName);
+                else
+                    EnabledModules.Remove(moduleName);
+
+                var status = enabled ? "enabled" : "disabled";
+                return $"[Success] Profiler module '{moduleName}' marked {status} in local bookkeeping. " +
+                    "Use Unity's Profiler window for actual module visibility control.";
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System.ComponentModel;
+using System.Linq;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 554d8f69ba0041a4390054aa370d2ace
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs
@@ -44,17 +44,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [Description("Returns memory statistics from the Unity Profiler (all values in MB).")]
         public MemoryStatsData GetMemoryStats(string? nothing = null)
         {
+            // Divide in double precision then cast — `long / 1048576f` loses precision
+            // above ~16 MB because the float mantissa is only 24 bits.
             return MainThread.Instance.Run(() => new MemoryStatsData
             {
-                TotalReservedMemoryMB = UnityProfiler.GetTotalReservedMemoryLong() / 1048576f,
-                TotalAllocatedMemoryMB = UnityProfiler.GetTotalAllocatedMemoryLong() / 1048576f,
-                TotalUnusedReservedMemoryMB = UnityProfiler.GetTotalUnusedReservedMemoryLong() / 1048576f,
-                MonoHeapSizeMB = UnityProfiler.GetMonoHeapSizeLong() / 1048576f,
-                MonoUsedSizeMB = UnityProfiler.GetMonoUsedSizeLong() / 1048576f,
-                TempAllocatorSizeMB = UnityProfiler.GetTempAllocatorSize() / 1048576f,
-                GraphicsMemoryMB = UnityProfiler.GetAllocatedMemoryForGraphicsDriver() / 1048576f,
-                MaxUsedMemoryMB = UnityProfiler.maxUsedMemory / 1048576f,
-                UsedHeapSizeMB = UnityProfiler.usedHeapSizeLong / 1048576f
+                TotalReservedMemoryMB = (float)(UnityProfiler.GetTotalReservedMemoryLong() / 1048576.0),
+                TotalAllocatedMemoryMB = (float)(UnityProfiler.GetTotalAllocatedMemoryLong() / 1048576.0),
+                TotalUnusedReservedMemoryMB = (float)(UnityProfiler.GetTotalUnusedReservedMemoryLong() / 1048576.0),
+                MonoHeapSizeMB = (float)(UnityProfiler.GetMonoHeapSizeLong() / 1048576.0),
+                MonoUsedSizeMB = (float)(UnityProfiler.GetMonoUsedSizeLong() / 1048576.0),
+                TempAllocatorSizeMB = (float)(UnityProfiler.GetTempAllocatorSize() / 1048576.0),
+                GraphicsMemoryMB = (float)(UnityProfiler.GetAllocatedMemoryForGraphicsDriver() / 1048576.0),
+                MaxUsedMemoryMB = (float)(UnityProfiler.maxUsedMemory / 1048576.0),
+                UsedHeapSizeMB = (float)(UnityProfiler.usedHeapSizeLong / 1048576.0)
             });
         }
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs
@@ -1,0 +1,61 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityProfiler = UnityEngine.Profiling.Profiler;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerGetMemoryStatsToolId = "profiler-get-memory-stats";
+        [McpPluginTool
+        (
+            ProfilerGetMemoryStatsToolId,
+            Title = "Profiler / Get Memory Stats",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Return memory statistics snapshot from UnityEngine.Profiling.Profiler — reserved, allocated, mono heap, graphics, etc. (in MB).")]
+        [McpPluginSkillBody("Reads UnityEngine.Profiling.Profiler scalar memory counters and converts each from bytes to megabytes (`/1048576f`).\n\n" +
+            "## Fields\n\n" +
+            "- `TotalReservedMemoryMB` — `GetTotalReservedMemoryLong()`.\n" +
+            "- `TotalAllocatedMemoryMB` — `GetTotalAllocatedMemoryLong()`.\n" +
+            "- `TotalUnusedReservedMemoryMB` — `GetTotalUnusedReservedMemoryLong()`.\n" +
+            "- `MonoHeapSizeMB` — `GetMonoHeapSizeLong()`.\n" +
+            "- `MonoUsedSizeMB` — `GetMonoUsedSizeLong()`.\n" +
+            "- `TempAllocatorSizeMB` — `GetTempAllocatorSize()`.\n" +
+            "- `GraphicsMemoryMB` — `GetAllocatedMemoryForGraphicsDriver()`.\n" +
+            "- `MaxUsedMemoryMB` — `maxUsedMemory`.\n" +
+            "- `UsedHeapSizeMB` — `usedHeapSizeLong`.\n\n" +
+            "## Behavior\n\n" +
+            "Uses only built-in Unity APIs (`UnityEngine.Profiling.Profiler`). No external Unity package is required.")]
+        [Description("Returns memory statistics from the Unity Profiler (all values in MB).")]
+        public MemoryStatsData GetMemoryStats(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() => new MemoryStatsData
+            {
+                TotalReservedMemoryMB = UnityProfiler.GetTotalReservedMemoryLong() / 1048576f,
+                TotalAllocatedMemoryMB = UnityProfiler.GetTotalAllocatedMemoryLong() / 1048576f,
+                TotalUnusedReservedMemoryMB = UnityProfiler.GetTotalUnusedReservedMemoryLong() / 1048576f,
+                MonoHeapSizeMB = UnityProfiler.GetMonoHeapSizeLong() / 1048576f,
+                MonoUsedSizeMB = UnityProfiler.GetMonoUsedSizeLong() / 1048576f,
+                TempAllocatorSizeMB = UnityProfiler.GetTempAllocatorSize() / 1048576f,
+                GraphicsMemoryMB = UnityProfiler.GetAllocatedMemoryForGraphicsDriver() / 1048576f,
+                MaxUsedMemoryMB = UnityProfiler.maxUsedMemory / 1048576f,
+                UsedHeapSizeMB = UnityProfiler.usedHeapSizeLong / 1048576f
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f32c0c724225da242929067c285605e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetRenderingStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetRenderingStats.cs
@@ -1,0 +1,59 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerGetRenderingStatsToolId = "profiler-get-rendering-stats";
+        [McpPluginTool
+        (
+            ProfilerGetRenderingStatsToolId,
+            Title = "Profiler / Get Rendering Stats",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Return current frame timing, FPS, vsync, target frame rate, threading mode, and graphics device type from Unity Time / QualitySettings / SystemInfo.")]
+        [McpPluginSkillBody("Snapshots rendering-related fields from `UnityEngine.Time`, `UnityEngine.QualitySettings`, " +
+            "`UnityEngine.Application` and `UnityEngine.SystemInfo`. All values are read from built-in Unity APIs " +
+            "so no external Unity package is required.\n\n" +
+            "## Fields\n\n" +
+            "- `FrameTimeMs` — `Time.deltaTime * 1000f`.\n" +
+            "- `Fps` — `1 / Time.deltaTime` (0 when delta is zero).\n" +
+            "- `VSyncCount` — `QualitySettings.vSyncCount`.\n" +
+            "- `TargetFrameRate` — `Application.targetFrameRate`.\n" +
+            "- `RenderingThreadingMode` — `SystemInfo.renderingThreadingMode.ToString()`.\n" +
+            "- `GraphicsDeviceType` — `SystemInfo.graphicsDeviceType.ToString()`.")]
+        [Description("Returns rendering statistics: frame time, FPS, vsync, target frame rate, threading mode, graphics device type.")]
+        public RenderingStatsData GetRenderingStats(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                var delta = Time.deltaTime;
+                return new RenderingStatsData
+                {
+                    FrameTimeMs = delta * 1000f,
+                    Fps = delta > 0f ? 1f / delta : 0f,
+                    VSyncCount = QualitySettings.vSyncCount,
+                    TargetFrameRate = Application.targetFrameRate,
+                    RenderingThreadingMode = SystemInfo.renderingThreadingMode.ToString(),
+                    GraphicsDeviceType = SystemInfo.graphicsDeviceType.ToString()
+                };
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetRenderingStats.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetRenderingStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fda1ceb749a9b44a8bf35585d588e70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs
@@ -1,0 +1,58 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityEngine;
+using UnityProfiler = UnityEngine.Profiling.Profiler;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerGetScriptStatsToolId = "profiler-get-script-stats";
+        [McpPluginTool
+        (
+            ProfilerGetScriptStatsToolId,
+            Title = "Profiler / Get Script Stats",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Return script execution timing (frame time, fixed dt, time scale, frame count, runtime) plus Mono / GC memory usage in MB.")]
+        [McpPluginSkillBody("Snapshots fields from `UnityEngine.Time`, `UnityEngine.Profiling.Profiler.GetMonoUsedSizeLong()` and " +
+            "`System.GC.GetTotalMemory(false)`. All values are produced by built-in Unity APIs.\n\n" +
+            "## Fields\n\n" +
+            "- `FrameTimeMs` — `Time.deltaTime * 1000f`.\n" +
+            "- `FixedDeltaTimeMs` — `Time.fixedDeltaTime * 1000f`.\n" +
+            "- `TimeScale` — `Time.timeScale`.\n" +
+            "- `TotalFrameCount` — `Time.frameCount`.\n" +
+            "- `RealtimeSinceStartup` — `Time.realtimeSinceStartup`.\n" +
+            "- `MonoMemoryUsageMB` — `Profiler.GetMonoUsedSizeLong() / 1048576f`.\n" +
+            "- `GCMemoryUsageMB` — `GC.GetTotalMemory(false) / 1048576f`.")]
+        [Description("Returns script execution statistics including timing and Mono / GC memory usage.")]
+        public ScriptStatsData GetScriptStats(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() => new ScriptStatsData
+            {
+                FrameTimeMs = Time.deltaTime * 1000f,
+                FixedDeltaTimeMs = Time.fixedDeltaTime * 1000f,
+                TimeScale = Time.timeScale,
+                TotalFrameCount = Time.frameCount,
+                RealtimeSinceStartup = Time.realtimeSinceStartup,
+                MonoMemoryUsageMB = UnityProfiler.GetMonoUsedSizeLong() / 1048576f,
+                GCMemoryUsageMB = GC.GetTotalMemory(false) / 1048576f
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs
@@ -43,6 +43,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [Description("Returns script execution statistics including timing and Mono / GC memory usage.")]
         public ScriptStatsData GetScriptStats(string? nothing = null)
         {
+            // Divide in double precision then cast — see GetMemoryStats for the rationale.
             return MainThread.Instance.Run(() => new ScriptStatsData
             {
                 FrameTimeMs = Time.deltaTime * 1000f,
@@ -50,8 +51,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 TimeScale = Time.timeScale,
                 TotalFrameCount = Time.frameCount,
                 RealtimeSinceStartup = Time.realtimeSinceStartup,
-                MonoMemoryUsageMB = UnityProfiler.GetMonoUsedSizeLong() / 1048576f,
-                GCMemoryUsageMB = GC.GetTotalMemory(false) / 1048576f
+                MonoMemoryUsageMB = (float)(UnityProfiler.GetMonoUsedSizeLong() / 1048576.0),
+                GCMemoryUsageMB = (float)(GC.GetTotalMemory(false) / 1048576.0)
             });
         }
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e7bb006eba618c4182ddbc34c387a7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
@@ -9,7 +9,6 @@
 */
 
 #nullable enable
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
@@ -45,7 +44,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             return MainThread.Instance.Run(() => new ProfilerStatusData
             {
                 ProfilerEnabled = UnityProfiler.enabled,
-                ActiveModules = new List<string>(EnabledModules).OrderBy(name => name).ToList(),
+                ActiveModules = EnabledModules.OrderBy(name => name).ToList(),
                 MaxUsedMemoryMB = (float)(UnityProfiler.maxUsedMemory / 1048576.0),
                 Supported = UnityProfiler.supported
             });

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
@@ -41,11 +41,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         [Description("Returns the current state of the Unity Profiler (enabled flag, active modules, max-used memory, platform support).")]
         public ProfilerStatusData GetStatus(string? nothing = null)
         {
+            // Divide in double precision then cast — see GetMemoryStats for the rationale.
             return MainThread.Instance.Run(() => new ProfilerStatusData
             {
                 ProfilerEnabled = UnityProfiler.enabled,
                 ActiveModules = new List<string>(EnabledModules).OrderBy(name => name).ToList(),
-                MaxUsedMemoryMB = UnityProfiler.maxUsedMemory / 1048576f,
+                MaxUsedMemoryMB = (float)(UnityProfiler.maxUsedMemory / 1048576.0),
                 Supported = UnityProfiler.supported
             });
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
@@ -1,0 +1,53 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityProfiler = UnityEngine.Profiling.Profiler;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerGetStatusToolId = "profiler-get-status";
+        [McpPluginTool
+        (
+            ProfilerGetStatusToolId,
+            Title = "Profiler / Get Status",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Return the Unity profiler's current enabled state, active modules, max-used memory, and platform support flag. Read-only.")]
+        [McpPluginSkillBody("Snapshots `UnityEngine.Profiling.Profiler` state and returns it in a single response.\n\n" +
+            "## Fields\n\n" +
+            "- `ProfilerEnabled` — `Profiler.enabled`.\n" +
+            "- `ActiveModules` — names of modules this wrapper considers enabled (local bookkeeping).\n" +
+            "- `MaxUsedMemoryMB` — `Profiler.maxUsedMemory / 1048576f`.\n" +
+            "- `Supported` — `Profiler.supported`.\n\n" +
+            "## Behavior\n\n" +
+            "Uses only built-in Unity APIs. No external Unity package is required.")]
+        [Description("Returns the current state of the Unity Profiler (enabled flag, active modules, max-used memory, platform support).")]
+        public ProfilerStatusData GetStatus(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() => new ProfilerStatusData
+            {
+                ProfilerEnabled = UnityProfiler.enabled,
+                ActiveModules = new List<string>(EnabledModules).OrderBy(name => name).ToList(),
+                MaxUsedMemoryMB = UnityProfiler.maxUsedMemory / 1048576f,
+                Supported = UnityProfiler.supported
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d15f499a17ca3843bc3e61c955ed516
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ListModules.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ListModules.cs
@@ -1,0 +1,51 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using System.Linq;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerListModulesToolId = "profiler-list-modules";
+        [McpPluginTool
+        (
+            ProfilerListModulesToolId,
+            Title = "Profiler / List Modules",
+            ReadOnlyHint = true,
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("List all known profiler module names with their local 'enabled' bookkeeping flag.")]
+        [McpPluginSkillBody("Returns `Tool_Profiler.AvailableModules` projected into a `ProfilerModulesData` list, " +
+            "with each entry's `Enabled` field reflecting the wrapper's local bookkeeping.\n\n" +
+            "## Behavior\n\n" +
+            "Uses only built-in Unity APIs and in-process state. No external Unity package is required. " +
+            "Pair with `profiler-enable-module` to flip the bookkeeping flag.")]
+        [Description("Lists all available profiler modules and whether the wrapper considers each enabled.")]
+        public ProfilerModulesData ListModules(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() => new ProfilerModulesData
+            {
+                Modules = AvailableModules
+                    .Select(name => new ProfilerModuleInfo
+                    {
+                        Name = name,
+                        Enabled = EnabledModules.Contains(name)
+                    })
+                    .ToList()
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ListModules.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ListModules.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 008b8fdc50fa5ee43895f7c3d33cacea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs
@@ -1,0 +1,66 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.IO;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerLoadDataToolId = "profiler-load-data";
+        [McpPluginTool
+        (
+            ProfilerLoadDataToolId,
+            Title = "Profiler / Load Data",
+            ReadOnlyHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Read back a previously-saved JSON snapshot from `profiler-save-data` and return its raw text.")]
+        [McpPluginSkillBody("Reads `filePath` as UTF-8 text and returns the file body unchanged. Caller is responsible " +
+            "for parsing.\n\n" +
+            "## Inputs\n\n" +
+            "- `filePath` (required) — path written by `profiler-save-data`.\n\n" +
+            "## Errors\n\n" +
+            "- Returns `[Error]` when `filePath` is empty, the file does not exist, or the read fails.\n\n" +
+            "## Behavior\n\n" +
+            "Uses `System.IO.File.ReadAllText` (BCL) — no external Unity package is required.")]
+        [Description("Reads a profiler snapshot JSON file and returns its raw text content.")]
+        public string LoadData
+        (
+            [Description("Path to a profiler snapshot file previously written by 'profiler-save-data'.")]
+            string filePath
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                if (string.IsNullOrEmpty(filePath))
+                    return Error.FilePathIsRequired();
+
+                if (!File.Exists(filePath))
+                    return Error.FileNotFound(filePath);
+
+                try
+                {
+                    var content = File.ReadAllText(filePath);
+                    return content;
+                }
+                catch (Exception ex)
+                {
+                    return Error.FailedToLoadData(ex.Message);
+                }
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs
@@ -20,6 +20,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerLoadDataToolId = "profiler-load-data";
+
+        // Cap to keep an accidental call against a huge file from OOMing the Editor.
+        // Snapshots written by SaveData are typically a few KB; 10 MB leaves plenty of
+        // headroom for future schema expansion while bounding worst-case memory.
+        const long MaxLoadFileSizeBytes = 10L * 1024L * 1024L;
+
         [McpPluginTool
         (
             ProfilerLoadDataToolId,
@@ -33,9 +39,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "## Inputs\n\n" +
             "- `filePath` (required) — path written by `profiler-save-data`.\n\n" +
             "## Errors\n\n" +
-            "- Returns `[Error]` when `filePath` is empty, the file does not exist, or the read fails.\n\n" +
+            "- Returns `[Error]` when `filePath` is empty, the file does not exist, exceeds the 10 MB size cap, or the read fails.\n\n" +
             "## Behavior\n\n" +
-            "Uses `System.IO.File.ReadAllText` (BCL) — no external Unity package is required.")]
+            "Uses `System.IO.File.ReadAllText` (BCL) — no external Unity package is required. " +
+            "Files larger than 10 MB are rejected up-front to avoid OOM on a stray call.")]
         [Description("Reads a profiler snapshot JSON file and returns its raw text content.")]
         public string LoadData
         (
@@ -53,6 +60,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 try
                 {
+                    var info = new FileInfo(filePath);
+                    if (info.Length > MaxLoadFileSizeBytes)
+                        return Error.FileTooLarge(filePath, info.Length, MaxLoadFileSizeBytes);
+
                     var content = File.ReadAllText(filePath);
                     return content;
                 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b2b44e39adcc214c925f6bd2fecc51a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
@@ -1,0 +1,107 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Text.Json;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityProfiler = UnityEngine.Profiling.Profiler;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerSaveDataToolId = "profiler-save-data";
+        [McpPluginTool
+        (
+            ProfilerSaveDataToolId,
+            Title = "Profiler / Save Data",
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Save a snapshot of profiler-derived stats (status + memory + rendering + script + frame capture) to a JSON file. Built-in Unity APIs only.")]
+        [McpPluginSkillBody("Composes the outputs of `profiler-get-status`, `profiler-get-memory-stats`, " +
+            "`profiler-get-rendering-stats`, `profiler-get-script-stats` and `profiler-capture-frame` into a single " +
+            "JSON document and writes it to `filePath`. Creates any missing parent directories.\n\n" +
+            "## Inputs\n\n" +
+            "- `filePath` (required) — absolute or workspace-relative path to write to.\n\n" +
+            "## Errors\n\n" +
+            "- Returns `[Error]` when `filePath` is empty or the write fails (message includes the underlying exception text).\n\n" +
+            "## Behavior\n\n" +
+            "Uses `System.Text.Json` (BCL) for serialization and `System.IO.File.WriteAllText` for the write. " +
+            "No external Unity package is required.")]
+        [Description("Saves a profiler snapshot (status + memory + rendering + script + frame) to a JSON file.")]
+        public string SaveData
+        (
+            [Description("Absolute or workspace-relative output file path.")]
+            string filePath
+        )
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                if (string.IsNullOrEmpty(filePath))
+                    return Error.FilePathIsRequired();
+
+                try
+                {
+                    var deltaTime = UnityEngine.Time.deltaTime;
+                    var snapshot = new
+                    {
+                        savedAt = DateTime.UtcNow.ToString("O"),
+                        status = new
+                        {
+                            profilerEnabled = UnityProfiler.enabled,
+                            supported = UnityProfiler.supported,
+                            maxUsedMemoryMB = UnityProfiler.maxUsedMemory / 1048576f,
+                            enabledModules = EnabledModules
+                        },
+                        memory = new
+                        {
+                            totalReservedMemoryMB = UnityProfiler.GetTotalReservedMemoryLong() / 1048576f,
+                            totalAllocatedMemoryMB = UnityProfiler.GetTotalAllocatedMemoryLong() / 1048576f,
+                            totalUnusedReservedMemoryMB = UnityProfiler.GetTotalUnusedReservedMemoryLong() / 1048576f,
+                            monoHeapSizeMB = UnityProfiler.GetMonoHeapSizeLong() / 1048576f,
+                            monoUsedSizeMB = UnityProfiler.GetMonoUsedSizeLong() / 1048576f,
+                            graphicsMemoryMB = UnityProfiler.GetAllocatedMemoryForGraphicsDriver() / 1048576f
+                        },
+                        rendering = new
+                        {
+                            frameTimeMs = deltaTime * 1000f,
+                            fps = deltaTime > 0f ? 1f / deltaTime : 0f,
+                            vSyncCount = UnityEngine.QualitySettings.vSyncCount,
+                            targetFrameRate = UnityEngine.Application.targetFrameRate
+                        },
+                        script = new
+                        {
+                            timeScale = UnityEngine.Time.timeScale,
+                            totalFrameCount = UnityEngine.Time.frameCount,
+                            realtimeSinceStartup = UnityEngine.Time.realtimeSinceStartup,
+                            gcMemoryUsageMB = GC.GetTotalMemory(false) / 1048576f
+                        }
+                    };
+
+                    var json = System.Text.Json.JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
+                    var dir = Path.GetDirectoryName(filePath);
+                    if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                        Directory.CreateDirectory(dir);
+
+                    File.WriteAllText(filePath, json);
+                    return $"[Success] Profiler snapshot saved to '{filePath}'.";
+                }
+                catch (Exception ex)
+                {
+                    return Error.FailedToSaveData(ex.Message);
+                }
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
@@ -12,7 +12,6 @@
 using System;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
@@ -55,7 +54,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 {
                     // Compose the snapshot by delegating to sibling Get* methods so the
                     // serialized shape stays in sync with each tool's POCO. Direct field reads
-                    // here would silently drift whenever a POCO gains/loses a field.
+                    // here would silently drift whenever a POCO gains/loses a field. The set of
+                    // enabled modules is carried by `status.ActiveModules` (already sorted) —
+                    // a separate top-level field would duplicate the data and risk drift.
                     var snapshot = new
                     {
                         savedAt = DateTime.UtcNow.ToString("O"),
@@ -63,10 +64,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         memory = GetMemoryStats(),
                         rendering = GetRenderingStats(),
                         script = GetScriptStats(),
-                        frame = CaptureFrame(),
-                        // Snapshot a sorted copy so two runs with the same enabled set produce
-                        // byte-identical output (HashSet iteration order is not guaranteed).
-                        enabledModules = EnabledModules.OrderBy(name => name).ToList()
+                        frame = CaptureFrame()
                     };
 
                     var json = System.Text.Json.JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
@@ -12,10 +12,10 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
-using UnityProfiler = UnityEngine.Profiling.Profiler;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
@@ -53,40 +53,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                 try
                 {
-                    var deltaTime = UnityEngine.Time.deltaTime;
+                    // Compose the snapshot by delegating to sibling Get* methods so the
+                    // serialized shape stays in sync with each tool's POCO. Direct field reads
+                    // here would silently drift whenever a POCO gains/loses a field.
                     var snapshot = new
                     {
                         savedAt = DateTime.UtcNow.ToString("O"),
-                        status = new
-                        {
-                            profilerEnabled = UnityProfiler.enabled,
-                            supported = UnityProfiler.supported,
-                            maxUsedMemoryMB = UnityProfiler.maxUsedMemory / 1048576f,
-                            enabledModules = EnabledModules
-                        },
-                        memory = new
-                        {
-                            totalReservedMemoryMB = UnityProfiler.GetTotalReservedMemoryLong() / 1048576f,
-                            totalAllocatedMemoryMB = UnityProfiler.GetTotalAllocatedMemoryLong() / 1048576f,
-                            totalUnusedReservedMemoryMB = UnityProfiler.GetTotalUnusedReservedMemoryLong() / 1048576f,
-                            monoHeapSizeMB = UnityProfiler.GetMonoHeapSizeLong() / 1048576f,
-                            monoUsedSizeMB = UnityProfiler.GetMonoUsedSizeLong() / 1048576f,
-                            graphicsMemoryMB = UnityProfiler.GetAllocatedMemoryForGraphicsDriver() / 1048576f
-                        },
-                        rendering = new
-                        {
-                            frameTimeMs = deltaTime * 1000f,
-                            fps = deltaTime > 0f ? 1f / deltaTime : 0f,
-                            vSyncCount = UnityEngine.QualitySettings.vSyncCount,
-                            targetFrameRate = UnityEngine.Application.targetFrameRate
-                        },
-                        script = new
-                        {
-                            timeScale = UnityEngine.Time.timeScale,
-                            totalFrameCount = UnityEngine.Time.frameCount,
-                            realtimeSinceStartup = UnityEngine.Time.realtimeSinceStartup,
-                            gcMemoryUsageMB = GC.GetTotalMemory(false) / 1048576f
-                        }
+                        status = GetStatus(),
+                        memory = GetMemoryStats(),
+                        rendering = GetRenderingStats(),
+                        script = GetScriptStats(),
+                        frame = CaptureFrame(),
+                        // Snapshot a sorted copy so two runs with the same enabled set produce
+                        // byte-identical output (HashSet iteration order is not guaranteed).
+                        enabledModules = EnabledModules.OrderBy(name => name).ToList()
                     };
 
                     var json = System.Text.Json.JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef061b6a2f484e14da46fdfe807c220e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs
@@ -13,6 +13,7 @@ using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.ReflectorNet.Utils;
 using UnityEditor;
+using UnityEngine;
 using UnityProfiler = UnityEngine.Profiling.Profiler;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
@@ -43,7 +44,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             return MainThread.Instance.Run(() =>
             {
                 UnityProfiler.enabled = true;
-                EditorApplication.ExecuteMenuItem("Window/Analysis/Profiler");
+                // ExecuteMenuItem returns false silently when the menu path is renamed
+                // or missing — log a warning so a broken UI hook does not look like a
+                // successful Start() (the profiler-enabled flag flips regardless).
+                if (!EditorApplication.ExecuteMenuItem("Window/Analysis/Profiler"))
+                    Debug.LogWarning("[Tool_Profiler] Could not open menu 'Window/Analysis/Profiler'. The runtime profiler is still enabled.");
                 return UnityProfiler.enabled;
             });
         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs
@@ -1,0 +1,51 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityEditor;
+using UnityProfiler = UnityEngine.Profiling.Profiler;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerStartToolId = "profiler-start";
+        [McpPluginTool
+        (
+            ProfilerStartToolId,
+            Title = "Profiler / Start",
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Enable Unity's runtime profiler and open the Profiler window. " +
+            "Idempotent: calling when already enabled returns the current enabled state without error.")]
+        [McpPluginSkillBody("Enables `UnityEngine.Profiling.Profiler.enabled = true` and opens " +
+            "`Window > Analysis > Profiler` via `EditorApplication.ExecuteMenuItem`. " +
+            "Returns `true` once the profiler is enabled.\n\n" +
+            "## Behavior\n\n" +
+            "Uses only built-in Unity APIs (`UnityEngine.Profiling`, `UnityEditor.EditorApplication`). " +
+            "No external Unity package is required.\n\n" +
+            "Snapshot-based: this tool does not stream historical frame data — use Unity's Profiler window directly " +
+            "for that.")]
+        [Description("Enable the Unity Profiler and open the Profiler window. Returns true once enabled.")]
+        public bool Start(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                UnityProfiler.enabled = true;
+                EditorApplication.ExecuteMenuItem("Window/Analysis/Profiler");
+                return UnityProfiler.enabled;
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44b565047b7028c4ca822fc7a7b73fb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Stop.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Stop.cs
@@ -1,0 +1,44 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Utils;
+using UnityProfiler = UnityEngine.Profiling.Profiler;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    public partial class Tool_Profiler
+    {
+        public const string ProfilerStopToolId = "profiler-stop";
+        [McpPluginTool
+        (
+            ProfilerStopToolId,
+            Title = "Profiler / Stop",
+            IdempotentHint = true,
+            Enabled = false
+        )]
+        [McpPluginSkillDescription("Disable Unity's runtime profiler. Idempotent — calling when already disabled returns the current disabled state.")]
+        [McpPluginSkillBody("Sets `UnityEngine.Profiling.Profiler.enabled = false`. Returns the post-call value of `Profiler.enabled` " +
+            "(expected `false`).\n\n" +
+            "## Behavior\n\n" +
+            "Uses only built-in Unity APIs (`UnityEngine.Profiling`). No external Unity package is required.")]
+        [Description("Disable the Unity Profiler. Returns false once disabled.")]
+        public bool Stop(string? nothing = null)
+        {
+            return MainThread.Instance.Run(() =>
+            {
+                UnityProfiler.enabled = false;
+                return UnityProfiler.enabled;
+            });
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Stop.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Stop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d32741d245263c04f9124eb992fdc847
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs
@@ -1,0 +1,216 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API
+{
+    [McpPluginToolType]
+    public partial class Tool_Profiler
+    {
+        /// <summary>
+        /// Locally-tracked set of profiler modules considered "enabled" by the MCP wrapper.
+        /// Unity's runtime Profiler API does not expose per-module enable/disable, so this
+        /// is a bookkeeping helper for callers; actual module visibility is controlled
+        /// from the Profiler window.
+        /// </summary>
+        internal static readonly HashSet<string> EnabledModules = new HashSet<string>()
+        {
+            "CPU",
+            "GPU",
+            "Rendering",
+            "Memory",
+            "Audio",
+            "Video",
+            "Physics",
+            "Physics2D",
+            "UI"
+        };
+
+        /// <summary>
+        /// Canonical list of profiler module names this tool surface understands. Derived
+        /// from the names Unity uses in its built-in Profiler window — kept here as a
+        /// constant so the wrapper is independent of the optional
+        /// `com.unity.profiling.core` package (per task scope, the core tool must rely on
+        /// built-in Unity APIs only).
+        /// </summary>
+        public static readonly List<string> AvailableModules = new List<string>()
+        {
+            "CPU",
+            "GPU",
+            "Rendering",
+            "Memory",
+            "Audio",
+            "Video",
+            "Physics",
+            "Physics2D",
+            "NetworkMessages",
+            "NetworkOperations",
+            "UI",
+            "UIDetails",
+            "GlobalIllumination",
+            "VirtualTexturing"
+        };
+
+        public static class Error
+        {
+            public static string ModuleNameIsRequired()
+                => "[Error] Module name is required.";
+
+            public static string UnknownModule(string moduleName)
+                => $"[Error] Unknown profiler module: '{moduleName}'. Available modules: {string.Join(", ", AvailableModules)}";
+
+            public static string FilePathIsRequired()
+                => "[Error] File path is required.";
+
+            public static string FileNotFound(string filePath)
+                => $"[Error] Profiler data file not found: '{filePath}'.";
+
+            public static string FailedToSaveData(string message)
+                => $"[Error] Failed to save profiler data: {message}";
+
+            public static string FailedToLoadData(string message)
+                => $"[Error] Failed to load profiler data: {message}";
+        }
+
+        [Description("Profiler status data including memory and module information.")]
+        public class ProfilerStatusData
+        {
+            [Description("Whether Unity's runtime profiler is currently enabled (UnityEngine.Profiling.Profiler.enabled).")]
+            public bool ProfilerEnabled { get; set; }
+
+            [Description("List of profiler modules this wrapper considers active. Local bookkeeping only.")]
+            public List<string>? ActiveModules { get; set; }
+
+            [Description("Maximum used memory recorded by the profiler, in megabytes.")]
+            public float MaxUsedMemoryMB { get; set; }
+
+            [Description("Whether profiling is supported on this platform (UnityEngine.Profiling.Profiler.supported).")]
+            public bool Supported { get; set; }
+        }
+
+        [Description("Memory statistics from the Unity Profiler. All values in megabytes unless otherwise noted.")]
+        public class MemoryStatsData
+        {
+            [Description("Total reserved memory (UnityEngine.Profiling.Profiler.GetTotalReservedMemoryLong / 1048576).")]
+            public float TotalReservedMemoryMB { get; set; }
+
+            [Description("Total allocated memory (UnityEngine.Profiling.Profiler.GetTotalAllocatedMemoryLong / 1048576).")]
+            public float TotalAllocatedMemoryMB { get; set; }
+
+            [Description("Total unused reserved memory (UnityEngine.Profiling.Profiler.GetTotalUnusedReservedMemoryLong / 1048576).")]
+            public float TotalUnusedReservedMemoryMB { get; set; }
+
+            [Description("Mono heap size (UnityEngine.Profiling.Profiler.GetMonoHeapSizeLong / 1048576).")]
+            public float MonoHeapSizeMB { get; set; }
+
+            [Description("Mono used size (UnityEngine.Profiling.Profiler.GetMonoUsedSizeLong / 1048576).")]
+            public float MonoUsedSizeMB { get; set; }
+
+            [Description("Temp allocator size (UnityEngine.Profiling.Profiler.GetTempAllocatorSize / 1048576).")]
+            public float TempAllocatorSizeMB { get; set; }
+
+            [Description("Graphics memory reserved by the driver (UnityEngine.Profiling.Profiler.GetAllocatedMemoryForGraphicsDriver / 1048576).")]
+            public float GraphicsMemoryMB { get; set; }
+
+            [Description("Maximum used memory observed (UnityEngine.Profiling.Profiler.maxUsedMemory / 1048576).")]
+            public float MaxUsedMemoryMB { get; set; }
+
+            [Description("Used heap size (UnityEngine.Profiling.Profiler.usedHeapSizeLong / 1048576).")]
+            public float UsedHeapSizeMB { get; set; }
+        }
+
+        [Description("Rendering statistics from Unity's Time / QualitySettings / SystemInfo. No external package required.")]
+        public class RenderingStatsData
+        {
+            [Description("Last reported frame time (Time.deltaTime * 1000) in milliseconds.")]
+            public float FrameTimeMs { get; set; }
+
+            [Description("Frames per second derived from Time.deltaTime.")]
+            public float Fps { get; set; }
+
+            [Description("QualitySettings.vSyncCount.")]
+            public int VSyncCount { get; set; }
+
+            [Description("Application.targetFrameRate.")]
+            public int TargetFrameRate { get; set; }
+
+            [Description("SystemInfo.renderingThreadingMode.")]
+            public string? RenderingThreadingMode { get; set; }
+
+            [Description("SystemInfo.graphicsDeviceType.")]
+            public string? GraphicsDeviceType { get; set; }
+        }
+
+        [Description("Script statistics derived from UnityEngine.Time + UnityEngine.Profiling.Profiler.")]
+        public class ScriptStatsData
+        {
+            [Description("Time.deltaTime in milliseconds.")]
+            public float FrameTimeMs { get; set; }
+
+            [Description("Time.fixedDeltaTime in milliseconds.")]
+            public float FixedDeltaTimeMs { get; set; }
+
+            [Description("Time.timeScale.")]
+            public float TimeScale { get; set; }
+
+            [Description("Total frame count since application start (Time.frameCount).")]
+            public int TotalFrameCount { get; set; }
+
+            [Description("Time.realtimeSinceStartup, in seconds.")]
+            public float RealtimeSinceStartup { get; set; }
+
+            [Description("Mono used size (Profiler.GetMonoUsedSizeLong / 1048576), in megabytes.")]
+            public float MonoMemoryUsageMB { get; set; }
+
+            [Description("System.GC.GetTotalMemory(false) / 1048576, in megabytes.")]
+            public float GCMemoryUsageMB { get; set; }
+        }
+
+        [Description("Single-frame snapshot of timing information from UnityEngine.Time. No historical frame data; use the Profiler window for that.")]
+        public class FrameCaptureData
+        {
+            [Description("Time.deltaTime in milliseconds at the moment of capture.")]
+            public float FrameTimeMs { get; set; }
+
+            [Description("Frames per second derived from Time.deltaTime.")]
+            public float Fps { get; set; }
+
+            [Description("Total frame count since application start (Time.frameCount). May include skipped renders.")]
+            public int TotalFrameCount { get; set; }
+
+            [Description("Time.realtimeSinceStartup, in seconds.")]
+            public float RealtimeSinceStartup { get; set; }
+
+            [Description("Frames actually rendered (Time.renderedFrameCount).")]
+            public int RenderedFrameCount { get; set; }
+        }
+
+        [Description("Profiler module entry returned by 'profiler-list-modules'.")]
+        public class ProfilerModuleInfo
+        {
+            [Description("Module name (e.g. 'CPU', 'Memory').")]
+            public string? Name { get; set; }
+
+            [Description("Whether the wrapper considers this module enabled. Local bookkeeping only.")]
+            public bool Enabled { get; set; }
+        }
+
+        [Description("Container for 'profiler-list-modules' output.")]
+        public class ProfilerModulesData
+        {
+            [Description("All known profiler modules and their wrapper-side enabled flag.")]
+            public List<ProfilerModuleInfo>? Modules { get; set; }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs
@@ -19,10 +19,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         /// <summary>
-        /// Locally-tracked set of profiler modules considered "enabled" by the MCP wrapper.
-        /// Unity's runtime Profiler API does not expose per-module enable/disable, so this
-        /// is a bookkeeping helper for callers; actual module visibility is controlled
-        /// from the Profiler window.
+        /// Default-enabled subset of <see cref="AvailableModules"/>. Mutated by
+        /// <c>profiler-enable-module</c> and read by <c>profiler-get-status</c> /
+        /// <c>profiler-list-modules</c>. Unity's runtime Profiler API does not expose
+        /// per-module enable/disable, so this is purely a bookkeeping helper for callers;
+        /// actual module visibility is controlled from the Profiler window.
         /// </summary>
         internal static readonly HashSet<string> EnabledModules = new HashSet<string>()
         {
@@ -42,9 +43,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         /// from the names Unity uses in its built-in Profiler window — kept here as a
         /// constant so the wrapper is independent of the optional
         /// `com.unity.profiling.core` package (per task scope, the core tool must rely on
-        /// built-in Unity APIs only).
+        /// built-in Unity APIs only). Exposed as <see cref="IReadOnlyList{T}"/> so callers
+        /// cannot accidentally mutate the canonical list via <c>.Add()</c>.
         /// </summary>
-        public static readonly List<string> AvailableModules = new List<string>()
+        internal static readonly IReadOnlyList<string> AvailableModules = new List<string>()
         {
             "CPU",
             "GPU",
@@ -60,7 +62,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "UIDetails",
             "GlobalIllumination",
             "VirtualTexturing"
-        };
+        }.AsReadOnly();
 
         public static class Error
         {
@@ -75,6 +77,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             public static string FileNotFound(string filePath)
                 => $"[Error] Profiler data file not found: '{filePath}'.";
+
+            public static string FileTooLarge(string filePath, long fileBytes, long maxBytes)
+                => $"[Error] Profiler data file '{filePath}' is {fileBytes} bytes, exceeding the {maxBytes}-byte cap.";
 
             public static string FailedToSaveData(string message)
                 => $"[Error] Failed to save profiler data: {message}";

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b3cb69409b6d724baccf47bd4f03ef4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1649d1ff825ddbc4c97fc70ef2f45a05
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Modules.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Modules.cs
@@ -1,0 +1,66 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Linq;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public partial class TestToolProfiler
+    {
+        [Test]
+        public void ListModules_IncludesAllKnownModules()
+        {
+            var data = _tool.ListModules();
+            Assert.IsNotNull(data, "ListModules() should never return null.");
+            Assert.IsNotNull(data.Modules, "Modules should be populated.");
+            Assert.AreEqual(Tool_Profiler.AvailableModules.Count, data.Modules!.Count,
+                "ListModules() should return one entry per AvailableModules entry.");
+
+            foreach (var name in Tool_Profiler.AvailableModules)
+                Assert.IsTrue(data.Modules.Any(m => m.Name == name), $"Module list should contain '{name}'.");
+        }
+
+        [Test]
+        public void EnableModule_TogglesBookkeeping()
+        {
+            // CPU is in the default-enabled set per Tool_Profiler.cs.
+            var disableResult = _tool.EnableModule("CPU", enabled: false);
+            Assert.IsTrue(disableResult.Contains("[Success]"), $"Disabling CPU should succeed.\n{disableResult}");
+
+            var afterDisable = _tool.ListModules().Modules!.First(m => m.Name == "CPU");
+            Assert.IsFalse(afterDisable.Enabled, "CPU should be marked disabled after EnableModule(CPU, false).");
+
+            var enableResult = _tool.EnableModule("CPU", enabled: true);
+            Assert.IsTrue(enableResult.Contains("[Success]"), $"Enabling CPU should succeed.\n{enableResult}");
+
+            var afterEnable = _tool.ListModules().Modules!.First(m => m.Name == "CPU");
+            Assert.IsTrue(afterEnable.Enabled, "CPU should be marked enabled after EnableModule(CPU, true).");
+        }
+
+        [Test]
+        public void EnableModule_RejectsEmptyModuleName()
+        {
+            var result = _tool.EnableModule("", enabled: true);
+            Assert.IsTrue(result.Contains("[Error]"), $"Empty module name should return error.\n{result}");
+            Assert.IsTrue(result.Contains("required"), "Error should mention required.");
+        }
+
+        [Test]
+        public void EnableModule_RejectsUnknownModuleName()
+        {
+            var result = _tool.EnableModule("NotARealModule");
+            Assert.IsTrue(result.Contains("[Error]"), $"Unknown module name should return error.\n{result}");
+            Assert.IsTrue(result.Contains("Unknown profiler module"), "Error should mention 'Unknown profiler module'.");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Modules.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Modules.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b5e051516c275a34fa81da5329cd31c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.SaveLoad.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.SaveLoad.cs
@@ -1,0 +1,83 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.IO;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public partial class TestToolProfiler
+    {
+        string _tempPath = null!;
+
+        [SetUp]
+        public void TestSetUp_SaveLoad()
+        {
+            _tempPath = Path.Combine(Path.GetTempPath(), $"unity-mcp-profiler-test-{System.Guid.NewGuid():N}.json");
+        }
+
+        [TearDown]
+        public void TestTearDown_SaveLoad()
+        {
+            if (!string.IsNullOrEmpty(_tempPath) && File.Exists(_tempPath))
+                File.Delete(_tempPath);
+        }
+
+        [Test]
+        public void SaveData_WritesValidJsonFile()
+        {
+            var result = _tool.SaveData(_tempPath);
+            Assert.IsTrue(result.Contains("[Success]"), $"SaveData should succeed.\n{result}");
+            Assert.IsTrue(File.Exists(_tempPath), "Output file should exist on disk after SaveData.");
+
+            var content = File.ReadAllText(_tempPath);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(content), "Snapshot file should not be empty.");
+            // Lightweight JSON shape check — avoids dragging in a JSON dep at test time.
+            Assert.IsTrue(content.TrimStart().StartsWith("{"), "Snapshot should begin with '{'.");
+            Assert.IsTrue(content.Contains("\"status\""), "Snapshot should contain a 'status' field.");
+            Assert.IsTrue(content.Contains("\"memory\""), "Snapshot should contain a 'memory' field.");
+        }
+
+        [Test]
+        public void SaveData_RejectsEmptyFilePath()
+        {
+            var result = _tool.SaveData("");
+            Assert.IsTrue(result.Contains("[Error]"), $"Empty path should return error.\n{result}");
+            Assert.IsTrue(result.Contains("required"), "Error should mention required.");
+        }
+
+        [Test]
+        public void LoadData_ReturnsContentForExistingFile()
+        {
+            // Round-trip — save then load.
+            _tool.SaveData(_tempPath);
+            var loaded = _tool.LoadData(_tempPath);
+            Assert.IsFalse(loaded.Contains("[Error]"), $"LoadData should not return error for an existing file.\n{loaded}");
+            Assert.IsTrue(loaded.Contains("\"status\""), "Loaded content should contain the 'status' field written by SaveData.");
+        }
+
+        [Test]
+        public void LoadData_ReportsFileNotFound()
+        {
+            var result = _tool.LoadData(Path.Combine(Path.GetTempPath(), $"unity-mcp-nonexistent-{System.Guid.NewGuid():N}.json"));
+            Assert.IsTrue(result.Contains("[Error]"), $"Missing file should return error.\n{result}");
+            Assert.IsTrue(result.Contains("not found"), "Error should mention 'not found'.");
+        }
+
+        [Test]
+        public void LoadData_RejectsEmptyFilePath()
+        {
+            var result = _tool.LoadData("");
+            Assert.IsTrue(result.Contains("[Error]"), $"Empty path should return error.\n{result}");
+            Assert.IsTrue(result.Contains("required"), "Error should mention required.");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.SaveLoad.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.SaveLoad.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 119b8006a3d819741ab486447591e471
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.StartStop.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.StartStop.cs
@@ -1,0 +1,54 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using NUnit.Framework;
+using UnityProfiler = UnityEngine.Profiling.Profiler;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public partial class TestToolProfiler
+    {
+        [Test]
+        public void Start_EnablesUnityProfiler()
+        {
+            var result = _tool.Start();
+            Assert.IsTrue(result, "Start() should return the profiler's enabled state, which should be true.");
+            Assert.IsTrue(UnityProfiler.enabled, "UnityEngine.Profiling.Profiler.enabled should be true after Start().");
+        }
+
+        [Test]
+        public void Stop_DisablesUnityProfiler()
+        {
+            _tool.Start();
+            var result = _tool.Stop();
+            Assert.IsFalse(result, "Stop() should return the profiler's enabled state, which should be false.");
+            Assert.IsFalse(UnityProfiler.enabled, "UnityEngine.Profiling.Profiler.enabled should be false after Stop().");
+        }
+
+        [Test]
+        public void Start_IsIdempotent()
+        {
+            _tool.Start();
+            var second = _tool.Start();
+            Assert.IsTrue(second, "Calling Start() twice should still leave the profiler enabled.");
+            Assert.IsTrue(UnityProfiler.enabled, "Profiler should remain enabled after a second Start().");
+        }
+
+        [Test]
+        public void Stop_IsIdempotent()
+        {
+            _tool.Stop();
+            var second = _tool.Stop();
+            Assert.IsFalse(second, "Calling Stop() twice should still leave the profiler disabled.");
+            Assert.IsFalse(UnityProfiler.enabled, "Profiler should remain disabled after a second Stop().");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.StartStop.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.StartStop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e7d260ce6f869d4eaec56f4aad8e0f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Stats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Stats.cs
@@ -1,0 +1,71 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public partial class TestToolProfiler
+    {
+        [Test]
+        public void GetStatus_ReturnsPopulatedSnapshot()
+        {
+            var status = _tool.GetStatus();
+            Assert.IsNotNull(status, "GetStatus() should never return null.");
+            Assert.IsNotNull(status.ActiveModules, "ActiveModules should always be initialised (even if empty).");
+            Assert.IsTrue(status.MaxUsedMemoryMB >= 0f, "MaxUsedMemoryMB should be a non-negative MB value.");
+        }
+
+        [Test]
+        public void GetMemoryStats_ReturnsNonNegativeFields()
+        {
+            var memory = _tool.GetMemoryStats();
+            Assert.IsNotNull(memory, "GetMemoryStats() should never return null.");
+            Assert.IsTrue(memory.TotalReservedMemoryMB >= 0f, "TotalReservedMemoryMB should be non-negative.");
+            Assert.IsTrue(memory.TotalAllocatedMemoryMB >= 0f, "TotalAllocatedMemoryMB should be non-negative.");
+            Assert.IsTrue(memory.MonoHeapSizeMB >= 0f, "MonoHeapSizeMB should be non-negative.");
+            Assert.IsTrue(memory.MonoUsedSizeMB >= 0f, "MonoUsedSizeMB should be non-negative.");
+            Assert.IsTrue(memory.UsedHeapSizeMB >= 0f, "UsedHeapSizeMB should be non-negative.");
+            // Allocated should never exceed reserved (Unity invariant).
+            Assert.IsTrue(memory.TotalAllocatedMemoryMB <= memory.TotalReservedMemoryMB + 0.001f,
+                "Allocated memory should not exceed reserved memory.");
+        }
+
+        [Test]
+        public void GetRenderingStats_ReturnsRequiredStringFields()
+        {
+            var rendering = _tool.GetRenderingStats();
+            Assert.IsNotNull(rendering, "GetRenderingStats() should never return null.");
+            Assert.IsFalse(string.IsNullOrEmpty(rendering.RenderingThreadingMode), "RenderingThreadingMode should be populated.");
+            Assert.IsFalse(string.IsNullOrEmpty(rendering.GraphicsDeviceType), "GraphicsDeviceType should be populated.");
+            Assert.IsTrue(rendering.Fps >= 0f, "Fps should be non-negative.");
+        }
+
+        [Test]
+        public void GetScriptStats_ReturnsNonNegativeTiming()
+        {
+            var script = _tool.GetScriptStats();
+            Assert.IsNotNull(script, "GetScriptStats() should never return null.");
+            Assert.IsTrue(script.TotalFrameCount >= 0, "TotalFrameCount should be non-negative.");
+            Assert.IsTrue(script.RealtimeSinceStartup >= 0f, "RealtimeSinceStartup should be non-negative.");
+            Assert.IsTrue(script.GCMemoryUsageMB > 0f, "GCMemoryUsageMB should be > 0 in a running .NET process.");
+        }
+
+        [Test]
+        public void CaptureFrame_ReturnsCurrentFrameSnapshot()
+        {
+            var frame = _tool.CaptureFrame();
+            Assert.IsNotNull(frame, "CaptureFrame() should never return null.");
+            Assert.IsTrue(frame.TotalFrameCount >= 0, "TotalFrameCount should be non-negative.");
+            Assert.IsTrue(frame.RealtimeSinceStartup >= 0f, "RealtimeSinceStartup should be non-negative.");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Stats.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.Stats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b954e9d03a0b3984aaa27322b1be5c60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.cs
@@ -9,6 +9,7 @@
 */
 
 #nullable enable
+using System.Collections.Generic;
 using com.IvanMurzak.Unity.MCP.Editor.API;
 using NUnit.Framework;
 
@@ -17,11 +18,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
     public partial class TestToolProfiler : BaseTest
     {
         protected Tool_Profiler _tool = null!;
+        HashSet<string> _enabledModulesSnapshot = null!;
 
         [SetUp]
         public void TestSetUp()
         {
             _tool = new Tool_Profiler();
+            // Snapshot the shared static EnabledModules set so a test that toggles it
+            // (or fails partway through toggling it) cannot pollute later tests.
+            _enabledModulesSnapshot = new HashSet<string>(Tool_Profiler.EnabledModules);
         }
 
         [TearDown]
@@ -30,6 +35,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             // Leave the profiler in a known-disabled state so subsequent tests do not
             // see drift from a previous test's Start() call.
             _tool.Stop();
+
+            // Restore EnabledModules to whatever it was at SetUp time. This is the
+            // safety net for asymmetric Enable/Disable sequences (or assertion failures
+            // mid-test) that would otherwise leave the static set in a drifted state.
+            Tool_Profiler.EnabledModules.Clear();
+            foreach (var name in _enabledModulesSnapshot)
+                Tool_Profiler.EnabledModules.Add(name);
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.cs
@@ -1,0 +1,35 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    public partial class TestToolProfiler : BaseTest
+    {
+        protected Tool_Profiler _tool = null!;
+
+        [SetUp]
+        public void TestSetUp()
+        {
+            _tool = new Tool_Profiler();
+        }
+
+        [TearDown]
+        public void TestTearDown()
+        {
+            // Leave the profiler in a known-disabled state so subsequent tests do not
+            // see drift from a previous test's Start() call.
+            _tool.Stop();
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Profiler/TestToolProfiler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08c95a99e51bfed47ae58b0532ab1e18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Port the Profiler tool surface that PR #338 introduced to the current codebase conventions (kebab-case tool IDs, `[McpPluginSkill*]` attributes, partial `Tool_Profiler` class under `Packages/com.ivanmurzak.unity.mcp/`).
- Twelve tools: `profiler-start`, `profiler-stop`, `profiler-get-status`, `profiler-get-memory-stats`, `profiler-get-rendering-stats`, `profiler-get-script-stats`, `profiler-capture-frame`, `profiler-clear-data`, `profiler-enable-module`, `profiler-list-modules`, `profiler-save-data`, `profiler-load-data`. All use only built-in Unity APIs (`UnityEngine.Profiling`, `UnityEditor`, `UnityEditorInternal`, `UnityEngine.Time`, `SystemInfo`) — no external Unity package dependency, so the tools stay in the core plugin per the issue's acceptance criterion.
- 18 EditMode tests under `TestToolProfiler.*` (partial class) covering start/stop idempotency, stats snapshot invariants, module bookkeeping (toggle / unknown / empty), and save/load round-trip with a JSON-shape check.

## Test plan
- [x] Target-specific local tests passed (`unity-mcp-cli run-tool tests-run --input '{"testMode":"EditMode"}'` → 946/946 passing, 0 failures).
- [x] Compiles cleanly (`assets-refresh` succeeded after the changes).
- [x] No version-bump files touched (`Packages/com.ivanmurzak.unity.mcp/package.json`, `cli/package.json` untouched).

Closes #595