### PR TITLE
refactor: switch consumer attribute usages from [McpPlugin*] to [Ai*]

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/AnimationTimeline.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/AnimationTimeline.cs
@@ -15,59 +15,59 @@ using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginPromptType]
+    [AiPromptType]
     public partial class Prompt_AnimationTimeline
     {
-        [McpPluginPrompt(Name = "setup-animator-controller", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-animator-controller", Role = Role.User, Enabled = false)]
         [Description("Create Animator Controller with state machine for character or object animation.")]
         public string SetupAnimatorController()
         {
             return "Create Animator Controller with basic state machine, setup animation states, transitions, parameters, and blend trees for character or object animation.";
         }
 
-        [McpPluginPrompt(Name = "create-simple-tweening", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-simple-tweening", Role = Role.User, Enabled = false)]
         [Description("Add simple tweening animations for UI elements or object movements.")]
         public string CreateSimpleTweening()
         {
             return "Create simple tweening animations using Animation curves, Coroutines, or tweening libraries like DOTween for smooth object movements and UI transitions.";
         }
 
-        [McpPluginPrompt(Name = "setup-timeline-sequence", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-timeline-sequence", Role = Role.User, Enabled = false)]
         [Description("Create Timeline sequence for cinematic scenes or complex gameplay sequences.")]
         public string SetupTimelineSequence()
         {
             return "Create Timeline asset with multiple tracks, setup Animation, Audio, and Activation tracks for cinematic sequences or complex gameplay events.";
         }
 
-        [McpPluginPrompt(Name = "add-animation-events", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-animation-events", Role = Role.User, Enabled = false)]
         [Description("Add animation events to trigger code execution at specific animation frames.")]
         public string AddAnimationEvents()
         {
             return "Add Animation Events to animation clips, create event handler methods, and setup communication between animation system and game logic.";
         }
 
-        [McpPluginPrompt(Name = "create-procedural-animation", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-procedural-animation", Role = Role.User, Enabled = false)]
         [Description("Implement procedural animation systems for dynamic object movement.")]
         public string CreateProceduralAnimation()
         {
             return "Create procedural animation systems using code-driven movement, physics-based animation, or mathematical functions for dynamic object behavior.";
         }
 
-        [McpPluginPrompt(Name = "setup-sprite-animation", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-sprite-animation", Role = Role.User, Enabled = false)]
         [Description("Create 2D sprite animations with proper frame timing and looping.")]
         public string SetupSpriteAnimation()
         {
             return "Create 2D sprite animations using Animation window, setup sprite sequences, configure frame timing, looping, and animation events for 2D characters.";
         }
 
-        [McpPluginPrompt(Name = "add-ik-system", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-ik-system", Role = Role.User, Enabled = false)]
         [Description("Implement Inverse Kinematics (IK) system for realistic character poses.")]
         public string AddIKSystem()
         {
             return "Setup IK system using Unity's built-in IK or custom IK solutions for realistic character posing, foot placement, and hand interactions.";
         }
 
-        [McpPluginPrompt(Name = "create-animation-blending", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-animation-blending", Role = Role.User, Enabled = false)]
         [Description("Setup animation blending and layering for complex character animations.")]
         public string CreateAnimationBlending()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/AssetManagement.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/AssetManagement.cs
@@ -15,59 +15,59 @@ using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginPromptType]
+    [AiPromptType]
     public partial class Prompt_AssetManagement
     {
-        [McpPluginPrompt(Name = "organize-project-structure", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "organize-project-structure", Role = Role.User, Enabled = false)]
         [Description("Create and organize standard project folder hierarchy with proper naming conventions.")]
         public string OrganizeProjectStructure()
         {
             return "Create standard project folder structure including Scripts, Prefabs, Materials, Textures, Audio, Scenes, and Resources folders with proper organization.";
         }
 
-        [McpPluginPrompt(Name = "import-setup-sprites", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "import-setup-sprites", Role = Role.User, Enabled = false)]
         [Description("Import sprite assets and configure sprite import settings with automatic slicing.")]
         public string ImportSetupSprites()
         {
             return "Import sprite assets, configure Texture Import Settings for sprites, setup sprite slicing for spritesheets, and organize sprites in appropriate folders.";
         }
 
-        [McpPluginPrompt(Name = "setup-audio-manager", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-audio-manager", Role = Role.User, Enabled = false)]
         [Description("Create audio management system with sound pools and volume controls.")]
         public string SetupAudioManager()
         {
             return "Create audio manager system with AudioSource pooling, volume controls, sound categories (SFX, Music, Voice), and easy-to-use audio playback methods.";
         }
 
-        [McpPluginPrompt(Name = "configure-build-settings", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "configure-build-settings", Role = Role.User, Enabled = false)]
         [Description("Setup build settings including scenes, player settings, and platform configurations.")]
         public string ConfigureBuildSettings()
         {
             return "Configure Build Settings with proper scene order, setup Player Settings including company name, product name, icons, and platform-specific configurations.";
         }
 
-        [McpPluginPrompt(Name = "create-material-library", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-material-library", Role = Role.User, Enabled = false)]
         [Description("Create a library of common materials with proper naming and organization.")]
         public string CreateMaterialLibrary()
         {
             return "Create collection of common materials (Standard, Unlit, UI, etc.) with proper naming conventions, organize in Materials folder, and setup material variants.";
         }
 
-        [McpPluginPrompt(Name = "setup-asset-bundles", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-asset-bundles", Role = Role.User, Enabled = false)]
         [Description("Configure AssetBundles for content streaming and modular loading.")]
         public string SetupAssetBundles()
         {
             return "Setup AssetBundle system for streaming assets, configure bundle naming and dependencies, create build pipeline for asset bundle generation.";
         }
 
-        [McpPluginPrompt(Name = "optimize-texture-settings", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "optimize-texture-settings", Role = Role.User, Enabled = false)]
         [Description("Optimize texture import settings for better performance and memory usage.")]
         public string OptimizeTextureSettings()
         {
             return "Review and optimize texture import settings including compression, max size, format selection, and platform-specific overrides for better performance.";
         }
 
-        [McpPluginPrompt(Name = "setup-addressables", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-addressables", Role = Role.User, Enabled = false)]
         [Description("Configure Unity Addressables system for efficient asset loading and management.")]
         public string SetupAddressables()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/DebuggingTesting.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/DebuggingTesting.cs
@@ -15,59 +15,59 @@ using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginPromptType]
+    [AiPromptType]
     public partial class Prompt_DebuggingTesting
     {
-        [McpPluginPrompt(Name = "add-debug-visualization", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-debug-visualization", Role = Role.User, Enabled = false)]
         [Description("Create debug visualization using Gizmos, Debug.DrawLine, and visual debugging tools.")]
         public string AddDebugVisualization()
         {
             return "Add debug visualization using OnDrawGizmos, OnDrawGizmosSelected, Debug.DrawLine, and Debug.DrawRay for visual debugging of game logic and physics.";
         }
 
-        [McpPluginPrompt(Name = "setup-performance-profiling", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-performance-profiling", Role = Role.User, Enabled = false)]
         [Description("Add profiler markers and performance tracking to identify bottlenecks.")]
         public string SetupPerformanceProfiling()
         {
             return "Add Profiler.BeginSample/EndSample markers, setup custom profiler counters, and create performance monitoring tools for identifying bottlenecks.";
         }
 
-        [McpPluginPrompt(Name = "create-test-scene", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-test-scene", Role = Role.User, Enabled = false)]
         [Description("Generate dedicated test scene for testing specific features and functionality.")]
         public string CreateTestScene()
         {
             return "Create dedicated test scene with testing GameObjects, test data, and isolated environment for testing specific features without affecting main scenes.";
         }
 
-        [McpPluginPrompt(Name = "add-logging-system", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-logging-system", Role = Role.User, Enabled = false)]
         [Description("Implement structured logging system with different log levels and categories.")]
         public string AddLoggingSystem()
         {
             return "Create structured logging system with log levels (Debug, Info, Warning, Error), categories, conditional compilation, and log file output options.";
         }
 
-        [McpPluginPrompt(Name = "create-unit-tests", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-unit-tests", Role = Role.User, Enabled = false)]
         [Description("Generate unit tests using Unity Test Framework for critical game systems.")]
         public string CreateUnitTests()
         {
             return "Create unit tests using Unity Test Framework, setup test assemblies, write EditMode and PlayMode tests for critical game systems and components.";
         }
 
-        [McpPluginPrompt(Name = "setup-debug-ui", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-debug-ui", Role = Role.User, Enabled = false)]
         [Description("Create debug UI overlay with runtime controls and information display.")]
         public string SetupDebugUI()
         {
             return "Create debug UI overlay with runtime controls, variable inspection, performance metrics display, and debugging tools accessible during gameplay.";
         }
 
-        [McpPluginPrompt(Name = "add-assertion-checks", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-assertion-checks", Role = Role.User, Enabled = false)]
         [Description("Add Debug.Assert statements and validation checks throughout the codebase.")]
         public string AddAssertionChecks()
         {
             return "Add Debug.Assert statements, null checks, range validations, and other assertion checks to catch bugs early in development builds.";
         }
 
-        [McpPluginPrompt(Name = "create-automated-tests", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-automated-tests", Role = Role.User, Enabled = false)]
         [Description("Setup automated testing pipeline with continuous integration support.")]
         public string CreateAutomatedTests()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/GameObjectComponent.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/GameObjectComponent.cs
@@ -15,59 +15,59 @@ using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginPromptType]
+    [AiPromptType]
     public partial class Prompt_GameObjectComponent
     {
-        [McpPluginPrompt(Name = "add-standard-components", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-standard-components", Role = Role.User, Enabled = false)]
         [Description("Add common Unity components like Rigidbody, Collider, and Renderer to selected GameObjects.")]
         public string AddStandardComponents()
         {
             return "Add standard Unity components to selected GameObjects: MeshRenderer, MeshFilter, Collider, and Rigidbody as appropriate for the object type.";
         }
 
-        [McpPluginPrompt(Name = "setup-player-controller", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-player-controller", Role = Role.User, Enabled = false)]
         [Description("Create a basic player controller with movement scripts and necessary components.")]
         public string SetupPlayerController()
         {
             return "Create player GameObject with CharacterController or Rigidbody, add basic movement script with WASD controls, camera follow, and jump mechanics.";
         }
 
-        [McpPluginPrompt(Name = "create-ui-canvas", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-ui-canvas", Role = Role.User, Enabled = false)]
         [Description("Setup Canvas with common UI elements and proper scaling configuration.")]
         public string CreateUICanvas()
         {
             return "Create UI Canvas with Canvas Scaler set to Scale With Screen Size, add EventSystem, and create common UI elements like buttons, text, and panels.";
         }
 
-        [McpPluginPrompt(Name = "add-physics-interactions", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-physics-interactions", Role = Role.User, Enabled = false)]
         [Description("Configure colliders, rigidbodies, and physics materials for realistic physics interactions.")]
         public string AddPhysicsInteractions()
         {
             return "Setup physics interactions by adding appropriate Colliders, configure Rigidbody properties, create Physics Materials, and setup collision layers.";
         }
 
-        [McpPluginPrompt(Name = "create-interactive-object", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-interactive-object", Role = Role.User, Enabled = false)]
         [Description("Create an interactive GameObject that responds to player input or triggers.")]
         public string CreateInteractiveObject()
         {
             return "Create interactive GameObject with appropriate collider setup, add interaction script with OnTriggerEnter/OnCollisionEnter events, and visual feedback.";
         }
 
-        [McpPluginPrompt(Name = "setup-audio-source", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-audio-source", Role = Role.User, Enabled = false)]
         [Description("Add and configure AudioSource component with common settings.")]
         public string SetupAudioSource()
         {
             return "Add AudioSource component to selected GameObjects, configure 3D spatial settings, volume, pitch, and loop options as appropriate.";
         }
 
-        [McpPluginPrompt(Name = "create-particle-effects", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-particle-effects", Role = Role.User, Enabled = false)]
         [Description("Add particle systems for visual effects like explosions, fire, or magic.")]
         public string CreateParticleEffects()
         {
             return "Create GameObject with Particle System component, configure emission, shape, velocity, and rendering settings for common visual effects.";
         }
 
-        [McpPluginPrompt(Name = "setup-animator-component", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-animator-component", Role = Role.User, Enabled = false)]
         [Description("Add Animator component and basic animation setup to GameObjects.")]
         public string SetupAnimatorComponent()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/SceneManagement.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/SceneManagement.cs
@@ -15,45 +15,45 @@ using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginPromptType]
+    [AiPromptType]
     public partial class Prompt_SceneManagement
     {
-        [McpPluginPrompt(Name = "setup-basic-scene", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-basic-scene", Role = Role.User, Enabled = false)]
         [Description("Setup a basic scene with camera, lighting, and basic environment.")]
         public string SetupBasicScene()
         {
             return "Create a basic Unity scene with Main Camera, Directional Light, and basic environment setup.";
         }
 
-        [McpPluginPrompt(Name = "organize-scene-hierarchy", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "organize-scene-hierarchy", Role = Role.User, Enabled = false)]
         [Description("Clean up and organize the scene hierarchy logically with proper naming and grouping.")]
         public string OrganizeSceneHierarchy()
         {
             return "Organize the scene hierarchy by grouping related GameObjects, using proper naming conventions, and creating empty parent objects for logical structure.";
         }
 
-        [McpPluginPrompt(Name = "add-lighting-setup", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-lighting-setup", Role = Role.User, Enabled = false)]
         [Description("Configure proper lighting setup including directional light, skybox, and ambient lighting.")]
         public string AddLightingSetup()
         {
             return "Setup comprehensive lighting including Directional Light, configure Skybox, adjust ambient lighting settings, and add Light Probes if needed.";
         }
 
-        [McpPluginPrompt(Name = "create-prefab-from-selection", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-prefab-from-selection", Role = Role.User, Enabled = false)]
         [Description("Convert selected GameObjects into reusable prefabs with proper naming and folder organization.")]
         public string CreatePrefabFromSelection()
         {
             return "Create prefab from currently selected GameObjects, place it in appropriate Prefabs folder, and replace the original with prefab instance.";
         }
 
-        [McpPluginPrompt(Name = "setup-scene-camera", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-scene-camera", Role = Role.User, Enabled = false)]
         [Description("Configure scene camera with appropriate settings for the project type.")]
         public string SetupSceneCamera()
         {
             return "Setup Main Camera with appropriate Field of View, Clipping Planes, Clear Flags, and positioning for the current scene type.";
         }
 
-        [McpPluginPrompt(Name = "create-environment-template", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-environment-template", Role = Role.User, Enabled = false)]
         [Description("Create a basic environment template with ground, sky, and common environmental elements.")]
         public string CreateEnvironmentTemplate()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/ScriptingCode.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Prompt/ScriptingCode.cs
@@ -15,59 +15,59 @@ using com.IvanMurzak.McpPlugin.Common.Model;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginPromptType]
+    [AiPromptType]
     public partial class Prompt_ScriptingCode
     {
-        [McpPluginPrompt(Name = "generate-monobehaviour-template", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "generate-monobehaviour-template", Role = Role.User, Enabled = false)]
         [Description("Create a MonoBehaviour script template with common Unity lifecycle methods and patterns.")]
         public string GenerateMonoBehaviourTemplate()
         {
             return "Create new MonoBehaviour script with Start, Update, and other common Unity lifecycle methods, including proper using statements and namespace.";
         }
 
-        [McpPluginPrompt(Name = "add-event-system", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-event-system", Role = Role.User, Enabled = false)]
         [Description("Implement UnityEvent-based communication system between GameObjects.")]
         public string AddEventSystem()
         {
             return "Create event system using UnityEvents, UnityActions, or custom event delegates for decoupled communication between game systems and components.";
         }
 
-        [McpPluginPrompt(Name = "create-singleton-manager", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-singleton-manager", Role = Role.User, Enabled = false)]
         [Description("Generate a singleton manager class following Unity best practices.")]
         public string CreateSingletonManager()
         {
             return "Create singleton manager class with proper initialization, thread-safe implementation, and DontDestroyOnLoad setup for persistent game managers.";
         }
 
-        [McpPluginPrompt(Name = "setup-coroutine-framework", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-coroutine-framework", Role = Role.User, Enabled = false)]
         [Description("Add coroutine-based asynchronous operations and utility methods.")]
         public string SetupCoroutineFramework()
         {
             return "Create coroutine utilities for async operations like delayed execution, gradual value changes, and time-based operations with proper cleanup.";
         }
 
-        [McpPluginPrompt(Name = "create-scriptableobject-data", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "create-scriptableobject-data", Role = Role.User, Enabled = false)]
         [Description("Generate ScriptableObject classes for data storage and configuration.")]
         public string CreateScriptableObjectData()
         {
             return "Create ScriptableObject classes for game data, settings, and configuration with proper CreateAssetMenu attributes and serialization.";
         }
 
-        [McpPluginPrompt(Name = "implement-object-pooling", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "implement-object-pooling", Role = Role.User, Enabled = false)]
         [Description("Create object pooling system for performance optimization.")]
         public string ImplementObjectPooling()
         {
             return "Implement object pooling system for frequently instantiated/destroyed objects like bullets, enemies, or particles to improve performance.";
         }
 
-        [McpPluginPrompt(Name = "add-state-machine", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "add-state-machine", Role = Role.User, Enabled = false)]
         [Description("Create a finite state machine for character or game state management.")]
         public string AddStateMachine()
         {
             return "Create finite state machine implementation for managing character states, game states, or AI behavior with proper state transitions.";
         }
 
-        [McpPluginPrompt(Name = "setup-dependency-injection", Role = Role.User, Enabled = false)]
+        [AiPrompt(Name = "setup-dependency-injection", Role = Role.User, Enabled = false)]
         [Description("Implement simple dependency injection pattern for better code organization.")]
         public string SetupDependencyInjection()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Resource/GameObject.Hierarchy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Resource/GameObject.Hierarchy.cs
@@ -26,10 +26,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
     using Consts = McpPlugin.Common.Consts;
 
-    [McpPluginResourceType]
+    [AiResourceType]
     public partial class Resource_GameObject
     {
-        [McpPluginResource
+        [AiResource
         (
             Name = "GameObject from Current Scene by Path",
             Route = "gameobject://currentScene/{path}",

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Ping.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Ping.cs
@@ -14,11 +14,11 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Ping
     {
         public const string PingToolId = "ping";
-        [McpPluginTool
+        [AiTool
         (
             PingToolId,
             Title = "Ping",
@@ -26,9 +26,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             ToolType = McpToolType.System
         )]
-        [McpPluginSkillDescription("Lightweight readiness probe. Returns the input `message` echoed back, or `'pong'` " +
+        [AiSkillDescription("Lightweight readiness probe. Returns the input `message` echoed back, or `'pong'` " +
             "when omitted. Useful for CLI health checks and SignalR connectivity smoke tests.")]
-        [McpPluginSkillBody("Lightweight readiness probe. Returns the input message or 'pong' if omitted.\n\n" +
+        [AiSkillBody("Lightweight readiness probe. Returns the input message or 'pong' if omitted.\n\n" +
             "## Inputs\n\n" +
             "- `message` (optional) — when present, echoed back verbatim.\n\n" +
             "## Behavior\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.SkillBody.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.SkillBody.cs
@@ -27,10 +27,10 @@ using UnityEngine;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Sample
     {
-        [McpPluginTool(""sample-get"", Title = ""Sample / Get"")]
+        [AiTool(""sample-get"", Title = ""Sample / Get"")]
         [Description(""Finds a GameObject and returns its ref data."")]
         public GameObjectRef Get
         (
@@ -47,7 +47,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             });
         }
 
-        [McpPluginTool(""sample-rename"", Title = ""Sample / Rename"")]
+        [AiTool(""sample-rename"", Title = ""Sample / Rename"")]
         [Description(""Renames a GameObject."")]
         public void Rename
         (
@@ -113,7 +113,7 @@ using AIGD;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Sample
     {
         public ResponseCallValueTool<MyResult> MyTool(...)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Create.cs
@@ -23,7 +23,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Skills
     {
         public const string SkillsCreateToolId = "unity-skill-create";
-        [McpPluginTool
+        [AiTool
         (
             SkillsCreateToolId,
             Title = "Skill (Tool) / Create",
@@ -31,19 +31,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Enabled = false,
             ToolType = McpToolType.System
         )]
-        [McpPluginSkillDescription("Create a new skill (MCP tool) for the Unity Editor by writing a C# (.cs) file " +
+        [AiSkillDescription("Create a new skill (MCP tool) for the Unity Editor by writing a C# (.cs) file " +
             "that Unity compiles into the project. After compilation the new tool becomes callable through MCP. " +
-            "The file must be a partial class decorated with [McpPluginToolType], each tool method must be " +
-            "decorated with [McpPluginTool], the class name should match the file name, all Unity API calls must " +
+            "The file must be a partial class decorated with [AiToolType], each tool method must be " +
+            "decorated with [AiTool], the class name should match the file name, all Unity API calls must " +
             "run via com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(), and the method should either " +
             "return a structured data model (for parseable output) or void (for side-effect-only operations). " +
             "See the body of this skill for a full sample and best-practice notes.")]
-        [McpPluginSkillBody(SkillsCreateSkillBody)]
+        [AiSkillBody(SkillsCreateSkillBody)]
         [Description("Create a new skill using C# code. " +
             "It will be added into the project as a .cs file and compiled by Unity. " +
             "The skill will be available for use after compilation.\n" +
             "\n" +
-            "It must be a partial class decorated with [McpPluginToolType]. Each tool method must be decorated with [McpPluginTool]. " +
+            "It must be a partial class decorated with [AiToolType]. Each tool method must be decorated with [AiTool]. " +
             "The class name should match the file name. " +
             "All Unity API calls must use com.IvanMurzak.ReflectorNet.Utils.MainThread.Instance.Run(). " +
             "Return a data model for structured output, or void for side-effect-only operations. " +
@@ -61,10 +61,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "\n" +
             "namespace com.IvanMurzak.Unity.MCP.Editor.API\n" +
             "{\n" +
-            "    [McpPluginToolType]\n" +
+            "    [AiToolType]\n" +
             "    public partial class Tool_Sample\n" +
             "    {\n" +
-            "        [McpPluginTool(\"sample-get\", Title = \"Sample / Get\")]\n" +
+            "        [AiTool(\"sample-get\", Title = \"Sample / Get\")]\n" +
             "        [Description(\"Finds a GameObject and returns its ref data.\")]\n" +
             "        public GameObjectRef Get\n" +
             "        (\n" +
@@ -81,7 +81,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "            });\n" +
             "        }\n" +
             "\n" +
-            "        [McpPluginTool(\"sample-rename\", Title = \"Sample / Rename\")]\n" +
+            "        [AiTool(\"sample-rename\", Title = \"Sample / Rename\")]\n" +
             "        [Description(\"Renames a GameObject.\")]\n" +
             "        public void Rename\n" +
             "        (\n" +
@@ -160,7 +160,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "\n" +
             "namespace com.IvanMurzak.Unity.MCP.Editor.API\n" +
             "{\n" +
-            "    [McpPluginToolType]\n" +
+            "    [AiToolType]\n" +
             "    public partial class Tool_Sample\n" +
             "    {\n" +
             "        public ResponseCallValueTool<MyResult> MyTool(...)\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Generate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.Generate.cs
@@ -21,7 +21,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Skills
     {
         public const string SkillsGenerateToolId = "unity-skill-generate";
-        [McpPluginTool
+        [AiTool
         (
             SkillsGenerateToolId,
             Title = "Skill (Tool) / Generate All",
@@ -29,10 +29,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             Enabled = false,
             ToolType = McpToolType.System
         )]
-        [McpPluginSkillDescription("Regenerate every `SKILL.md` from the project's currently-registered MCP tools into " +
+        [AiSkillDescription("Regenerate every `SKILL.md` from the project's currently-registered MCP tools into " +
             "the configured skills folder (or a project-relative override path). " +
-            "Writes the YAML `description:` from `[McpPluginSkillDescription]` and the body from `[McpPluginSkillBody]`.")]
-        [McpPluginSkillBody("Generate all skills from the existed Tools in the Unity Project.\n\n" +
+            "Writes the YAML `description:` from `[AiSkillDescription]` and the body from `[AiSkillBody]`.")]
+        [AiSkillBody("Generate all skills from the existed Tools in the Unity Project.\n\n" +
             "## Inputs\n\n" +
             "- `path` (optional) — project-relative skills folder (e.g. `.claude/skills`). Absolute paths and `..` " +
             "traversal segments are rejected. When null/empty, the editor's configured `SkillsRootFolderAbsolutePath` " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/SystemTool/Skills.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Skills
     {
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Copy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Copy.cs
@@ -22,16 +22,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsCopyToolId = "assets-copy";
-        [McpPluginTool
+        [AiTool
         (
             AssetsCopyToolId,
             Title = "Assets / Copy",
             Enabled = false
         )]
-        [McpPluginSkillDescription("Copy assets at given paths and store them at new paths. " +
+        [AiSkillDescription("Copy assets at given paths and store them at new paths. " +
             "Refreshes the AssetDatabase at the end. " +
             "Use '" + AssetsFindToolId + "' to locate the source assets first.")]
-        [McpPluginSkillBody("Copy assets at given paths and store them at new paths. " +
+        [AiSkillBody("Copy assets at given paths and store them at new paths. " +
             "Does AssetDatabase.Refresh() at the end. " +
             "Use '" + AssetsFindToolId + "' tool to find assets before copying.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.CreateFolders.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.CreateFolders.cs
@@ -34,16 +34,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         };
 
         public const string AssetsCreateFolderToolId = "assets-create-folder";
-        [McpPluginTool
+        [AiTool
         (
             AssetsCreateFolderToolId,
             Title = "Assets / Create Folder",
             Enabled = false
         )]
-        [McpPluginSkillDescription("Create a new folder under a parent folder inside 'Assets/'. " +
+        [AiSkillDescription("Create a new folder under a parent folder inside 'Assets/'. " +
             "The parent path must start with 'Assets/' and every intermediate folder in it must already exist. " +
             "Refreshes the AssetDatabase at the end and returns the GUID(s) of the created folder(s).")]
-        [McpPluginSkillBody("Creates a new folder in the specified parent folder. " +
+        [AiSkillBody("Creates a new folder in the specified parent folder. " +
             "The parent folder string must start with the 'Assets' folder, and all folders within the parent folder string must already exist. " +
             "For example, when specifying 'Assets/ParentFolder1/ParentFolder2/', the new folder will be created in 'ParentFolder2' only if ParentFolder1 and ParentFolder2 already exist. " +
             "Use it to organize scripts and assets in the project. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Delete.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Delete.cs
@@ -24,17 +24,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsDeleteToolId = "assets-delete";
-        [McpPluginTool
+        [AiTool
         (
             AssetsDeleteToolId,
             Title = "Assets / Delete",
             DestructiveHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Delete the assets at the given project paths. " +
+        [AiSkillDescription("Delete the assets at the given project paths. " +
             "Refreshes the AssetDatabase at the end. " +
             "Use '" + AssetsFindToolId + "' to locate the assets first.")]
-        [McpPluginSkillBody("Delete the assets at paths from the project. " +
+        [AiSkillBody("Delete the assets at paths from the project. " +
             "Does AssetDatabase.Refresh() at the end. " +
             "Use '" + AssetsFindToolId + "' tool to find assets before deleting.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Find.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Find.cs
@@ -21,17 +21,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsFindToolId = "assets-find";
-        [McpPluginTool
+        [AiTool
         (
             AssetsFindToolId,
             Title = "Assets / Find",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Search the Unity asset database using a search filter string. " +
+        [AiSkillDescription("Search the Unity asset database using a search filter string. " +
             "The filter accepts names, labels (`l:`), types (`t:`), AssetBundles (`b:`), areas (`a:`), and globs (`glob:`). " +
             "See the body for the full filter syntax.")]
-        [McpPluginSkillBody("Search the asset database using the search filter string. " +
+        [AiSkillBody("Search the asset database using the search filter string. " +
             "Allows you to search for Assets. The string argument can provide names, labels or types (classnames).\n\n" +
             "## Filter syntax\n\n" +
             "- **Name** — filter assets by their filename (without extension). Words separated by whitespace are " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.FindBuiltIn.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.FindBuiltIn.cs
@@ -25,17 +25,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsFindBuiltInToolId = "assets-find-built-in";
-        [McpPluginTool
+        [AiTool
         (
             AssetsFindBuiltInToolId,
             Title = "Assets / Find (Built-in)",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Search the built-in assets of the Unity Editor (located at " +
+        [AiSkillDescription("Search the built-in assets of the Unity Editor (located at " +
             ExtensionsRuntimeObject.UnityEditorBuiltInResourcesPath + "). " +
             "Filters by name and/or type; built-in assets have no GUID so GUID-based lookups are not supported.")]
-        [McpPluginSkillBody("Search the built-in assets of the Unity Editor located in the built-in resources: " +
+        [AiSkillBody("Search the built-in assets of the Unity Editor located in the built-in resources: " +
             ExtensionsRuntimeObject.UnityEditorBuiltInResourcesPath + ". " +
             "Doesn't support GUIDs since built-in assets do not have them.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.GetData.cs
@@ -26,17 +26,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsGetDataToolId = "assets-get-data";
-        [McpPluginTool
+        [AiTool
         (
             AssetsGetDataToolId,
             Title = "Assets / Get Data",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Get asset data from the asset file in the Unity project — every serializable " +
+        [AiSkillDescription("Get asset data from the asset file in the Unity project — every serializable " +
             "field and property. Supports token-saving path-scoped reads via `paths` or `viewQuery`. " +
             "Use '" + AssetsFindToolId + "' to find the asset first.")]
-        [McpPluginSkillBody("Get asset data from the asset file in the Unity project. " +
+        [AiSkillBody("Get asset data from the asset file in the Unity project. " +
             "It includes all serializable fields and properties of the asset. " +
             "Use '" + AssetsFindToolId + "' tool to find asset before using this tool.\n\n" +
             "## Path-scoped reads (token-saving)\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Material.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Material.Create.cs
@@ -23,15 +23,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsMaterialCreateToolId = "assets-material-create";
-        [McpPluginTool
+        [AiTool
         (
             AssetsMaterialCreateToolId,
             Title = "Assets / Create Material"
         )]
-        [McpPluginSkillDescription("Create a new Material asset with default parameters at a given 'Assets/'-rooted " +
+        [AiSkillDescription("Create a new Material asset with default parameters at a given 'Assets/'-rooted " +
             "path ending in '.mat'. Creates intermediate folders if missing. Use '" +
             Tool_Assets_Shader.AssetsShaderListAllToolId + "' to find a valid `shaderName`.")]
-        [McpPluginSkillBody("Create new material asset with default parameters. " +
+        [AiSkillBody("Create new material asset with default parameters. " +
             "Creates folders recursively if they do not exist. " +
             "Provide proper 'shaderName' - use '" + Tool_Assets_Shader.AssetsShaderListAllToolId + "' tool to find available shaders.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Material.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Material.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Assets_Material
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
@@ -30,14 +30,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsModifyToolId = "assets-modify";
-        [McpPluginTool
+        [AiTool
         (
             AssetsModifyToolId,
             Title = "Assets / Modify",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription(ModifySkill.Description)]
-        [McpPluginSkillBody(ModifySkill.Body)]
+        [AiSkillDescription(ModifySkill.Description)]
+        [AiSkillBody(ModifySkill.Body)]
         [Description("Modify asset file in the project. " +
             "Use '" + AssetsGetDataToolId + "' tool first to inspect the asset structure before modifying. " +
             "Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
@@ -29,14 +29,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsModifyToolId = "assets-modify";
-        [McpPluginTool
+        [AiTool
         (
             AssetsModifyToolId,
             Title = "Assets / Modify",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription(ModifySkill.Description)]
-        [McpPluginSkillBody(ModifySkill.Body)]
+        [AiSkillDescription(ModifySkill.Description)]
+        [AiSkillBody(ModifySkill.Body)]
         [Description("Modify asset file in the project. " +
             "Use '" + AssetsGetDataToolId + "' tool first to inspect the asset structure before modifying. " +
             "Not allowed to modify asset file in 'Packages/' folder. Please modify it in 'Assets/' folder.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Move.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Move.cs
@@ -23,16 +23,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsMoveToolId = "assets-move";
-        [McpPluginTool
+        [AiTool
         (
             AssetsMoveToolId,
             Title = "Assets / Move",
             Enabled = false
         )]
-        [McpPluginSkillDescription("Move or rename assets at the given project paths. " +
+        [AiSkillDescription("Move or rename assets at the given project paths. " +
             "Refreshes the AssetDatabase at the end. " +
             "Use '" + AssetsFindToolId + "' to locate the assets first.")]
-        [McpPluginSkillBody("Move the assets at paths in the project. " +
+        [AiSkillBody("Move the assets at paths in the project. " +
             "Should be used for asset rename. " +
             "Does AssetDatabase.Refresh() at the end. " +
             "Use '" + AssetsFindToolId + "' tool to find assets before moving.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Close.cs
@@ -23,15 +23,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets_Prefab
     {
         public const string AssetsPrefabCloseToolId = "assets-prefab-close";
-        [McpPluginTool
+        [AiTool
         (
             AssetsPrefabCloseToolId,
             Title = "Assets / Prefab / Close"
         )]
-        [McpPluginSkillDescription("Close the currently opened prefab edit stage. " +
+        [AiSkillDescription("Close the currently opened prefab edit stage. " +
             "Optionally saves changes back to the prefab asset before closing. " +
             "Pair with '" + AssetsPrefabOpenToolId + "' to enter the edit mode first.")]
-        [McpPluginSkillBody("Close currently opened prefab. " +
+        [AiSkillBody("Close currently opened prefab. " +
             "Use it when you are in prefab editing mode in Unity Editor. " +
             "Use '" + AssetsPrefabOpenToolId + "' tool to open a prefab first.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Create.cs
@@ -23,16 +23,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets_Prefab
     {
         public const string AssetsPrefabCreateToolId = "assets-prefab-create";
-        [McpPluginTool
+        [AiTool
         (
             AssetsPrefabCreateToolId,
             Title = "Assets / Prefab / Create"
         )]
-        [McpPluginSkillDescription("Create a Prefab (or Prefab Variant) at a project asset path. " +
+        [AiSkillDescription("Create a Prefab (or Prefab Variant) at a project asset path. " +
             "Source can be a scene GameObject (`gameObjectRef`) or an existing prefab asset (`sourcePrefabAssetPath`). " +
             "Creates intermediate folders if missing. Use '" + Tool_GameObject.GameObjectFindToolId +
             "' to locate the source GameObject first.")]
-        [McpPluginSkillBody("Create a prefab from a GameObject in the current active scene. " +
+        [AiSkillBody("Create a prefab from a GameObject in the current active scene. " +
             "The prefab will be saved in the project assets at the specified path. " +
             "Creates folders recursively if they do not exist. " +
             "If the source GameObject is already a prefab instance and 'connectGameObjectToPrefab' is true, a Prefab Variant is created automatically. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Instantiate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Instantiate.cs
@@ -24,15 +24,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets_Prefab
     {
         public const string AssetsPrefabInstantiateToolId = "assets-prefab-instantiate";
-        [McpPluginTool
+        [AiTool
         (
             AssetsPrefabInstantiateToolId,
             Title = "Assets / Prefab / Instantiate"
         )]
-        [McpPluginSkillDescription("Instantiate a prefab into the currently active scene at an optional position/rotation/scale, " +
+        [AiSkillDescription("Instantiate a prefab into the currently active scene at an optional position/rotation/scale, " +
             "parented under an optional scene GameObject path. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' to locate the prefab asset first.")]
-        [McpPluginSkillBody("Instantiates prefab in the current active scene. " +
+        [AiSkillBody("Instantiates prefab in the current active scene. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool to find prefab assets in the project.\n\n" +
             "## Inputs\n\n" +
             "- `prefabAssetPath` — project asset path of the prefab to instantiate.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Open.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Open.cs
@@ -23,15 +23,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets_Prefab
     {
         public const string AssetsPrefabOpenToolId = "assets-prefab-open";
-        [McpPluginTool
+        [AiTool
         (
             AssetsPrefabOpenToolId,
             Title = "Assets / Prefab / Open"
         )]
-        [McpPluginSkillDescription("Open the prefab edit stage for a prefab instance or prefab asset GameObject. " +
+        [AiSkillDescription("Open the prefab edit stage for a prefab instance or prefab asset GameObject. " +
             "Modifications inside the edit stage propagate to all instances. " +
             "Pair with '" + AssetsPrefabCloseToolId + "' to exit the stage when done.")]
-        [McpPluginSkillBody("Open prefab edit mode for a specific GameObject. " +
+        [AiSkillBody("Open prefab edit mode for a specific GameObject. " +
             "In the Edit mode you can modify the prefab. " +
             "The modification will be applied to all instances of the prefab across the project. " +
             "Note: Please use '" + AssetsPrefabCloseToolId + "' tool later to exit prefab editing mode.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.Save.cs
@@ -23,15 +23,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets_Prefab
     {
         public const string AssetsPrefabSaveToolId = "assets-prefab-save";
-        [McpPluginTool
+        [AiTool
         (
             AssetsPrefabSaveToolId,
             Title = "Assets / Prefab / Save",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Save the currently opened prefab edit stage back to its prefab asset without exiting the stage. " +
+        [AiSkillDescription("Save the currently opened prefab edit stage back to its prefab asset without exiting the stage. " +
             "Pair with '" + AssetsPrefabOpenToolId + "' to enter the edit mode first.")]
-        [McpPluginSkillBody("Save a prefab. " +
+        [AiSkillBody("Save a prefab. " +
             "Use it when you are in prefab editing mode in Unity Editor. " +
             "Use '" + AssetsPrefabOpenToolId + "' tool to open a prefab first.\n\n" +
             "## Behavior\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Prefab.cs
@@ -14,7 +14,7 @@ using UnityEditor;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Assets_Prefab
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Refresh.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Refresh.cs
@@ -22,16 +22,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets
     {
         public const string AssetsRefreshToolId = "assets-refresh";
-        [McpPluginTool
+        [AiTool
         (
             AssetsRefreshToolId,
             Title = "Assets / Refresh",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Refresh the Unity AssetDatabase. " +
+        [AiSkillDescription("Refresh the Unity AssetDatabase. " +
             "Use after files were added or updated outside of the Unity API, or to force script recompilation " +
             "when a '.cs' file changed. Returns a processing/success response and waits for compilation when triggered.")]
-        [McpPluginSkillBody("Refreshes the AssetDatabase. " +
+        [AiSkillBody("Refreshes the AssetDatabase. " +
             "Use it if any file was added or updated in the project outside of Unity API. " +
             "Use it if need to force scripts recompilation when '.cs' file changed.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.GetData.cs
@@ -30,18 +30,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         public const string AssetsShaderGetDataToolId = "assets-shader-get-data";
 
-        [McpPluginTool
+        [AiTool
         (
             AssetsShaderGetDataToolId,
             Title = "Assets / Shader / Get Data",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Get detailed data about a shader asset — properties, subshaders, passes, " +
+        [AiSkillDescription("Get detailed data about a shader asset — properties, subshaders, passes, " +
             "compilation messages, and supported status. Supports token-saving path-scoped reads via `paths` or " +
             "`viewQuery`. Use '" + Tool_Assets.AssetsFindToolId + "' with `t:Shader` or '" +
             AssetsShaderListAllToolId + "' to locate the shader first.")]
-        [McpPluginSkillBody("Get detailed data about a shader asset in the Unity project. " +
+        [AiSkillBody("Get detailed data about a shader asset in the Unity project. " +
             "Returns shader properties, subshaders, passes, compilation errors, and supported status. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool with filter 't:Shader' to find shaders, " +
             "or '" + AssetsShaderListAllToolId + "' tool to list all shader names.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.ListAll.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.ListAll.cs
@@ -21,16 +21,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Assets_Shader
     {
         public const string AssetsShaderListAllToolId = "assets-shader-list-all";
-        [McpPluginTool
+        [AiTool
         (
             AssetsShaderListAllToolId,
             Title = "Assets / List Shaders",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("List all shaders available in the project assets and packages, sorted by name. " +
+        [AiSkillDescription("List all shaders available in the project assets and packages, sorted by name. " +
             "Use this to discover a valid `shaderName` for '" + Tool_Assets.AssetsMaterialCreateToolId + "'.")]
-        [McpPluginSkillBody("List all available shaders in the project assets and packages. " +
+        [AiSkillBody("List all available shaders in the project assets and packages. " +
             "Returns their names. " +
             "Use this to find a shader name for '" + Tool_Assets.AssetsMaterialCreateToolId + "' tool.\n\n" +
             "## Behavior\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Shader.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Assets_Shader
     {
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Assets
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.ClearLogs.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.ClearLogs.cs
@@ -20,7 +20,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Console
     {
         public const string ConsoleClearLogsToolId = "console-clear-logs";
-        [McpPluginTool
+        [AiTool
         (
             ConsoleClearLogsToolId,
             Title = "Console / Clear Logs",
@@ -28,9 +28,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             DestructiveHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Clear the MCP log cache (used by '" + ConsoleGetLogsToolId + "') and the Unity Editor Console window. " +
+        [AiSkillDescription("Clear the MCP log cache (used by '" + ConsoleGetLogsToolId + "') and the Unity Editor Console window. " +
             "Useful for isolating logs to a specific action by clearing the slate first.")]
-        [McpPluginSkillBody("Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. " +
+        [AiSkillBody("Clears the MCP log cache (used by console-get-logs) and the Unity Editor Console window. " +
             "Useful for isolating errors related to a specific action by clearing logs before performing the action.\n\n" +
             "## Behavior\n\n" +
             "Calls `Debug.ClearDeveloperConsole()` to wipe the Editor Console, then clears the MCP-side `LogCollector` " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.GetLogs.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.GetLogs.cs
@@ -19,16 +19,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Console
     {
         public const string ConsoleGetLogsToolId = "console-get-logs";
-        [McpPluginTool
+        [AiTool
         (
             ConsoleGetLogsToolId,
             Title = "Console / Get Logs",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Retrieve Unity Editor logs from the MCP plugin's `LogCollector`, " +
+        [AiSkillDescription("Retrieve Unity Editor logs from the MCP plugin's `LogCollector`, " +
             "optionally filtered by log type or time window. Useful for debugging and monitoring Editor activity.")]
-        [McpPluginSkillBody("Retrieves Unity Editor logs. " +
+        [AiSkillBody("Retrieves Unity Editor logs. " +
             "Useful for debugging and monitoring Unity Editor activity.\n\n" +
             "## Inputs\n\n" +
             "- `maxEntries` (default 100, minimum 1) — caps the size of the returned array.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Console.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Console
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.GetState.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.GetState.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Editor
     {
         public const string EditorApplicationGetStateToolId = "editor-application-get-state";
-        [McpPluginTool
+        [AiTool
         (
             EditorApplicationGetStateToolId,
             Title = "Editor / Application / Get State",
@@ -27,9 +27,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Return the current state of `UnityEditor.EditorApplication` — playmode, " +
+        [AiSkillDescription("Return the current state of `UnityEditor.EditorApplication` — playmode, " +
             "paused state, compilation state, and related flags.")]
-        [McpPluginSkillBody("Returns available information about 'UnityEditor.EditorApplication'. " +
+        [AiSkillBody("Returns available information about 'UnityEditor.EditorApplication'. " +
             "Use it to get information about the current state of the Unity Editor application. " +
             "Such as: playmode, paused state, compilation state, etc.\n\n" +
             "## Behavior\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.SetState.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Application.SetState.cs
@@ -22,17 +22,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Editor
     {
         public const string EditorApplicationSetStateToolId = "editor-application-set-state";
-        [McpPluginTool
+        [AiTool
         (
             EditorApplicationSetStateToolId,
             Title = "Editor / Application / Set State",
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Start / stop / pause the Unity Editor 'playmode'. " +
+        [AiSkillDescription("Start / stop / pause the Unity Editor 'playmode'. " +
             "Use '" + EditorApplicationGetStateToolId + "' to inspect the current state first. " +
             "Throws if the project currently has compilation errors.")]
-        [McpPluginSkillBody("Control the Unity Editor application state. " +
+        [AiSkillBody("Control the Unity Editor application state. " +
             "You can start, stop, or pause the 'playmode'. " +
             "Use '" + EditorApplicationGetStateToolId + "' tool to get the current state first.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.cs
@@ -22,7 +22,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Editor_Selection
     {
         public const string EditorSelectionGetToolId = "editor-selection-get";
-        [McpPluginTool
+        [AiTool
         (
             EditorSelectionGetToolId,
             Title = "Editor / Selection / Get",
@@ -30,8 +30,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription(GetSkill.Description)]
-        [McpPluginSkillBody(GetSkill.Body)]
+        [AiSkillDescription(GetSkill.Description)]
+        [AiSkillBody(GetSkill.Body)]
         [Description("Get information about the current Selection in the Unity Editor. " +
             "Use '" + EditorSelectionSetToolId + "' tool to set the selection.")]
         public SelectionData Get(

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Get.pre-Unity.6.5.cs
@@ -22,7 +22,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Editor_Selection
     {
         public const string EditorSelectionGetToolId = "editor-selection-get";
-        [McpPluginTool
+        [AiTool
         (
             EditorSelectionGetToolId,
             Title = "Editor / Selection / Get",
@@ -30,8 +30,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription(GetSkill.Description)]
-        [McpPluginSkillBody(GetSkill.Body)]
+        [AiSkillDescription(GetSkill.Description)]
+        [AiSkillBody(GetSkill.Body)]
         [Description("Get information about the current Selection in the Unity Editor. " +
             "Use '" + EditorSelectionSetToolId + "' tool to set the selection.")]
         public SelectionData Get(

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.cs
@@ -23,15 +23,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Editor_Selection
     {
         public const string EditorSelectionSetToolId = "editor-selection-set";
-        [McpPluginTool
+        [AiTool
         (
             EditorSelectionSetToolId,
             Title = "Editor / Selection / Set",
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription(SetSkill.Description)]
-        [McpPluginSkillBody(SetSkill.Body)]
+        [AiSkillDescription(SetSkill.Description)]
+        [AiSkillBody(SetSkill.Body)]
         [Description("Set the current Selection in the Unity Editor to the provided objects. " +
             "Use '" + EditorSelectionGetToolId + "' tool to get the current selection first.")]
         public SelectionData Set(ObjectRef[] select)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.Set.pre-Unity.6.5.cs
@@ -23,15 +23,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Editor_Selection
     {
         public const string EditorSelectionSetToolId = "editor-selection-set";
-        [McpPluginTool
+        [AiTool
         (
             EditorSelectionSetToolId,
             Title = "Editor / Selection / Set",
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription(SetSkill.Description)]
-        [McpPluginSkillBody(SetSkill.Body)]
+        [AiSkillDescription(SetSkill.Description)]
+        [AiSkillBody(SetSkill.Body)]
         [Description("Set the current Selection in the Unity Editor to the provided objects. " +
             "Use '" + EditorSelectionGetToolId + "' tool to get the current selection first.")]
         public SelectionData Set(ObjectRef[] select)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.cs
@@ -18,7 +18,7 @@ using UnityEditor;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Editor_Selection
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.Selection.pre-Unity.6.5.cs
@@ -18,7 +18,7 @@ using UnityEditor;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Editor_Selection
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Editor.cs
@@ -16,7 +16,7 @@ using UnityEditor;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Editor
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Add.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Add.cs
@@ -23,16 +23,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectComponentAddToolId = "gameobject-component-add";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectComponentAddToolId,
             Title = "GameObject / Component / Add"
         )]
-        [McpPluginSkillDescription("Add one or more Components to a GameObject in the opened Prefab or active Scene. " +
+        [AiSkillDescription("Add one or more Components to a GameObject in the opened Prefab or active Scene. " +
             "Component types are looked up by full name (with namespace) or by class-name fallback. " +
             "Use '" + GameObjectFindToolId + "' to locate the host GameObject and '" + ComponentListToolId +
             "' to discover valid component type names.")]
-        [McpPluginSkillBody("Add Component to GameObject in opened Prefab or in a Scene. " +
+        [AiSkillBody("Add Component to GameObject in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject first. " +
             "Use '" + ComponentListToolId + "' tool to find the component type names to add.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Destroy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Destroy.cs
@@ -22,17 +22,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectComponentDestroyToolId = "gameobject-component-destroy";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectComponentDestroyToolId,
             Title = "GameObject / Component / Destroy",
             DestructiveHint = true
         )]
-        [McpPluginSkillDescription("Destroy one or more Components from a target GameObject. Missing (null) components " +
+        [AiSkillDescription("Destroy one or more Components from a target GameObject. Missing (null) components " +
             "are skipped — they cannot be destroyed. " +
             "Use '" + GameObjectFindToolId + "' and '" + GameObjectComponentGetToolId +
             "' to identify the components first.")]
-        [McpPluginSkillBody("Destroy one or many components from target GameObject. Can't destroy missed components. " +
+        [AiSkillBody("Destroy one or many components from target GameObject. Can't destroy missed components. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject and '" + GameObjectComponentGetToolId + "' to get component details first.\n\n" +
             "## Inputs\n\n" +
             "- `gameObjectRef` — the host GameObject.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.cs
@@ -28,15 +28,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectComponentGetToolId = "gameobject-component-get";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectComponentGetToolId,
             Title = "GameObject / Component / Get",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription(ComponentGetSkill.Description)]
-        [McpPluginSkillBody(ComponentGetSkill.Body)]
+        [AiSkillDescription(ComponentGetSkill.Description)]
+        [AiSkillBody(ComponentGetSkill.Body)]
         [Description("Get detailed information about a specific Component on a GameObject. " +
             "Returns component type, enabled state, and optionally serialized fields and properties. " +
             "Use this to inspect component data before modifying it. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Get.pre-Unity.6.5.cs
@@ -28,15 +28,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectComponentGetToolId = "gameobject-component-get";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectComponentGetToolId,
             Title = "GameObject / Component / Get",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription(ComponentGetSkill.Description)]
-        [McpPluginSkillBody(ComponentGetSkill.Body)]
+        [AiSkillDescription(ComponentGetSkill.Description)]
+        [AiSkillBody(ComponentGetSkill.Body)]
         [Description("Get detailed information about a specific Component on a GameObject. " +
             "Returns component type, enabled state, and optionally serialized fields and properties. " +
             "Use this to inspect component data before modifying it. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.ListAll.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.ListAll.cs
@@ -27,17 +27,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             .Where(type => typeof(UnityEngine.Component).IsAssignableFrom(type) && !type.IsAbstract);
 
         public const string ComponentListToolId = "gameobject-component-list-all";
-        [McpPluginTool
+        [AiTool
         (
             ComponentListToolId,
             Title = "GameObject / Component / List All",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("List the fully-qualified C# type names of every concrete `UnityEngine.Component` " +
+        [AiSkillDescription("List the fully-qualified C# type names of every concrete `UnityEngine.Component` " +
             "subclass available in the project. Paginated (default 5/page, max 500). " +
             "Use this to find a valid `componentName` for '" + GameObjectComponentAddToolId + "'.")]
-        [McpPluginSkillBody("List C# class names extended from UnityEngine.Component. " +
+        [AiSkillBody("List C# class names extended from UnityEngine.Component. " +
             "Use this to find component type names for '" + GameObjectComponentAddToolId + "' tool. " +
             "Results are paginated to avoid overwhelming responses.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
@@ -26,17 +26,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectComponentModifyToolId = "gameobject-component-modify";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectComponentModifyToolId,
             Title = "GameObject / Component / Modify",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Modify a specific Component on a GameObject in opened Prefab or in a Scene. " +
+        [AiSkillDescription("Modify a specific Component on a GameObject in opened Prefab or in a Scene. " +
             "Allows direct modification of component fields and properties without wrapping in GameObject structure. " +
             "Use '" + GameObjectComponentGetToolId + "' first to inspect the component structure before modifying. " +
             "Three modification surfaces are available (componentDiff, pathPatches, jsonPatch) — see the skill body for details.")]
-        [McpPluginSkillBody(
+        [AiSkillBody(
             "## Three modification surfaces\n\n" +
             "Use whichever fits the task:\n\n" +
             "1. `componentDiff` — full `SerializedMember` diff (legacy, backwards compatible).\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Create.cs
@@ -25,15 +25,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectCreateToolId = "gameobject-create";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectCreateToolId,
             Title = "GameObject / Create"
         )]
-        [McpPluginSkillDescription("Create a new GameObject in the currently opened Prefab or active Scene, optionally " +
+        [AiSkillDescription("Create a new GameObject in the currently opened Prefab or active Scene, optionally " +
             "parented under another GameObject and pre-positioned. Pass `primitiveType` to spawn a Unity primitive " +
             "(Cube, Sphere, etc.) instead of an empty GameObject.")]
-        [McpPluginSkillBody("Create a new GameObject in opened Prefab or in a Scene. " +
+        [AiSkillBody("Create a new GameObject in opened Prefab or in a Scene. " +
             "If needed - provide proper 'position', 'rotation' and 'scale' to reduce amount of operations.\n\n" +
             "## Inputs\n\n" +
             "- `name` — required non-empty name.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.cs
@@ -26,14 +26,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectDestroyToolId = "gameobject-destroy";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectDestroyToolId,
             Title = "GameObject / Destroy",
             DestructiveHint = true
         )]
-        [McpPluginSkillDescription(DestroySkill.Description)]
-        [McpPluginSkillBody(DestroySkill.Body)]
+        [AiSkillDescription(DestroySkill.Description)]
+        [AiSkillBody(DestroySkill.Body)]
         [Description("Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject first.")]
         public DestroyGameObjectResult Destroy(GameObjectRef gameObjectRef)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.pre-Unity.6.5.cs
@@ -26,14 +26,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectDestroyToolId = "gameobject-destroy";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectDestroyToolId,
             Title = "GameObject / Destroy",
             DestructiveHint = true
         )]
-        [McpPluginSkillDescription(DestroySkill.Description)]
-        [McpPluginSkillBody(DestroySkill.Body)]
+        [AiSkillDescription(DestroySkill.Description)]
+        [AiSkillBody(DestroySkill.Body)]
         [Description("Destroy GameObject and all nested GameObjects recursively in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObject first.")]
         public DestroyGameObjectResult Destroy(GameObjectRef gameObjectRef)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Duplicate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Duplicate.cs
@@ -25,15 +25,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectDuplicateToolId = "gameobject-duplicate";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectDuplicateToolId,
             Title = "GameObject / Duplicate"
         )]
-        [McpPluginSkillDescription("Duplicate a batch of GameObjects in the currently opened Prefab or active Scene. " +
+        [AiSkillDescription("Duplicate a batch of GameObjects in the currently opened Prefab or active Scene. " +
             "Marks each affected scene as dirty after duplication. " +
             "Use '" + GameObjectFindToolId + "' to locate the source GameObjects first.")]
-        [McpPluginSkillBody("Duplicate GameObjects in opened Prefab or in a Scene. " +
+        [AiSkillBody("Duplicate GameObjects in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObjects first.\n\n" +
             "## Inputs\n\n" +
             "- `gameObjectRefs` — `GameObjectRefList` of source GameObjects.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Find.cs
@@ -25,17 +25,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectFindToolId = "gameobject-find";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectFindToolId,
             Title = "GameObject / Find",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Find a specific GameObject in the opened Prefab (preferred when present) or the " +
+        [AiSkillDescription("Find a specific GameObject in the opened Prefab (preferred when present) or the " +
             "active Scene. Optionally include editable data, components preview, bounds, and limited hierarchy. " +
             "Supports token-saving path-scoped reads via `paths` or `viewQuery`.")]
-        [McpPluginSkillBody("Finds specific GameObject by provided information in opened Prefab or in a Scene. " +
+        [AiSkillBody("Finds specific GameObject by provided information in opened Prefab or in a Scene. " +
             "First it looks for the opened Prefab, if any Prefab is opened it looks only there ignoring a scene. " +
             "If no opened Prefab it looks into current active scene. " +
             "Returns GameObject information and its children. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
@@ -25,16 +25,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectModifyToolId = "gameobject-modify";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectModifyToolId,
             Title = "GameObject / Modify",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Modify GameObject fields and properties in opened Prefab or in a Scene. " +
+        [AiSkillDescription("Modify GameObject fields and properties in opened Prefab or in a Scene. " +
             "You can modify multiple GameObjects at once. Just provide the same number of GameObject references and SerializedMember objects. " +
             "Three modification surfaces are available per GameObject (gameObjectDiffs, pathPatchesPerGameObject, jsonPatchesPerGameObject) — see the skill body for details.")]
-        [McpPluginSkillBody(
+        [AiSkillBody(
             "## Three modification surfaces\n\n" +
             "Per GameObject — parallel arrays must have the same length as `gameObjectRefs`:\n\n" +
             "1. `gameObjectDiffs` — full `SerializedMember` diff per GameObject (legacy, backwards compatible).\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.SetParent.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.SetParent.cs
@@ -23,16 +23,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_GameObject
     {
         public const string GameObjectSetParentToolId = "gameobject-set-parent";
-        [McpPluginTool
+        [AiTool
         (
             GameObjectSetParentToolId,
             Title = "GameObject / Set Parent",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Reparent a batch of GameObjects under a new parent in the currently opened Prefab " +
+        [AiSkillDescription("Reparent a batch of GameObjects under a new parent in the currently opened Prefab " +
             "or active Scene. Per-item failures are reported in the returned status string instead of aborting the batch. " +
             "Use '" + GameObjectFindToolId + "' to locate the GameObjects first.")]
-        [McpPluginSkillBody("Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. " +
+        [AiSkillBody("Set parent GameObject to list of GameObjects in opened Prefab or in a Scene. " +
             "Use '" + GameObjectFindToolId + "' tool to find the target GameObjects first.\n\n" +
             "## Inputs\n\n" +
             "- `gameObjectRefs` — list of children to reparent.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.cs
@@ -21,7 +21,7 @@ using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_GameObject
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.pre-Unity.6.5.cs
@@ -21,7 +21,7 @@ using Microsoft.Extensions.Logging;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_GameObject
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.GetData.cs
@@ -25,17 +25,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Object
     {
         public const string ObjectGetDataToolId = "object-get-data";
-        [McpPluginTool
+        [AiTool
         (
             ObjectGetDataToolId,
             Title = "Object / Get Data",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Get serialized data for a Unity `UnityEngine.Object` — all serializable fields " +
+        [AiSkillDescription("Get serialized data for a Unity `UnityEngine.Object` — all serializable fields " +
             "and properties. Supports token-saving path-scoped reads via `paths` or `viewQuery`. " +
             "Pair with '" + ObjectModifyToolId + "' when you need to write back.")]
-        [McpPluginSkillBody("Get data of the specified Unity Object. " +
+        [AiSkillBody("Get data of the specified Unity Object. " +
             "Returns serialized data of the object including its properties and fields. " +
             "If need to modify the data use '" + ObjectModifyToolId + "' tool.\n\n" +
             "## Path-scoped reads (token-saving)\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
@@ -26,16 +26,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Object
     {
         public const string ObjectModifyToolId = "object-modify";
-        [McpPluginTool
+        [AiTool
         (
             ObjectModifyToolId,
             Title = "Object / Modify",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Modify a Unity `UnityEngine.Object`'s serializable fields/properties. " +
+        [AiSkillDescription("Modify a Unity `UnityEngine.Object`'s serializable fields/properties. " +
             "Three modification surfaces are available (`objectDiff`, `pathPatches`, `jsonPatch`) — see the skill body. " +
             "Use '" + ObjectGetDataToolId + "' first to inspect the object structure.")]
-        [McpPluginSkillBody("Modify the specified Unity Object. " +
+        [AiSkillBody("Modify the specified Unity Object. " +
             "Allows direct modification of object fields and properties. " +
             "Use '" + ObjectGetDataToolId + "' first to inspect the object structure before modifying.\n\n" +
             "## Three modification surfaces\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Object
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Add.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Add.cs
@@ -22,18 +22,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Package
     {
         public const string PackageAddToolId = "package-add";
-        [McpPluginTool
+        [AiTool
         (
             PackageAddToolId,
             Title = "Package Manager / Add",
             OpenWorldHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Install a Unity package from the registry, a Git URL, or a local path. " +
+        [AiSkillDescription("Install a Unity package from the registry, a Git URL, or a local path. " +
             "Modifies `manifest.json` and triggers package resolution; may also trigger a domain reload — the final " +
             "result is delivered after the reload via the request's `requestId`. " +
             "Use '" + PackageSearchToolId + "' / '" + PackageListToolId + "' for discovery first.")]
-        [McpPluginSkillBody("Install a package from the Unity Package Manager registry, Git URL, or local path. " +
+        [AiSkillBody("Install a package from the Unity Package Manager registry, Git URL, or local path. " +
             "This operation modifies the project's manifest.json and triggers package resolution. " +
             "Note: Package installation may trigger a domain reload. The result will be sent after the reload completes. " +
             "Use '" + PackageSearchToolId + "' tool to search for packages and '" + PackageListToolId + "' to list installed packages.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.List.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.List.cs
@@ -49,7 +49,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         }
 
         public const string PackageListToolId = "package-list";
-        [McpPluginTool
+        [AiTool
         (
             PackageListToolId,
             Title = "Package Manager / List Installed",
@@ -57,10 +57,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("List all UPM packages installed in the Unity project — name, version, source, " +
+        [AiSkillDescription("List all UPM packages installed in the Unity project — name, version, source, " +
             "description. Optionally filter by source (registry, embedded, local, git, built-in, local tarball), " +
             "by name/display/description substring, and by direct-dependency-only.")]
-        [McpPluginSkillBody("List all packages installed in the Unity project (UPM packages). " +
+        [AiSkillBody("List all packages installed in the Unity project (UPM packages). " +
             "Returns information about each installed package including name, version, source, and description. " +
             "Use this to check which packages are currently installed before adding or removing packages.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Remove.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Remove.cs
@@ -23,18 +23,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Package
     {
         public const string PackageRemoveToolId = "package-remove";
-        [McpPluginTool
+        [AiTool
         (
             PackageRemoveToolId,
             Title = "Package Manager / Remove",
             DestructiveHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Uninstall a UPM package from the Unity project. Modifies `manifest.json` and may " +
+        [AiSkillDescription("Uninstall a UPM package from the Unity project. Modifies `manifest.json` and may " +
             "trigger a domain reload — the final result is delivered after the reload via the request's `requestId`. " +
             "Built-in packages and packages that are dependencies of others cannot be removed. " +
             "Use '" + PackageListToolId + "' to list installed packages first.")]
-        [McpPluginSkillBody("Remove (uninstall) a package from the Unity project. " +
+        [AiSkillBody("Remove (uninstall) a package from the Unity project. " +
             "This removes the package from the project's manifest.json and triggers package resolution. " +
             "Note: Built-in packages and packages that are dependencies of other installed packages cannot be removed. " +
             "Note: Package removal may trigger a domain reload. The result will be sent after the reload completes. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Search.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.Search.cs
@@ -25,7 +25,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
 
         public const string PackageSearchToolId = "package-search";
-        [McpPluginTool
+        [AiTool
         (
             PackageSearchToolId,
             Title = "Package Manager / Search",
@@ -34,10 +34,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             OpenWorldHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Search Unity's package registry plus locally installed packages (Git, local, " +
+        [AiSkillDescription("Search Unity's package registry plus locally installed packages (Git, local, " +
             "embedded sources) by query string. Returns available versions and installation status. " +
             "Online mode fetches exact matches from the live registry then supplements with cached substring matches.")]
-        [McpPluginSkillBody("Search for packages in both Unity Package Manager registry and installed packages. " +
+        [AiSkillBody("Search for packages in both Unity Package Manager registry and installed packages. " +
             "Use this to find packages by name before installing them. Returns available versions and installation status. " +
             "Searches both the Unity registry and locally installed packages (including Git, local, and embedded sources). " +
             "Results are prioritized: exact name match, exact display name match, name substring, display name substring, description substring. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Package.cs
@@ -14,7 +14,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Package
     {
         public static class Error

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.CaptureFrame.cs
@@ -19,15 +19,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerCaptureFrameToolId = "profiler-capture-frame";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerCaptureFrameToolId,
             Title = "Profiler / Capture Frame",
             ReadOnlyHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Capture the current frame's timing info (delta time, FPS, frame counts, runtime). Snapshot only — historical frames live in Unity's Profiler window.")]
-        [McpPluginSkillBody("Reads `UnityEngine.Time` fields and returns them in a single struct. " +
+        [AiSkillDescription("Capture the current frame's timing info (delta time, FPS, frame counts, runtime). Snapshot only — historical frames live in Unity's Profiler window.")]
+        [AiSkillBody("Reads `UnityEngine.Time` fields and returns them in a single struct. " +
             "This tool is intentionally a single-frame snapshot — Unity's runtime API does not expose historical " +
             "frame-data outside the Profiler window.\n\n" +
             "## Fields\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ClearData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ClearData.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerClearDataToolId = "profiler-clear-data";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerClearDataToolId,
             Title = "Profiler / Clear Data",
@@ -27,8 +27,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Discard all frames currently held by the Editor Profiler (UnityEditorInternal.ProfilerDriver.ClearAllFrames). Cannot be undone.")]
-        [McpPluginSkillBody("Invokes `UnityEditorInternal.ProfilerDriver.ClearAllFrames()` on the main thread. " +
+        [AiSkillDescription("Discard all frames currently held by the Editor Profiler (UnityEditorInternal.ProfilerDriver.ClearAllFrames). Cannot be undone.")]
+        [AiSkillBody("Invokes `UnityEditorInternal.ProfilerDriver.ClearAllFrames()` on the main thread. " +
             "`UnityEditorInternal` is a built-in editor namespace — no external Unity package is required.\n\n" +
             "## Behavior\n\n" +
             "After this call, the Profiler window's frame history is empty; subsequent recording starts from frame 0. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.EnableModule.cs
@@ -19,14 +19,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerEnableModuleToolId = "profiler-enable-module";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerEnableModuleToolId,
             Title = "Profiler / Enable Module",
             Enabled = false
         )]
-        [McpPluginSkillDescription("Toggle the wrapper's local 'enabled' flag for a named profiler module. Bookkeeping only — Unity's runtime API does not expose direct module control; for real module visibility use the Profiler window.")]
-        [McpPluginSkillBody("Adds or removes the given module name from the wrapper's `EnabledModules` set. " +
+        [AiSkillDescription("Toggle the wrapper's local 'enabled' flag for a named profiler module. Bookkeeping only — Unity's runtime API does not expose direct module control; for real module visibility use the Profiler window.")]
+        [AiSkillBody("Adds or removes the given module name from the wrapper's `EnabledModules` set. " +
             "This is local bookkeeping consumed by `profiler-get-status` and `profiler-list-modules`; Unity's " +
             "runtime API does not allow programmatic toggling of Profiler-window modules from a built-in " +
             "namespace, so this tool intentionally does not pretend to.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetMemoryStats.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerGetMemoryStatsToolId = "profiler-get-memory-stats";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerGetMemoryStatsToolId,
             Title = "Profiler / Get Memory Stats",
@@ -27,8 +27,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Return memory statistics snapshot from UnityEngine.Profiling.Profiler — reserved, allocated, mono heap, graphics, etc. (in MB).")]
-        [McpPluginSkillBody("Reads UnityEngine.Profiling.Profiler scalar memory counters and converts each from bytes to megabytes (`/1048576f`).\n\n" +
+        [AiSkillDescription("Return memory statistics snapshot from UnityEngine.Profiling.Profiler — reserved, allocated, mono heap, graphics, etc. (in MB).")]
+        [AiSkillBody("Reads UnityEngine.Profiling.Profiler scalar memory counters and converts each from bytes to megabytes (`/1048576f`).\n\n" +
             "## Fields\n\n" +
             "- `TotalReservedMemoryMB` — `GetTotalReservedMemoryLong()`.\n" +
             "- `TotalAllocatedMemoryMB` — `GetTotalAllocatedMemoryLong()`.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetRenderingStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetRenderingStats.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerGetRenderingStatsToolId = "profiler-get-rendering-stats";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerGetRenderingStatsToolId,
             Title = "Profiler / Get Rendering Stats",
@@ -27,8 +27,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Return current frame timing, FPS, vsync, target frame rate, threading mode, and graphics device type from Unity Time / QualitySettings / SystemInfo.")]
-        [McpPluginSkillBody("Snapshots rendering-related fields from `UnityEngine.Time`, `UnityEngine.QualitySettings`, " +
+        [AiSkillDescription("Return current frame timing, FPS, vsync, target frame rate, threading mode, and graphics device type from Unity Time / QualitySettings / SystemInfo.")]
+        [AiSkillBody("Snapshots rendering-related fields from `UnityEngine.Time`, `UnityEngine.QualitySettings`, " +
             "`UnityEngine.Application` and `UnityEngine.SystemInfo`. All values are read from built-in Unity APIs " +
             "so no external Unity package is required.\n\n" +
             "## Fields\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetScriptStats.cs
@@ -21,7 +21,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerGetScriptStatsToolId = "profiler-get-script-stats";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerGetScriptStatsToolId,
             Title = "Profiler / Get Script Stats",
@@ -29,8 +29,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Return script execution timing (frame time, fixed dt, time scale, frame count, runtime) plus Mono / GC memory usage in MB.")]
-        [McpPluginSkillBody("Snapshots fields from `UnityEngine.Time`, `UnityEngine.Profiling.Profiler.GetMonoUsedSizeLong()` and " +
+        [AiSkillDescription("Return script execution timing (frame time, fixed dt, time scale, frame count, runtime) plus Mono / GC memory usage in MB.")]
+        [AiSkillBody("Snapshots fields from `UnityEngine.Time`, `UnityEngine.Profiling.Profiler.GetMonoUsedSizeLong()` and " +
             "`System.GC.GetTotalMemory(false)`. All values are produced by built-in Unity APIs.\n\n" +
             "## Fields\n\n" +
             "- `FrameTimeMs` — `Time.deltaTime * 1000f`.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.GetStatus.cs
@@ -20,7 +20,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerGetStatusToolId = "profiler-get-status";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerGetStatusToolId,
             Title = "Profiler / Get Status",
@@ -28,8 +28,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Return the Unity profiler's current enabled state, active modules, max-used memory, and platform support flag. Read-only.")]
-        [McpPluginSkillBody("Snapshots `UnityEngine.Profiling.Profiler` state and returns it in a single response.\n\n" +
+        [AiSkillDescription("Return the Unity profiler's current enabled state, active modules, max-used memory, and platform support flag. Read-only.")]
+        [AiSkillBody("Snapshots `UnityEngine.Profiling.Profiler` state and returns it in a single response.\n\n" +
             "## Fields\n\n" +
             "- `ProfilerEnabled` — `Profiler.enabled`.\n" +
             "- `ActiveModules` — names of modules this wrapper considers enabled (local bookkeeping).\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ListModules.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.ListModules.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerListModulesToolId = "profiler-list-modules";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerListModulesToolId,
             Title = "Profiler / List Modules",
@@ -27,8 +27,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("List all known profiler module names with their local 'enabled' bookkeeping flag.")]
-        [McpPluginSkillBody("Returns `Tool_Profiler.AvailableModules` projected into a `ProfilerModulesData` list, " +
+        [AiSkillDescription("List all known profiler module names with their local 'enabled' bookkeeping flag.")]
+        [AiSkillBody("Returns `Tool_Profiler.AvailableModules` projected into a `ProfilerModulesData` list, " +
             "with each entry's `Enabled` field reflecting the wrapper's local bookkeeping.\n\n" +
             "## Behavior\n\n" +
             "Uses only built-in Unity APIs and in-process state. No external Unity package is required. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.LoadData.cs
@@ -26,15 +26,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         // headroom for future schema expansion while bounding worst-case memory.
         const long MaxLoadFileSizeBytes = 10L * 1024L * 1024L;
 
-        [McpPluginTool
+        [AiTool
         (
             ProfilerLoadDataToolId,
             Title = "Profiler / Load Data",
             ReadOnlyHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Read back a previously-saved JSON snapshot from `profiler-save-data` and return its raw text.")]
-        [McpPluginSkillBody("Reads `filePath` as UTF-8 text and returns the file body unchanged. Caller is responsible " +
+        [AiSkillDescription("Read back a previously-saved JSON snapshot from `profiler-save-data` and return its raw text.")]
+        [AiSkillBody("Reads `filePath` as UTF-8 text and returns the file body unchanged. Caller is responsible " +
             "for parsing.\n\n" +
             "## Inputs\n\n" +
             "- `filePath` (required) — path written by `profiler-save-data`.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.SaveData.cs
@@ -21,14 +21,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerSaveDataToolId = "profiler-save-data";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerSaveDataToolId,
             Title = "Profiler / Save Data",
             Enabled = false
         )]
-        [McpPluginSkillDescription("Save a snapshot of profiler-derived stats (status + memory + rendering + script + frame capture) to a JSON file. Built-in Unity APIs only.")]
-        [McpPluginSkillBody("Composes the outputs of `profiler-get-status`, `profiler-get-memory-stats`, " +
+        [AiSkillDescription("Save a snapshot of profiler-derived stats (status + memory + rendering + script + frame capture) to a JSON file. Built-in Unity APIs only.")]
+        [AiSkillBody("Composes the outputs of `profiler-get-status`, `profiler-get-memory-stats`, " +
             "`profiler-get-rendering-stats`, `profiler-get-script-stats` and `profiler-capture-frame` into a single " +
             "JSON document and writes it to `filePath`. Creates any missing parent directories.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Start.cs
@@ -21,16 +21,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerStartToolId = "profiler-start";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerStartToolId,
             Title = "Profiler / Start",
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Enable Unity's runtime profiler and open the Profiler window. " +
+        [AiSkillDescription("Enable Unity's runtime profiler and open the Profiler window. " +
             "Idempotent: calling when already enabled returns the current enabled state without error.")]
-        [McpPluginSkillBody("Enables `UnityEngine.Profiling.Profiler.enabled = true` and opens " +
+        [AiSkillBody("Enables `UnityEngine.Profiling.Profiler.enabled = true` and opens " +
             "`Window > Analysis > Profiler` via `EditorApplication.ExecuteMenuItem`. " +
             "Returns `true` once the profiler is enabled.\n\n" +
             "## Behavior\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Stop.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.Stop.cs
@@ -19,15 +19,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Profiler
     {
         public const string ProfilerStopToolId = "profiler-stop";
-        [McpPluginTool
+        [AiTool
         (
             ProfilerStopToolId,
             Title = "Profiler / Stop",
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Disable Unity's runtime profiler. Idempotent — calling when already disabled returns the current disabled state.")]
-        [McpPluginSkillBody("Sets `UnityEngine.Profiling.Profiler.enabled = false`. Returns the post-call value of `Profiler.enabled` " +
+        [AiSkillDescription("Disable Unity's runtime profiler. Idempotent — calling when already disabled returns the current disabled state.")]
+        [AiSkillBody("Sets `UnityEngine.Profiling.Profiler.enabled = false`. Returns the post-call value of `Profiler.enabled` " +
             "(expected `false`).\n\n" +
             "## Behavior\n\n" +
             "Uses only built-in Unity APIs (`UnityEngine.Profiling`). No external Unity package is required.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Profiler.cs
@@ -15,7 +15,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Profiler
     {
         /// <summary>

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodCall.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodCall.cs
@@ -24,17 +24,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Reflection
     {
         public const string ReflectionMethodCallToolId = "reflection-method-call";
-        [McpPluginTool
+        [AiTool
         (
             ReflectionMethodCallToolId,
             Title = "Method C# / Call",
             Enabled = false
         )]
-        [McpPluginSkillDescription("Call a C# method by reflection — including private methods. " +
+        [AiSkillDescription("Call a C# method by reflection — including private methods. " +
             "Requires a method schema obtained via '" + ReflectionMethodFindToolId + "'. " +
             "Supports static methods, instance methods (with optional target deserialization), and main-thread / " +
             "off-thread execution.")]
-        [McpPluginSkillBody("Call C# method. Any method could be called, even private methods. " +
+        [AiSkillBody("Call C# method. Any method could be called, even private methods. " +
             "It requires to receive proper method schema. " +
             "Use '" + ReflectionMethodFindToolId + "' to find available method before using it. " +
             "Receives input parameters and returns result.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodFind.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.MethodFind.cs
@@ -22,7 +22,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Reflection
     {
         public const string ReflectionMethodFindToolId = "reflection-method-find";
-        [McpPluginTool
+        [AiTool
         (
             ReflectionMethodFindToolId,
             Title = "Method C# / Find",
@@ -30,10 +30,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Find C# methods across every loaded assembly by name / type / parameters — " +
+        [AiSkillDescription("Find C# methods across every loaded assembly by name / type / parameters — " +
             "including private methods. Returns serialized `MethodData` entries usable as schemas for '" +
             ReflectionMethodCallToolId + "'.")]
-        [McpPluginSkillBody("Find method in the project using C# Reflection. " +
+        [AiSkillBody("Find method in the project using C# Reflection. " +
             "It looks for all assemblies in the project and finds method by its name, class name and parameters. " +
             "Even private methods are available. " +
             "Use '" + ReflectionMethodCallToolId + "' to call the method after finding it.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Reflection.cs
@@ -20,7 +20,7 @@ using com.IvanMurzak.ReflectorNet.Utils;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Reflection
     {
         static IEnumerable<Type> AllTypes => TypeUtils.AllTypes;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Create.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Create.cs
@@ -20,14 +20,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Scene
     {
         public const string SceneCreateToolId = "scene-create";
-        [McpPluginTool
+        [AiTool
         (
             SceneCreateToolId,
             Title = "Scene / Create"
         )]
-        [McpPluginSkillDescription("Create a new Unity scene asset and save it at the given `.unity` path. " +
+        [AiSkillDescription("Create a new Unity scene asset and save it at the given `.unity` path. " +
             "Use '" + SceneListOpenedToolId + "' to inspect the resulting opened-scene set afterwards.")]
-        [McpPluginSkillBody("Create new scene in the project assets. " +
+        [AiSkillBody("Create new scene in the project assets. " +
             "Use '" + SceneListOpenedToolId + "' tool to list all opened scenes after creation.\n\n" +
             "## Inputs\n\n" +
             "- `path` — must end with `.unity`. Non-empty.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.GetData.cs
@@ -24,17 +24,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Scene
     {
         public const string SceneGetDataToolId = "scene-get-data";
-        [McpPluginTool
+        [AiTool
         (
             SceneGetDataToolId,
             Title = "Scene / Get Data",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Retrieve the list of root GameObjects in the specified opened scene " +
+        [AiSkillDescription("Retrieve the list of root GameObjects in the specified opened scene " +
             "(or the active scene when `openedSceneName` is empty). Supports token-saving path-scoped reads over the " +
             "root-GameObjects array via `paths` or `viewQuery`. Use '" + SceneListOpenedToolId + "' to enumerate scenes.")]
-        [McpPluginSkillBody("This tool retrieves the list of root GameObjects in the specified scene. " +
+        [AiSkillBody("This tool retrieves the list of root GameObjects in the specified scene. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
             "## Toggles (all default `false` to keep responses small)\n\n" +
             "- `includeRootGameObjects` — include root GameObjects in the scene data.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.ListOpened.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.ListOpened.cs
@@ -20,16 +20,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Scene
     {
         public const string SceneListOpenedToolId = "scene-list-opened";
-        [McpPluginTool
+        [AiTool
         (
             SceneListOpenedToolId,
             Title = "Scene / List Opened",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("List every scene currently opened in the Unity Editor as a shallow snapshot " +
+        [AiSkillDescription("List every scene currently opened in the Unity Editor as a shallow snapshot " +
             "(name, path, build flags). Use '" + SceneGetDataToolId + "' for the deep view of a specific scene.")]
-        [McpPluginSkillBody("Returns the list of currently opened scenes in Unity Editor. " +
+        [AiSkillBody("Returns the list of currently opened scenes in Unity Editor. " +
             "Use '" + SceneGetDataToolId + "' tool to get detailed information about a specific scene.\n\n" +
             "## Behavior\n\n" +
             "Maps `OpenedScenes` through `ToSceneDataShallow()` on the main thread and returns the resulting array. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Open.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Open.cs
@@ -22,15 +22,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Scene
     {
         public const string SceneOpenToolId = "scene-open";
-        [McpPluginTool
+        [AiTool
         (
             SceneOpenToolId,
             Title = "Scene / Open"
         )]
-        [McpPluginSkillDescription("Open a Unity scene asset in Single or Additive mode. " +
+        [AiSkillDescription("Open a Unity scene asset in Single or Additive mode. " +
             "Returns the post-open list of all opened scenes. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' to locate the scene asset first.")]
-        [McpPluginSkillBody("Open scene from the project asset file. " +
+        [AiSkillBody("Open scene from the project asset file. " +
             "Use '" + Tool_Assets.AssetsFindToolId + "' tool to find the scene asset first.\n\n" +
             "## Inputs\n\n" +
             "- `sceneRef` — `AssetObjectRef` pointing at a `SceneAsset`. Throws if the asset cannot be resolved or " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Save.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Save.cs
@@ -22,16 +22,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Scene
     {
         public const string SceneSaveToolId = "scene-save";
-        [McpPluginTool
+        [AiTool
         (
             SceneSaveToolId,
             Title = "Scene / Save",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Save an opened scene back to its asset file (or to a new path when `path` is " +
+        [AiSkillDescription("Save an opened scene back to its asset file (or to a new path when `path` is " +
             "provided). When `openedSceneName` is empty, saves the currently active scene. " +
             "Use '" + SceneListOpenedToolId + "' to find the scene name first.")]
-        [McpPluginSkillBody("Save Opened scene to the asset file. " +
+        [AiSkillBody("Save Opened scene to the asset file. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
             "## Inputs\n\n" +
             "- `openedSceneName` (optional) — name of an opened scene to save. Empty/null = active scene.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.SetActive.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.SetActive.cs
@@ -22,16 +22,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Scene
     {
         public const string SceneSetActiveToolId = "scene-set-active";
-        [McpPluginTool
+        [AiTool
         (
             SceneSetActiveToolId,
             Title = "Scene / Set Active",
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("Mark an opened scene as the Editor's active scene (the one new GameObjects are " +
+        [AiSkillDescription("Mark an opened scene as the Editor's active scene (the one new GameObjects are " +
             "added to and that's used as the default for many operations). " +
             "Use '" + SceneListOpenedToolId + "' to enumerate opened scenes first.")]
-        [McpPluginSkillBody("Set the specified opened scene as the active scene. " +
+        [AiSkillBody("Set the specified opened scene as the active scene. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
             "## Inputs\n\n" +
             "- `sceneRef` — `AssetObjectRef` pointing at a `SceneAsset`. The scene must already be opened.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Unload.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.Unload.cs
@@ -26,15 +26,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Scene
     {
         public const string SceneUnloadToolId = "scene-unload";
-        [McpPluginTool
+        [AiTool
         (
             SceneUnloadToolId,
             Title = "Scene / Unload"
         )]
-        [McpPluginSkillDescription("Unload an opened scene from the Unity Editor (asynchronously via " +
+        [AiSkillDescription("Unload an opened scene from the Unity Editor (asynchronously via " +
             "`SceneManager.UnloadSceneAsync`). " +
             "Use '" + SceneListOpenedToolId + "' to find the scene name first.")]
-        [McpPluginSkillBody("Unload scene from the Opened scenes in Unity Editor. " +
+        [AiSkillBody("Unload scene from the Opened scenes in Unity Editor. " +
             "Use '" + SceneListOpenedToolId + "' tool to get the list of all opened scenes.\n\n" +
             "## Inputs\n\n" +
             "- `name` — required non-empty scene name. Must match an opened scene; otherwise throws.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Scene.cs
@@ -16,7 +16,7 @@ using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Scene
     {
         public static IEnumerable<UnityEngine.SceneManagement.Scene> OpenedScenes => SceneUtils.GetAllOpenedScenes();

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Camera.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Camera.cs
@@ -23,7 +23,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Screenshot
     {
         public const string ScreenshotCameraToolId = "screenshot-camera";
-        [McpPluginTool
+        [AiTool
         (
             ScreenshotCameraToolId,
             Title = "Screenshot / Camera",
@@ -31,10 +31,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Capture a screenshot from a Unity `Camera` and return it as a PNG image " +
+        [AiSkillDescription("Capture a screenshot from a Unity `Camera` and return it as a PNG image " +
             "for direct LLM inspection. Falls back to `Camera.main` (then any active camera) when `cameraRef` is null. " +
             "Width and height are capped to keep response size manageable.")]
-        [McpPluginSkillBody("Captures a screenshot from a camera and returns it as an image. " +
+        [AiSkillBody("Captures a screenshot from a camera and returns it as an image. " +
             "If no camera is specified, uses the Main Camera. " +
             "Returns the image directly for visual inspection by the LLM.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
@@ -23,7 +23,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Screenshot
     {
         public const string ScreenshotGameViewToolId = "screenshot-game-view";
-        [McpPluginTool
+        [AiTool
         (
             ScreenshotGameViewToolId,
             Title = "Screenshot / Game View",
@@ -31,10 +31,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Capture a screenshot of the Unity Editor's Game View by reading its internal " +
+        [AiSkillDescription("Capture a screenshot of the Unity Editor's Game View by reading its internal " +
             "render texture directly. Image size matches the current Game View resolution; the tool corrects Y-flip on " +
             "DirectX / Metal so the output is always upright. Requires an open Game View window.")]
-        [McpPluginSkillBody("Captures a screenshot from the Unity Editor Game View and returns it as an image. " +
+        [AiSkillBody("Captures a screenshot from the Unity Editor Game View and returns it as an image. " +
             "Reads the Game View's own render texture directly via the Unity Editor API. " +
             "The image size matches the current Game View resolution. " +
             "Returns the image directly for visual inspection by the LLM.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -89,7 +89,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             [JsonPropertyName("renderMode")] public string? RenderMode { get; set; }
         }
 
-        [McpPluginTool
+        [AiTool
         (
             ScreenshotIsolatedToolId,
             Title = "Screenshot / Isolated GameObject",
@@ -97,11 +97,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = true
         )]
-        [McpPluginSkillDescription("Render a target GameObject from a chosen camera angle with optional layer-based " +
+        [AiSkillDescription("Render a target GameObject from a chosen camera angle with optional layer-based " +
             "isolation, configurable background (solid/skybox/transparent), multi-light setup via JSON, and Composite " +
             "(2x2 Front/Right/Back/Top) mode. Returns a PNG image. When isolated=true, inactive children may briefly " +
             "fire OnEnable — see the body for side-effect notes.")]
-        [McpPluginSkillBody("Renders a screenshot of a target GameObject with configurable isolation, background, "
+        [AiSkillBody("Renders a screenshot of a target GameObject with configurable isolation, background, "
                    + "camera angle, and lighting. When isolated=true (default), only the target object is "
                    + "visible via layer-based culling and inactive children of the target are temporarily "
                    + "activated for the render (their OnEnable callbacks may fire — restored in finally, but "

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.SceneView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.SceneView.cs
@@ -21,7 +21,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Screenshot
     {
         public const string ScreenshotSceneViewToolId = "screenshot-scene-view";
-        [McpPluginTool
+        [AiTool
         (
             ScreenshotSceneViewToolId,
             Title = "Screenshot / Scene View",
@@ -29,9 +29,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Capture a screenshot from the Unity Editor Scene View at the requested size. " +
+        [AiSkillDescription("Capture a screenshot from the Unity Editor Scene View at the requested size. " +
             "Renders via the Scene View's active camera onto a temporary `RenderTexture`. Requires an open Scene View.")]
-        [McpPluginSkillBody("Captures a screenshot from the Unity Editor Scene View and returns it as an image. " +
+        [AiSkillBody("Captures a screenshot from the Unity Editor Scene View and returns it as an image. " +
             "Returns the image directly for visual inspection by the LLM.\n\n" +
             "## Inputs\n\n" +
             "- `width` (default 1920) / `height` (default 1080) — output pixels. Must be > 0 and ≤ `MaxDimension`.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Screenshot
     {
         private const int MaxDimension = 16384;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Delete.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Delete.cs
@@ -24,17 +24,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public static partial class Tool_Script
     {
         public const string ScriptDeleteToolId = "script-delete";
-        [McpPluginTool
+        [AiTool
         (
             ScriptDeleteToolId,
             Title = "Script / Delete",
             DestructiveHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Delete one or more `.cs` script files from disk, refresh the AssetDatabase, and " +
+        [AiSkillDescription("Delete one or more `.cs` script files from disk, refresh the AssetDatabase, and " +
             "wait for Unity compilation to settle before delivering the final result via the request's `requestId`. " +
             "Pair with '" + ScriptReadToolId + "' to inspect files before deletion.")]
-        [McpPluginSkillBody("Delete the script file(s). " +
+        [AiSkillBody("Delete the script file(s). " +
             "Does AssetDatabase.Refresh() and waits for Unity compilation to complete before reporting results. " +
             "Use '" + ScriptReadToolId + "' tool to read existing script files first.\n\n" +
             "## Inputs\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Execute.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Execute.cs
@@ -28,15 +28,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public static partial class Tool_Script
     {
         public const string ScriptExecuteToolId = "script-execute";
-        [McpPluginTool
+        [AiTool
         (
             ScriptExecuteToolId,
             Title = "Script / Execute",
             OpenWorldHint = true
         )]
-        [McpPluginSkillDescription("Compiles and executes C# code dynamically using Roslyn. " +
+        [AiSkillDescription("Compiles and executes C# code dynamically using Roslyn. " +
             "Supports a full-code mode (default) and a body-only mode — see the skill body for the difference and for how to pass Unity object references as parameters.")]
-        [McpPluginSkillBody(
+        [AiSkillBody(
             "## Modes\n\n" +
             "- **Full code mode** (default, `isMethodBody=false`): the `csharpCode` argument must define a complete class with a static method (no top-level statements).\n" +
             "- **Body-only mode** (`isMethodBody=true`): provide only the method body statements. The tool auto-generates the usings, class, and method header.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Read.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Read.cs
@@ -20,7 +20,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public static partial class Tool_Script
     {
         public const string ScriptReadToolId = "script-read";
-        [McpPluginTool
+        [AiTool
         (
             ScriptReadToolId,
             Title = "Script / Read",
@@ -28,10 +28,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Read a `.cs` script file and return its content as a string. " +
+        [AiSkillDescription("Read a `.cs` script file and return its content as a string. " +
             "Supports a 1-based `lineFrom`/`lineTo` slice for partial reads. " +
             "Pair with '" + ScriptUpdateOrCreateToolId + "' to write back.")]
-        [McpPluginSkillBody("Reads the content of a script file and returns it as a string. " +
+        [AiSkillBody("Reads the content of a script file and returns it as a string. " +
             "Use '" + ScriptUpdateOrCreateToolId + "' tool to update or create script files.\n\n" +
             "## Inputs\n\n" +
             "- `filePath` — required `.cs` path. Throws if missing on disk.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.UpdateOrCreate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.UpdateOrCreate.cs
@@ -23,7 +23,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public static partial class Tool_Script
     {
         public const string ScriptUpdateOrCreateToolId = "script-update-or-create";
-        [McpPluginTool
+        [AiTool
         (
             ScriptUpdateOrCreateToolId,
             Title = "Script / Update or Create",
@@ -31,11 +31,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             OpenWorldHint = false,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Write a `.cs` script file (create or overwrite) with the provided C# code. " +
+        [AiSkillDescription("Write a `.cs` script file (create or overwrite) with the provided C# code. " +
             "Validates syntax via Roslyn before write — invalid code is rejected with error details and the file is left " +
             "untouched. Refreshes the AssetDatabase and delivers the final result via `requestId` after Unity finishes " +
             "the triggered compilation. Use '" + ScriptReadToolId + "' to inspect existing content first.")]
-        [McpPluginSkillBody("Updates or creates script file with the provided C# code. " +
+        [AiSkillBody("Updates or creates script file with the provided C# code. " +
             "Does AssetDatabase.Refresh() at the end. " +
             "Provides compilation error details if the code has syntax errors. " +
             "Use '" + ScriptReadToolId + "' tool to read existing script files first.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.cs
@@ -18,7 +18,7 @@ using UnityEditor;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     [InitializeOnLoad]
     public static partial class Tool_Script
     {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
@@ -29,17 +29,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public static partial class Tool_Tests
     {
         public const string TestsRunToolId = "tests-run";
-        [McpPluginTool
+        [AiTool
         (
             TestsRunToolId,
             Title = "Tests / Run",
             Enabled = true
         )]
-        [McpPluginSkillDescription("Execute Unity tests (`EditMode` or `PlayMode`) and return per-test results. " +
+        [AiSkillDescription("Execute Unity tests (`EditMode` or `PlayMode`) and return per-test results. " +
             "Supports filtering by test assembly, namespace, class, and method. " +
             "Refreshes the AssetDatabase first; defers execution across domain reloads if scripts changed. " +
             "Precondition: every open scene must be saved — dirty scenes abort the run.")]
-        [McpPluginSkillBody("Execute Unity tests and return detailed results. " +
+        [AiSkillBody("Execute Unity tests and return detailed results. " +
             "Supports filtering by test mode, assembly, namespace, class, and method. " +
             "Recommended to use '" + nameof(TestMode.EditMode) + "' for faster iteration during development. " +
             "Precondition: every open scene MUST be saved (no unsaved changes). If any open scene is dirty, " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
@@ -25,7 +25,7 @@ using UnityEngine.SceneManagement;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     [InitializeOnLoad]
     public static partial class Tool_Tests
     {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.List.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.List.cs
@@ -41,17 +41,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             InputsWithDescription = 2
         }
 
-        [McpPluginTool
+        [AiTool
         (
             ToolListId,
             Title = "Tool / List",
             ReadOnlyHint = true,
             IdempotentHint = true
         )]
-        [McpPluginSkillDescription("List all Unity-MCP tools registered in the connected Unity Editor instance. " +
+        [AiSkillDescription("List all Unity-MCP tools registered in the connected Unity Editor instance. " +
             "Optional regex filter matches against tool name, description, and argument names/descriptions. " +
             "Use the `includeDescription` / `includeInputs` toggles to control the response size.")]
-        [McpPluginSkillBody("List all Unity-MCP tools registered in the connected Unity Editor instance. " +
+        [AiSkillBody("List all Unity-MCP tools registered in the connected Unity Editor instance. " +
             "Optionally filter by regex across tool names, descriptions, and arguments.\n\n" +
             "## Inputs\n\n" +
             "- `regexSearch` (optional) — case-insensitive regex with a 200ms execution-timeout guard. " +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.SetEnabledState.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.SetEnabledState.cs
@@ -24,16 +24,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     {
         public const string ToolSetEnabledStateId = "tool-set-enabled-state";
 
-        [McpPluginTool
+        [AiTool
         (
             ToolSetEnabledStateId,
             Title = "Tool / Set Enabled State",
             Enabled = false
         )]
-        [McpPluginSkillDescription("Enable or disable MCP tools by name in batch. " +
+        [AiSkillDescription("Enable or disable MCP tools by name in batch. " +
             "Persists the change via `UnityMcpPluginEditor.Instance.Save()` only when at least one tool actually flipped. " +
             "Returns per-input success flags plus optional operation logs.")]
-        [McpPluginSkillBody("Enable or disable MCP tools by name. " +
+        [AiSkillBody("Enable or disable MCP tools by name. " +
             "Allows controlling which tools are available for the AI agent.\n\n" +
             "## Inputs\n\n" +
             "- `tools` — array of `ToolToggleInput { Name, Enabled }`. Non-empty.\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tool.cs
@@ -19,7 +19,7 @@ using com.IvanMurzak.ReflectorNet.Utils;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Tool
     {
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Type.GetJsonSchema.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Type.GetJsonSchema.cs
@@ -22,7 +22,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Type
     {
         public const string TypeGetJsonSchemaToolId = "type-get-json-schema";
-        [McpPluginTool
+        [AiTool
         (
             TypeGetJsonSchemaToolId,
             Title = "Type / Get Json Schema",
@@ -31,10 +31,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             IdempotentHint = true,
             Enabled = false
         )]
-        [McpPluginSkillDescription("Generate a JSON Schema for a C# type name via reflection. " +
+        [AiSkillDescription("Generate a JSON Schema for a C# type name via reflection. " +
             "Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. " +
             "Knobs control inclusion of nested `$defs` and whether type-level / property-level descriptions are emitted.")]
-        [McpPluginSkillBody("Generates a JSON Schema for a given C# type name using reflection. " +
+        [AiSkillBody("Generates a JSON Schema for a given C# type name using reflection. " +
             "Supports primitives, enums, arrays, generic collections, dictionaries, and complex objects. " +
             "The type must be present in any loaded assembly. " +
             "Use the full type name (e.g. 'UnityEngine.Vector3') for best results.\n\n" +

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Type.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Type.cs
@@ -13,7 +13,7 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginToolType]
+    [AiToolType]
     public partial class Tool_Type
     {
         public enum DescriptionMode

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Skills/Skill_InitialSetup.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Skills/Skill_InitialSetup.cs
@@ -14,12 +14,12 @@ using com.IvanMurzak.McpPlugin;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
-    [McpPluginSkillType]
+    [AiSkillType]
     public static class Skill_InitialSetup
     {
         public const string SkillId = "unity-initial-setup";
 
-        [McpPluginSkill(SkillId,
+        [AiSkill(SkillId,
 @"Provides an initial setup for AI Skills, `unity-mcp-cli` command line tool installation
 and everything else that is helpful to set up at the start of the project. Essential packages,
 and basic configurations.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.GetComponents.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.GetComponents.cs
@@ -46,7 +46,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             var toolName = typeof(Tool_GameObject)
                 .GetMethod(nameof(Tool_GameObject.Find))
-                .GetCustomAttribute<McpPluginToolAttribute>()
+                .GetCustomAttribute<AiToolAttribute>()
                 .Name;
 
             var task = UnityMcpPluginEditor.Instance.Tools!.RunCallTool(new RequestCallTool(toolName, parameters!));

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.GetComponents.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.GetComponents.pre-Unity.6.5.cs
@@ -46,7 +46,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             var toolName = typeof(Tool_GameObject)
                 .GetMethod(nameof(Tool_GameObject.Find))
-                .GetCustomAttribute<McpPluginToolAttribute>()
+                .GetCustomAttribute<AiToolAttribute>()
                 .Name;
 
             var task = UnityMcpPluginEditor.Instance.Tools!.RunCallTool(new RequestCallTool(toolName, parameters!));

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/ToolParameterTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/ToolParameterTests.cs
@@ -30,9 +30,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                     try { return assembly.GetTypes(); }
                     catch (ReflectionTypeLoadException) { return Array.Empty<Type>(); }
                 })
-                .Where(type => type.GetCustomAttribute<McpPluginToolTypeAttribute>() != null)
+                .Where(type => type.GetCustomAttribute<AiToolTypeAttribute>() != null)
                 .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
-                .Where(method => method.GetCustomAttribute<McpPluginToolAttribute>() != null)
+                .Where(method => method.GetCustomAttribute<AiToolAttribute>() != null)
                 .ToList();
 
             Assert.IsTrue(toolMethods.Count > 0, "Should find at least one MCP tool method");
@@ -43,7 +43,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 var parameters = method.GetParameters();
                 if (parameters.Length == 0)
                 {
-                    var attr = method.GetCustomAttribute<McpPluginToolAttribute>()!;
+                    var attr = method.GetCustomAttribute<AiToolAttribute>()!;
                     zeroParamTools.Add($"  - {attr.Name} ({method.DeclaringType?.Name}.{method.Name})");
                 }
             }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/Executor/CallToolExecutor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/Executor/CallToolExecutor.cs
@@ -23,8 +23,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests.Utils
     public class CallToolExecutor : LazyNodeExecutor
     {
         public CallToolExecutor(MethodInfo toolMethod, string json, Reflector? reflector = null) : this(
-            toolName: toolMethod.GetCustomAttribute<McpPluginToolAttribute>()?.Name
-                ?? throw new ArgumentException("Tool method must have a McpPluginTool attribute."),
+            toolName: toolMethod.GetCustomAttribute<AiToolAttribute>()?.Name
+                ?? throw new ArgumentException("Tool method must have an AiTool attribute."),
             json: json,
             reflector: reflector)
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/Executor/DynamicCallToolExecutor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/Executor/DynamicCallToolExecutor.cs
@@ -23,8 +23,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests.Utils
     public class DynamicCallToolExecutor : LazyNodeExecutor
     {
         public DynamicCallToolExecutor(MethodInfo toolMethod, Func<string> jsonProvider, Reflector? reflector = null) : this(
-            toolName: toolMethod.GetCustomAttribute<McpPluginToolAttribute>()?.Name
-                ?? throw new ArgumentException("Tool method must have a McpPluginTool attribute."),
+            toolName: toolMethod.GetCustomAttribute<AiToolAttribute>()?.Name
+                ?? throw new ArgumentException("Tool method must have an AiTool attribute."),
             jsonProvider: jsonProvider,
             reflector: reflector)
         {


### PR DESCRIPTION
## Summary

- Migrate every Unity-MCP-Plugin consumer-side usage of the legacy `[McpPlugin*]` attributes to the new shorter `[Ai*]` names introduced in MCP-Plugin-dotnet 6.5.0.
- 116 .cs files touched, 342 sites renamed (1:1 mechanical rewrite, 342 insertions + 342 deletions).
- Also updates reflection-style class references (`McpPluginToolAttribute` -> `AiToolAttribute`, etc.), documentation strings in skill templates, and exception messages so user-facing guidance teaches the new names.

The legacy `[McpPlugin*]` attributes still exist as `[Obsolete]` subclasses of the new `[Ai*]` types in MCP-Plugin-dotnet 6.5.0, so this rewrite is functionally a no-op at runtime; it eliminates deprecation warnings and unifies consumer code on the canonical names.

Out of scope (intentionally untouched):
- `Assets/Plugins/NuGet/**` — binary NuGet drops that *own* the attribute definitions; not consumer code.
- `using com.IvanMurzak.McpPlugin;` — namespace did not change in 6.5.0.
- Unrelated identifiers: `UnityMcpPluginEditor`, `UnityMcpPluginRuntime`, `McpPluginInstance`, `IMcpPlugin`, `McpPluginBuilder`, etc.
- `Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/package.json` version and `Unity-MCP-Server/*.csproj` — release pipeline handles those.

## Test plan

- [x] Local Unity EditMode tests passed on `Unity-Tests/6000.5.0b3` (the gated project picked by the implement-task resolver because the diff includes files behind `#if UNITY_6000_5_OR_NEWER` guards). 986 total / 981 passed / 5 failed; all 5 failures match the documented `TestToolConsole` / `ToolThreadSafetyTests` flaky carve-out (pre-existing IOException race on `ai-editor-logs.txt` between `unity-mcp-server.exe` and the test's `[SetUp]`).
- [x] Clean-subset gates: `ToolParameterTests` (1 pass) directly validates reflection-based attribute discovery (`GetCustomAttribute<AiToolAttribute>()` / `GetCustomAttribute<AiToolTypeAttribute>()`) post-rename. `TestToolGameObject` (44 pass) covers the GameObject tool surface that was renamed.
- [ ] CI matrix across Unity versions (will be confirmed automatically on push).

Closes #648