### PR TITLE
fix: return ResponseCallTool to prevent MCP error -32600

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Data/ScriptExecuteResponse.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Data/ScriptExecuteResponse.cs
@@ -1,0 +1,25 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.ComponentModel;
+using com.IvanMurzak.ReflectorNet.Model;
+
+namespace AIGD
+{
+    public class ScriptExecuteResponse
+    {
+        [Description("The serialized return value of the executed script. Null if the script returns void.")]
+        public SerializedMember? Result { get; set; }
+
+        [Description("Human-readable message describing the execution result.")]
+        public string? Message { get; set; }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Execute.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Execute.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using AIGD;
 using com.IvanMurzak.McpPlugin;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.ReflectorNet.Model;
@@ -53,7 +54,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "while body-only mode (isMethodBody=true) auto-generates the boilerplate so you only " +
             "provide the method body. Unity objects (GameObject, Component, etc.) can be passed as " +
             "parameters using their Ref types (GameObjectRef, ComponentRef, etc.) or directly by type.")]
-        public static ResponseCallTool Execute
+        public static ResponseCallValueTool<ScriptExecuteResponse> Execute
         (
             [Description("C# code to compile and execute. " +
                 "In full code mode (default, isMethodBody=false): must define a complete class with a static method. " +
@@ -132,20 +133,41 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     throw new Exception(error);
                 }
 
-                if (result is null)
-                    return ResponseCallTool.Success("Script executed successfully. No return value.");
-
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
                 var jsonSerializer = reflector.JsonSerializer;
 
+                // Void return - use plain success message
+                if (result is null)
+                {
+                    return ResponseCallValueTool<ScriptExecuteResponse>
+                        .Success(new ScriptExecuteResponse
+                        {
+                            Result = null,
+                            Message = "Script executed successfully. No return value."
+                        });
+                }
+
+                // Non-null result - use SuccessStructured to preserve JSON structure
                 if (result is SerializedMember serializedResult)
-                    return ResponseCallTool.Success(jsonSerializer.Serialize(serializedResult));
+                {
+                    return ResponseCallValueTool<ScriptExecuteResponse>
+                        .SuccessStructured(jsonSerializer.SerializeToNode(new ScriptExecuteResponse
+                        {
+                            Result = serializedResult,
+                            Message = "Script executed successfully."
+                        }));
+                }
 
                 var serialized = reflector.Serialize(
                     obj: result,
                     logger: logger);
 
-                return ResponseCallTool.Success(jsonSerializer.Serialize(serialized));
+                return ResponseCallValueTool<ScriptExecuteResponse>
+                    .SuccessStructured(jsonSerializer.SerializeToNode(new ScriptExecuteResponse
+                    {
+                        Result = serialized,
+                        Message = "Script executed successfully."
+                    }));
             });
         }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Execute.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Script.Execute.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Utils;
@@ -52,7 +53,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             "while body-only mode (isMethodBody=true) auto-generates the boilerplate so you only " +
             "provide the method body. Unity objects (GameObject, Component, etc.) can be passed as " +
             "parameters using their Ref types (GameObjectRef, ComponentRef, etc.) or directly by type.")]
-        public static SerializedMember? Execute
+        public static ResponseCallTool Execute
         (
             [Description("C# code to compile and execute. " +
                 "In full code mode (default, isMethodBody=false): must define a complete class with a static method. " +
@@ -132,16 +133,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 }
 
                 if (result is null)
-                    return null;
-
-                if (result is SerializedMember serializedResult)
-                    return serializedResult;
+                    return ResponseCallTool.Success("Script executed successfully. No return value.");
 
                 var reflector = UnityMcpPluginEditor.Instance.Reflector ?? throw new Exception("Reflector is not available.");
+                var jsonSerializer = reflector.JsonSerializer;
 
-                return reflector.Serialize(
+                if (result is SerializedMember serializedResult)
+                    return ResponseCallTool.Success(jsonSerializer.Serialize(serializedResult));
+
+                var serialized = reflector.Serialize(
                     obj: result,
                     logger: logger);
+
+                return ResponseCallTool.Success(jsonSerializer.Serialize(serialized));
             });
         }
 


### PR DESCRIPTION
#779 
Changed Tool_Script.Execute return type from SerializedMember? to ResponseCallTool to ensure structured content is always returned. When script returns void, now returns a success message instead of null. This fixes MCP error -32600 which occurs when a tool has output schema but returns null.
