### PR TITLE
fix: cap screenshot resolution so large captures aren't dropped in transit

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Camera.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Camera.cs
@@ -63,6 +63,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (width > MaxDimension || height > MaxDimension)
                 return ResponseCallTool.Error($"Width and height must not exceed {MaxDimension} pixels. Got {width}x{height}.");
 
+            // Keep the encoded PNG within the MCP transport limit so the screenshot is not
+            // dropped in transit; an oversized request is scaled down (aspect preserved).
+            (width, height) = ClampToTransportLimit(width, height);
+
             return MainThread.Instance.Run(() =>
             {
                 var camera = cameraRef?.FindGameObject()?.GetComponent<Camera>()

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
@@ -79,7 +79,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 // The Game View renders at the live resolution, which on high-DPI / 4K
                 // displays can be large enough that the encoded PNG exceeds the MCP transport's
                 // message-size limit — the result is then dropped in transit and never reaches
-                // the chat. Clamp the longest edge to `MaxGameViewDimension`, downscaling on the
+                // the chat. Clamp the longest edge to `MaxScreenshotDimension`, downscaling on the
                 // GPU (an RT→RT blit preserves pixel orientation, so the flip compensation below
                 // stays correct), so the payload stays comparable to the other screenshot tools.
                 var srcWidth = sourceRt.width;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.GameView.cs
@@ -75,15 +75,38 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 // DirectX/Metal because Unity performs a Y-flip at display-blit time — a step
                 // bypassed when ReadPixels runs against the GameView RT directly.
                 // `SystemInfo.graphicsUVStartsAtTop` identifies the APIs that need the flip.
-                var width = sourceRt.width;
-                var height = sourceRt.height;
+                //
+                // The Game View renders at the live resolution, which on high-DPI / 4K
+                // displays can be large enough that the encoded PNG exceeds the MCP transport's
+                // message-size limit — the result is then dropped in transit and never reaches
+                // the chat. Clamp the longest edge to `MaxGameViewDimension`, downscaling on the
+                // GPU (an RT→RT blit preserves pixel orientation, so the flip compensation below
+                // stays correct), so the payload stays comparable to the other screenshot tools.
+                var srcWidth = sourceRt.width;
+                var srcHeight = sourceRt.height;
+
+                var scale = Mathf.Min(1f, (float)MaxScreenshotDimension / Mathf.Max(srcWidth, srcHeight));
+                var width = Mathf.Max(1, Mathf.RoundToInt(srcWidth * scale));
+                var height = Mathf.Max(1, Mathf.RoundToInt(srcHeight * scale));
 
                 var prevActive = RenderTexture.active;
+                RenderTexture? scaledRt = null;
                 Texture2D? tex = null;
                 byte[]? pngBytes = null;
                 try
                 {
-                    RenderTexture.active = sourceRt;
+                    // When the Game View is within the limit (scale == 1) the read path is
+                    // byte-identical to a direct read of the source RT; otherwise we read from a
+                    // downscaled copy.
+                    var readSource = sourceRt;
+                    if (scale < 1f)
+                    {
+                        scaledRt = RenderTexture.GetTemporary(width, height, 0, sourceRt.format);
+                        Graphics.Blit(sourceRt, scaledRt);
+                        readSource = scaledRt;
+                    }
+
+                    RenderTexture.active = readSource;
                     tex = new Texture2D(width, height, TextureFormat.RGB24, false);
                     tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
 
@@ -106,6 +129,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 finally
                 {
                     RenderTexture.active = prevActive;
+                    if (scaledRt != null)
+                        RenderTexture.ReleaseTemporary(scaledRt);
                     if (tex != null)
                         UnityEngine.Object.DestroyImmediate(tex);
                 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.Isolated.cs
@@ -183,6 +183,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             var resolvedFar = farClipPlane ?? 1000f;
             var resolvedPadding = padding ?? 1.2f;
 
+            // Keep the encoded PNG within the MCP transport limit so the screenshot is not
+            // dropped in transit. Composite emits a resolution*2 x resolution*2 grid, so its
+            // per-axis budget is half the cap; single views use the full cap.
+            var maxResolutionForMode = resolvedCameraView == CameraView.Composite
+                ? MaxScreenshotDimension / 2
+                : MaxScreenshotDimension;
+            if (resolvedResolution > maxResolutionForMode)
+                resolvedResolution = maxResolutionForMode;
+
             if (!float.IsFinite(resolvedFov) || resolvedFov < MinFieldOfView || resolvedFov > MaxFieldOfView)
                 return ResponseCallTool.Error(
                     $"fieldOfView must be finite and between {MinFieldOfView} and {MaxFieldOfView} degrees. Got {resolvedFov}.");

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.SceneView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.SceneView.cs
@@ -55,6 +55,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (width > MaxDimension || height > MaxDimension)
                 return ResponseCallTool.Error($"Width and height must not exceed {MaxDimension} pixels. Got {width}x{height}.");
 
+            // Keep the encoded PNG within the MCP transport limit so the screenshot is not
+            // dropped in transit; an oversized request is scaled down (aspect preserved).
+            (width, height) = ClampToTransportLimit(width, height);
+
             return MainThread.Instance.Run(() =>
             {
                 var sceneView = SceneView.lastActiveSceneView;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Screenshot.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using com.IvanMurzak.McpPlugin;
+using UnityEngine;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.API
 {
@@ -17,5 +18,32 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
     public partial class Tool_Screenshot
     {
         private const int MaxDimension = 16384;
+
+        // Encoded screenshots travel back to the AI as base64 PNG inside a JSON envelope over
+        // the MCP transport, which caps a single message (MaximumReceiveMessageSize, 128 MB).
+        // A capture whose pixel dimensions are too large produces a PNG that exceeds that cap
+        // and is silently dropped in transit — the image never reaches the chat. Every
+        // screenshot tool keeps its longest output edge at or below this value so the payload
+        // stays transportable.
+        //
+        // Worst case (incompressible content) the message is ~ D*D*4 bytes for a D-px square, so
+        // the 128 MB cap allows up to ~5790 px. 3840 (true 4K) leaves comfortable headroom
+        // (~59 MB worst case) while staying well clear of that ceiling. Going higher has little
+        // value: Claude's vision downsamples images to ~1568 px on the longest edge before the
+        // model sees them, so extra resolution past ~4K only inflates the payload.
+        private const int MaxScreenshotDimension = 3840;
+
+        // Scale (width, height) so the longest edge is at most MaxScreenshotDimension, preserving
+        // aspect ratio. Returns the input unchanged when it is already within the limit.
+        private static (int width, int height) ClampToTransportLimit(int width, int height)
+        {
+            var longest = Mathf.Max(width, height);
+            if (longest <= MaxScreenshotDimension)
+                return (width, height);
+
+            var scale = (float)MaxScreenshotDimension / longest;
+            return (Mathf.Max(1, Mathf.RoundToInt(width * scale)),
+                    Mathf.Max(1, Mathf.RoundToInt(height * scale)));
+        }
     }
 }


### PR DESCRIPTION
## Problem

Encoded screenshots return to the AI as base64 PNG inside a JSON envelope over the MCP transport, which caps a single message. A capture whose pixel dimensions are too large produces a payload that exceeds the cap and is **silently dropped in transit** — the image never appears in the chat.

The **Game View** tool was the most exposed: it reads the live Game View render texture at its native (uncapped) resolution, so on high-DPI / 4K displays its PNG routinely exceeded the limit. The 1080p-default Scene View / Camera / Isolated tools usually slipped under, but a large explicit `width`/`height`/`resolution` (or Composite's `resolution*2` grid) hits the same wall.

## Fix

Shared `MaxScreenshotDimension = 3840` (true 4K) + `ClampToTransportLimit` helper in `Screenshot.cs`, applied to every capture tool:

| Tool | Bounding |
|---|---|
| Game View | Renders native, GPU-downscales (RT→RT `Graphics.Blit`, which preserves orientation so the existing `graphicsUVStartsAtTop` Y-flip stays correct) to ≤ 3840 long edge |
| Scene View / Camera | Clamps requested `width`/`height`, aspect preserved |
| Isolated | Clamps `resolution`; **Composite** gets half the cap (it emits a `resolution*2` grid) |

3840 leaves comfortable headroom (~59 MB worst case for an incompressible square) under the companion 128 MB transport cap, well clear of the ~5790 px ceiling that cap allows. Ordinary ≤1080p requests are never altered.

## Notes / verification
- Pairs with `MCP-Plugin-dotnet` raising `MaximumReceiveMessageSize` to 128 MB.
- The existing `ScreenshotGameViewTests` assert success/error only — **not** orientation. The ≤cap path is byte-identical to before; only the new downscale branch (>3840 px Game View) is new behavior, so please eyeball a >4K Game View capture once on DirectX/Metal to confirm it's still upright (the #662 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)