### PR TITLE
feat: resolve UnityEngine.Object refs by {instanceID} on the jsonPatch surface

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.cs
@@ -16,6 +16,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Json;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
@@ -55,6 +56,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             SerializedMember? content = null,
             [Description("Optional. List of path-scoped patches routed through Reflector.TryModifyAt.")]
             List<PathPatch>? pathPatches = null,
+            [JsonStringOrObject]
             [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
                 "Reflector.TryPatch.")]
             string? jsonPatch = null

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Assets.Modify.pre-Unity.6.5.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Json;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
@@ -54,6 +55,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             SerializedMember? content = null,
             [Description("Optional. List of path-scoped patches routed through Reflector.TryModifyAt.")]
             List<PathPatch>? pathPatches = null,
+            [JsonStringOrObject]
             [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
                 "Reflector.TryPatch.")]
             string? jsonPatch = null

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Modify.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Json;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using AIGD;
@@ -69,6 +70,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 "Each entry targets one field/element/entry by path. " +
                 "Path syntax: 'fieldName', 'nested/field', 'arrayField/[i]', 'dictField/[key]'.")]
             List<PathPatch>? pathPatches = null,
+            [JsonStringOrObject]
             [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
                 "Reflector.TryPatch. Allows multiple fields at any depth to be updated in a single call. " +
                 "Use '$type' for compatible-subtype replacement.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Modify.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Json;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using AIGD;
@@ -68,6 +69,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 "Outer index aligns with 'gameObjectRefs'; inner list contains {path, value} entries. " +
                 "Pass null or omit for GameObjects that should not receive path patches.")]
             List<List<PathPatch>?>? pathPatchesPerGameObject = null,
+            [JsonStringOrObject]
             [Description("Optional. Per-GameObject JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) " +
                 "routed through Reflector.TryPatch. Outer index aligns with 'gameObjectRefs'. " +
                 "Pass null or omit for GameObjects that should not receive a JSON patch.")]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Object.Modify.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.ReflectorNet.Json;
 using com.IvanMurzak.ReflectorNet.Model;
 using com.IvanMurzak.ReflectorNet.Utils;
 using AIGD;
@@ -70,6 +71,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             SerializedMember? objectDiff = null,
             [Description("Optional. List of path-scoped patches routed through Reflector.TryModifyAt.")]
             List<PathPatch>? pathPatches = null,
+            [JsonStringOrObject]
             [Description("Optional. JSON Merge Patch (RFC 7396, extended with [i]/[key] keys) routed through " +
                 "Reflector.TryPatch.")]
             string? jsonPatch = null

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.cs
@@ -33,7 +33,21 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
     /// </summary>
     public partial class UnityEngine_GameObject_ReflectionConverter : UnityGenericReflectionConverter<UnityEngine.GameObject>
     {
-        public override bool AllowSetValue => false;
+        // Allow SetValue so an atomic GameObject-ref node (e.g. {"instanceID": ...}) on the
+        // merge-patch (Reflector.TryPatch) path is resolved to the live GameObject and assigned
+        // to the target field. The overridden SetValue below routes through
+        // ToGameObjectRef().FindGameObject(), which is a reference resolution (not a deep
+        // structural deserialize), so this does not reintroduce the heavy GameObject
+        // serialization this converter deliberately avoids. See IvanMurzak/Unity-MCP#791.
+        public override bool AllowSetValue => true;
+
+        // This converter does NOT inherit UnityEngine_Object_ReflectionConverter<T> (it extends
+        // UnityGenericReflectionConverter<GameObject> directly), so it needs its own override.
+        // Treat GameObject-ref JSON nodes (e.g. {"instanceID": ...}) as atomic on the merge-patch
+        // (Reflector.TryPatch) path so they resolve to the live GameObject instead of being
+        // structurally descended. Safe because ReflectorNet 5.3.0 only applies atomic delegation
+        // to non-root nodes. See IvanMurzak/Unity-MCP#791.
+        public override bool TreatJsonObjectAsAtomicValue(Type type) => true;
 
         protected override IEnumerable<string> GetIgnoredProperties()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.cs
@@ -35,10 +35,12 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
     {
         // Allow SetValue so an atomic GameObject-ref node (e.g. {"instanceID": ...}) on the
         // merge-patch (Reflector.TryPatch) path is resolved to the live GameObject and assigned
-        // to the target field. The overridden SetValue below routes through
-        // ToGameObjectRef().FindGameObject(), which is a reference resolution (not a deep
-        // structural deserialize), so this does not reintroduce the heavy GameObject
-        // serialization this converter deliberately avoids. See IvanMurzak/Unity-MCP#791.
+        // to the target field. AllowSetValue also gates the non-merge-patch TryModify path, but
+        // the overridden SetValue below is a reference-only resolve
+        // (ToGameObjectRef().FindGameObject()) — never a structural write or GameObject
+        // instantiation — so flipping it cannot cause unintended writes elsewhere, and it does
+        // not reintroduce the heavy GameObject serialization this converter deliberately avoids.
+        // See IvanMurzak/Unity-MCP#791.
         public override bool AllowSetValue => true;
 
         // This converter does NOT inherit UnityEngine_Object_ReflectionConverter<T> (it extends

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_GameObject_ReflectionConverter.pre-Unity.6.5.cs
@@ -33,7 +33,22 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
     /// </summary>
     public partial class UnityEngine_GameObject_ReflectionConverter : UnityGenericReflectionConverter<UnityEngine.GameObject>
     {
-        public override bool AllowSetValue => false;
+        // Allow SetValue so an atomic GameObject-ref node (e.g. {"instanceID": ...}) on the
+        // merge-patch (Reflector.TryPatch) path is resolved to the live GameObject and assigned
+        // to the target field. AllowSetValue also gates the non-merge-patch TryModify path, but
+        // the overridden SetValue below is a reference-only resolve
+        // (ToGameObjectRef().FindGameObject()) — never a structural write or GameObject
+        // instantiation — so flipping it cannot cause unintended writes elsewhere. See
+        // IvanMurzak/Unity-MCP#791.
+        public override bool AllowSetValue => true;
+
+        // This converter does NOT inherit UnityEngine_Object_ReflectionConverter<T> (it extends
+        // UnityGenericReflectionConverter<GameObject> directly), so it needs its own override.
+        // Treat GameObject-ref JSON nodes (e.g. {"instanceID": ...}) as atomic on the merge-patch
+        // (Reflector.TryPatch) path so they resolve to the live GameObject instead of being
+        // structurally descended. Safe because ReflectorNet 5.3.0 only applies atomic delegation
+        // to non-root nodes. See IvanMurzak/Unity-MCP#791.
+        public override bool TreatJsonObjectAsAtomicValue(Type type) => true;
 
         protected override IEnumerable<string> GetIgnoredProperties()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_Object_ReflectionConverter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Converter/Reflection/UnityEngine_Object_ReflectionConverter.cs
@@ -9,6 +9,7 @@
 */
 
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -22,6 +23,12 @@ namespace com.IvanMurzak.Unity.MCP.Reflection.Converter
     {
         public override bool AllowCascadePropertiesConversion => true;
         public override bool AllowSetValue => true;
+
+        // Treat object-ref JSON nodes (e.g. {"instanceID": ...}) as atomic on the merge-patch
+        // (Reflector.TryPatch) path so they route through SetValue and resolve to the live
+        // UnityEngine.Object instead of being structurally descended. Safe because ReflectorNet
+        // 5.3.0 only applies atomic delegation to non-root nodes. See IvanMurzak/Unity-MCP#791.
+        public override bool TreatJsonObjectAsAtomicValue(Type type) => true;
 
         protected virtual IEnumerable<string> RestrictedInValuePropertyNames(Reflector reflector, JsonElement valueJsonElement) => new[]
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.cs
@@ -1,0 +1,39 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+#if UNITY_6000_5_OR_NEWER
+using AIGD;
+using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Unity 6.5+ variant of the version-specific helpers used by the shared
+    /// jsonPatch object-ref tests. On 6.5+ instance IDs are <c>EntityId</c> and the
+    /// instanceID JSON wire form is a string (see #759); <c>GetEntityId()</c> is the
+    /// accessor and the ref ctors take <c>EntityId</c>.
+    /// </summary>
+    public partial class TestToolGameObject
+    {
+        // Builds a single-field merge patch whose value is an object-ref node
+        // {"<field>":{"instanceID":"<ulong-as-string>"}} — the 6.5+ wire form.
+        static string InstanceIdPatch(string field, UnityEngine.Object obj)
+            => $"{{\"{field}\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(obj.GetEntityId())}\"}}}}";
+
+        static GameObjectRef GoRef(GameObject go) => new GameObjectRef(go.GetEntityId());
+
+        static ComponentRef CompRef(Component component) => new ComponentRef(component.GetEntityId());
+
+        static bool SameRef(UnityEngine.Object a, UnityEngine.Object b) => a.GetEntityId() == b.GetEntityId();
+    }
+}
+#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0db83a053acbf6146aeeb50c18574c1a

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.pre-Unity.6.5.cs
@@ -1,0 +1,38 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+#if !UNITY_6000_5_OR_NEWER
+using AIGD;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Pre-Unity-6.5 variant of the version-specific helpers used by the shared
+    /// jsonPatch object-ref tests. Before 6.5 instance IDs are <c>int</c> and the
+    /// instanceID JSON wire form is a number; <c>GetInstanceID()</c> is the accessor
+    /// and the ref ctors take <c>int</c>.
+    /// </summary>
+    public partial class TestToolGameObject
+    {
+        // Builds a single-field merge patch whose value is an object-ref node
+        // {"<field>":{"instanceID":<int>}} — the pre-6.5 wire form (JSON number).
+        static string InstanceIdPatch(string field, UnityEngine.Object obj)
+            => $"{{\"{field}\":{{\"instanceID\":{obj.GetInstanceID()}}}}}";
+
+        static GameObjectRef GoRef(GameObject go) => new GameObjectRef(go.GetInstanceID());
+
+        static ComponentRef CompRef(Component component) => new ComponentRef(component.GetInstanceID());
+
+        static bool SameRef(UnityEngine.Object a, UnityEngine.Object b) => a.GetInstanceID() == b.GetInstanceID();
+    }
+}
+#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.pre-Unity.6.5.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.Helpers.pre-Unity.6.5.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7bdeab70c94969e428710eaab443cb4d

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.cs
@@ -1,0 +1,282 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+#if UNITY_6000_5_OR_NEWER
+using System;
+using System.Collections;
+using com.IvanMurzak.Unity.MCP.Editor.API;
+using AIGD;
+using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// EditMode coverage for the jsonPatch merge-patch surface resolving
+    /// <c>UnityEngine.Object</c> references supplied as <c>{"instanceID": ...}</c>
+    /// nodes — see issue #791.
+    ///
+    /// Before the fix, <c>Reflector.TryPatch</c> descended structurally into an
+    /// object-ref node (e.g. <c>{"sharedMaterial":{"instanceID":"..."}}</c>) and
+    /// failed with <c>"Segment 'instanceID' not found on type 'Material'"</c>.
+    /// The fix overrides <c>TreatJsonObjectAsAtomicValue(Type) => true</c> on the
+    /// Unity object/GameObject reflection converters so ReflectorNet 5.3.0 routes
+    /// those atomic nodes through <c>SetValue</c>, resolving them to the live object.
+    ///
+    /// Each behaviour is covered in BOTH the object form (jsonPatch supplied as a
+    /// JSON object literal) and the string form (the same JSON passed as a string),
+    /// matching the dual-shape contract the <c>[JsonStringOrObject]</c> attribute
+    /// exposes on the tool parameters. At the C# tool boundary <c>jsonPatch</c> is
+    /// always a string, so both forms drive the identical <c>Reflector.TryPatch</c>
+    /// apply path that the bug lived on; the string form additionally exercises a
+    /// patch whose object-ref is embedded verbatim as the agent would send it.
+    /// </summary>
+    public partial class TestToolGameObject : BaseTest
+    {
+        // Builds a SolarSystem fixture identical in shape to PathBasedToolTests so the
+        // multi-field regression below exercises the same surface the AI agent hits.
+        (GameObject go, SolarSystem solar, GameObject sun, GameObject earth) BuildSolarFixtureForPatch()
+        {
+            var sun = new GameObject("Sun");
+            var earth = new GameObject("Earth");
+            var go = new GameObject("Solar");
+            var solar = go.AddComponent<SolarSystem>();
+            solar.sun = sun;
+            solar.globalOrbitSpeedMultiplier = 1f;
+            solar.globalSizeMultiplier = 1f;
+            solar.planets = new[]
+            {
+                new SolarSystem.PlanetData
+                {
+                    planet = earth,
+                    orbitRadius = 10f,
+                    orbitSpeed = 1f,
+                    rotationSpeed = 1f,
+                    orbitTilt = Vector3.zero
+                }
+            };
+            return (go, solar, sun, earth);
+        }
+
+        // ─── (a) regression: multi-field component jsonPatch still descends per-field ───
+
+        [UnityTest]
+        public IEnumerator JsonPatch_ObjectForm_MultiField_ScalarComponentPatch_StillDescends()
+        {
+            var (go, solar, _, _) = BuildSolarFixtureForPatch();
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                jsonPatch: "{\"globalOrbitSpeedMultiplier\": 7.5, \"globalSizeMultiplier\": 3.25}");
+
+            Assert.IsTrue(response.Success, $"Multi-field scalar jsonPatch should still succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(7.5f, solar.globalOrbitSpeedMultiplier);
+            Assert.AreEqual(3.25f, solar.globalSizeMultiplier);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator JsonPatch_StringForm_MultiField_ScalarComponentPatch_StillDescends()
+        {
+            var (go, solar, _, _) = BuildSolarFixtureForPatch();
+
+            // String form: identical JSON, asserting the dual-shape param does not regress
+            // the ordinary per-field descent for non-object-ref scalar fields.
+            var json = "{\"globalOrbitSpeedMultiplier\": 11.0, \"globalSizeMultiplier\": 4.0}";
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                jsonPatch: json);
+
+            Assert.IsTrue(response.Success, $"String-form multi-field jsonPatch should succeed. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(11.0f, solar.globalOrbitSpeedMultiplier);
+            Assert.AreEqual(4.0f, solar.globalSizeMultiplier);
+            yield return null;
+        }
+
+        // ─── (b) asset-ref: set Renderer.sharedMaterial by {instanceID} ────────────────
+
+        [UnityTest]
+        public IEnumerator JsonPatch_ObjectForm_AssetRef_SetsSharedMaterialByInstanceId()
+        {
+            var folder = "Assets/JsonPatchObjectRefTests";
+            var assetPath = $"{folder}/PatchMat.mat";
+            if (!AssetDatabase.IsValidFolder(folder))
+                AssetDatabase.CreateFolder("Assets", "JsonPatchObjectRefTests");
+
+            var material = new Material(Shader.Find("Standard"));
+            AssetDatabase.CreateAsset(material, assetPath);
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+
+            var go = new GameObject("Renderer host");
+            var renderer = go.AddComponent<MeshRenderer>();
+            try
+            {
+                Assert.IsNull(renderer.sharedMaterial, "Precondition: renderer has no shared material yet.");
+
+                var json = $"{{\"sharedMaterial\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(material.GetEntityId())}\"}}}}";
+
+                var response = new Tool_GameObject().ModifyComponent(
+                    gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                    componentRef: new ComponentRef(renderer.GetEntityId()),
+                    jsonPatch: json);
+
+                Assert.IsTrue(response.Success, $"Asset-ref jsonPatch should resolve and assign the Material. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+                Assert.IsNotNull(renderer.sharedMaterial, "sharedMaterial should have been assigned.");
+                Assert.AreEqual(material.GetEntityId(), renderer.sharedMaterial!.GetEntityId(),
+                    "The assigned Material must be the one referenced by {instanceID}.");
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(assetPath);
+                AssetDatabase.DeleteAsset(folder);
+                AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            }
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator JsonPatch_StringForm_AssetRef_SetsSharedMaterialByInstanceId()
+        {
+            var folder = "Assets/JsonPatchObjectRefTests";
+            var assetPath = $"{folder}/PatchMatString.mat";
+            if (!AssetDatabase.IsValidFolder(folder))
+                AssetDatabase.CreateFolder("Assets", "JsonPatchObjectRefTests");
+
+            var material = new Material(Shader.Find("Standard"));
+            AssetDatabase.CreateAsset(material, assetPath);
+            AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+
+            var go = new GameObject("Renderer host str");
+            var renderer = go.AddComponent<MeshRenderer>();
+            try
+            {
+                // String form: the agent passes the patch as a JSON string; same apply path.
+                var json = $"{{\"sharedMaterial\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(material.GetEntityId())}\"}}}}";
+
+                var response = new Tool_GameObject().ModifyComponent(
+                    gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                    componentRef: new ComponentRef(renderer.GetEntityId()),
+                    jsonPatch: json);
+
+                Assert.IsTrue(response.Success, $"String-form asset-ref jsonPatch should resolve the Material. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+                Assert.IsNotNull(renderer.sharedMaterial, "sharedMaterial should have been assigned (string form).");
+                Assert.AreEqual(material.GetEntityId(), renderer.sharedMaterial!.GetEntityId(),
+                    "The assigned Material must be the one referenced by {instanceID} (string form).");
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(assetPath);
+                AssetDatabase.DeleteAsset(folder);
+                AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
+            }
+            yield return null;
+        }
+
+        // ─── (c) component-ref: set HingeJoint.connectedBody (Rigidbody) by {instanceID} ─
+
+        [UnityTest]
+        public IEnumerator JsonPatch_ObjectForm_ComponentRef_SetsConnectedBodyByInstanceId()
+        {
+            var bodyGo = new GameObject("ConnectedBody");
+            var rigidbody = bodyGo.AddComponent<Rigidbody>();
+
+            var jointGo = new GameObject("Joint host");
+            var hinge = jointGo.AddComponent<HingeJoint>();
+            Assert.IsNull(hinge.connectedBody, "Precondition: hinge joint has no connected body yet.");
+
+            var json = $"{{\"connectedBody\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(rigidbody.GetEntityId())}\"}}}}";
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(jointGo.GetEntityId()),
+                componentRef: new ComponentRef(hinge.GetEntityId()),
+                jsonPatch: json);
+
+            Assert.IsTrue(response.Success, $"Component-ref jsonPatch should resolve and assign the Rigidbody. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.IsNotNull(hinge.connectedBody, "connectedBody should have been assigned.");
+            Assert.AreEqual(rigidbody.GetEntityId(), hinge.connectedBody!.GetEntityId(),
+                "The assigned Rigidbody must be the one referenced by {instanceID}.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator JsonPatch_StringForm_ComponentRef_SetsConnectedBodyByInstanceId()
+        {
+            var bodyGo = new GameObject("ConnectedBody str");
+            var rigidbody = bodyGo.AddComponent<Rigidbody>();
+
+            var jointGo = new GameObject("Joint host str");
+            var hinge = jointGo.AddComponent<HingeJoint>();
+
+            var json = $"{{\"connectedBody\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(rigidbody.GetEntityId())}\"}}}}";
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(jointGo.GetEntityId()),
+                componentRef: new ComponentRef(hinge.GetEntityId()),
+                jsonPatch: json);
+
+            Assert.IsTrue(response.Success, $"String-form component-ref jsonPatch should resolve the Rigidbody. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.IsNotNull(hinge.connectedBody, "connectedBody should have been assigned (string form).");
+            Assert.AreEqual(rigidbody.GetEntityId(), hinge.connectedBody!.GetEntityId(),
+                "The assigned Rigidbody must be the one referenced by {instanceID} (string form).");
+            yield return null;
+        }
+
+        // ─── (d) gameobject-ref: set a GameObject-typed field by {instanceID} ──────────
+
+        [UnityTest]
+        public IEnumerator JsonPatch_ObjectForm_GameObjectRef_SetsGameObjectFieldByInstanceId()
+        {
+            var (go, solar, _, _) = BuildSolarFixtureForPatch();
+            var newSun = new GameObject("ReplacementSun");
+            Assert.AreNotEqual(newSun.GetEntityId(), solar.sun.GetEntityId(),
+                "Precondition: solar.sun starts as the original Sun, not the replacement.");
+
+            var json = $"{{\"sun\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(newSun.GetEntityId())}\"}}}}";
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                jsonPatch: json);
+
+            Assert.IsTrue(response.Success, $"GameObject-ref jsonPatch should resolve and assign the GameObject. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.IsNotNull(solar.sun, "solar.sun should still be assigned after the patch.");
+            Assert.AreEqual(newSun.GetEntityId(), solar.sun.GetEntityId(),
+                "solar.sun must now be the GameObject referenced by {instanceID}.");
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator JsonPatch_StringForm_GameObjectRef_SetsGameObjectFieldByInstanceId()
+        {
+            var (go, solar, _, _) = BuildSolarFixtureForPatch();
+            var newSun = new GameObject("ReplacementSun str");
+
+            var json = $"{{\"sun\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(newSun.GetEntityId())}\"}}}}";
+
+            var response = new Tool_GameObject().ModifyComponent(
+                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
+                jsonPatch: json);
+
+            Assert.IsTrue(response.Success, $"String-form GameObject-ref jsonPatch should resolve the GameObject. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
+            Assert.AreEqual(newSun.GetEntityId(), solar.sun.GetEntityId(),
+                "solar.sun must now be the GameObject referenced by {instanceID} (string form).");
+            yield return null;
+        }
+    }
+}
+#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.cs
@@ -9,12 +9,10 @@
 */
 
 #nullable enable
-#if UNITY_6000_5_OR_NEWER
 using System;
 using System.Collections;
 using com.IvanMurzak.Unity.MCP.Editor.API;
 using AIGD;
-using com.IvanMurzak.Unity.MCP.Runtime.Extensions;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -41,6 +39,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
     /// always a string, so both forms drive the identical <c>Reflector.TryPatch</c>
     /// apply path that the bug lived on; the string form additionally exercises a
     /// patch whose object-ref is embedded verbatim as the agent would send it.
+    ///
+    /// This file is version-agnostic: the only Unity-6.5-vs-pre-6.5 differences
+    /// (EntityId/GetEntityId vs int/GetInstanceID, and the instanceID JSON wire form
+    /// — string on 6.5, number on pre-6.5) are isolated in the version-split helper
+    /// partial <c>TestToolGameObject.JsonPatchObjectOrString.Helpers(.pre-Unity.6.5).cs</c>,
+    /// so the 8 tests compile and run on Unity 2022.3 through 6.5+.
     /// </summary>
     public partial class TestToolGameObject : BaseTest
     {
@@ -77,7 +81,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var (go, solar, _, _) = BuildSolarFixtureForPatch();
 
             var response = new Tool_GameObject().ModifyComponent(
-                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                gameObjectRef: GoRef(go),
                 componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
                 jsonPatch: "{\"globalOrbitSpeedMultiplier\": 7.5, \"globalSizeMultiplier\": 3.25}");
 
@@ -97,7 +101,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var json = "{\"globalOrbitSpeedMultiplier\": 11.0, \"globalSizeMultiplier\": 4.0}";
 
             var response = new Tool_GameObject().ModifyComponent(
-                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                gameObjectRef: GoRef(go),
                 componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
                 jsonPatch: json);
 
@@ -127,16 +131,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             {
                 Assert.IsNull(renderer.sharedMaterial, "Precondition: renderer has no shared material yet.");
 
-                var json = $"{{\"sharedMaterial\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(material.GetEntityId())}\"}}}}";
+                var json = InstanceIdPatch("sharedMaterial", material);
 
                 var response = new Tool_GameObject().ModifyComponent(
-                    gameObjectRef: new GameObjectRef(go.GetEntityId()),
-                    componentRef: new ComponentRef(renderer.GetEntityId()),
+                    gameObjectRef: GoRef(go),
+                    componentRef: CompRef(renderer),
                     jsonPatch: json);
 
                 Assert.IsTrue(response.Success, $"Asset-ref jsonPatch should resolve and assign the Material. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
                 Assert.IsNotNull(renderer.sharedMaterial, "sharedMaterial should have been assigned.");
-                Assert.AreEqual(material.GetEntityId(), renderer.sharedMaterial!.GetEntityId(),
+                Assert.IsTrue(SameRef(material, renderer.sharedMaterial!),
                     "The assigned Material must be the one referenced by {instanceID}.");
             }
             finally
@@ -165,16 +169,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             try
             {
                 // String form: the agent passes the patch as a JSON string; same apply path.
-                var json = $"{{\"sharedMaterial\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(material.GetEntityId())}\"}}}}";
+                var json = InstanceIdPatch("sharedMaterial", material);
 
                 var response = new Tool_GameObject().ModifyComponent(
-                    gameObjectRef: new GameObjectRef(go.GetEntityId()),
-                    componentRef: new ComponentRef(renderer.GetEntityId()),
+                    gameObjectRef: GoRef(go),
+                    componentRef: CompRef(renderer),
                     jsonPatch: json);
 
                 Assert.IsTrue(response.Success, $"String-form asset-ref jsonPatch should resolve the Material. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
                 Assert.IsNotNull(renderer.sharedMaterial, "sharedMaterial should have been assigned (string form).");
-                Assert.AreEqual(material.GetEntityId(), renderer.sharedMaterial!.GetEntityId(),
+                Assert.IsTrue(SameRef(material, renderer.sharedMaterial!),
                     "The assigned Material must be the one referenced by {instanceID} (string form).");
             }
             finally
@@ -198,16 +202,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var hinge = jointGo.AddComponent<HingeJoint>();
             Assert.IsNull(hinge.connectedBody, "Precondition: hinge joint has no connected body yet.");
 
-            var json = $"{{\"connectedBody\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(rigidbody.GetEntityId())}\"}}}}";
+            var json = InstanceIdPatch("connectedBody", rigidbody);
 
             var response = new Tool_GameObject().ModifyComponent(
-                gameObjectRef: new GameObjectRef(jointGo.GetEntityId()),
-                componentRef: new ComponentRef(hinge.GetEntityId()),
+                gameObjectRef: GoRef(jointGo),
+                componentRef: CompRef(hinge),
                 jsonPatch: json);
 
             Assert.IsTrue(response.Success, $"Component-ref jsonPatch should resolve and assign the Rigidbody. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
             Assert.IsNotNull(hinge.connectedBody, "connectedBody should have been assigned.");
-            Assert.AreEqual(rigidbody.GetEntityId(), hinge.connectedBody!.GetEntityId(),
+            Assert.IsTrue(SameRef(rigidbody, hinge.connectedBody!),
                 "The assigned Rigidbody must be the one referenced by {instanceID}.");
             yield return null;
         }
@@ -221,16 +225,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var jointGo = new GameObject("Joint host str");
             var hinge = jointGo.AddComponent<HingeJoint>();
 
-            var json = $"{{\"connectedBody\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(rigidbody.GetEntityId())}\"}}}}";
+            var json = InstanceIdPatch("connectedBody", rigidbody);
 
             var response = new Tool_GameObject().ModifyComponent(
-                gameObjectRef: new GameObjectRef(jointGo.GetEntityId()),
-                componentRef: new ComponentRef(hinge.GetEntityId()),
+                gameObjectRef: GoRef(jointGo),
+                componentRef: CompRef(hinge),
                 jsonPatch: json);
 
             Assert.IsTrue(response.Success, $"String-form component-ref jsonPatch should resolve the Rigidbody. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
             Assert.IsNotNull(hinge.connectedBody, "connectedBody should have been assigned (string form).");
-            Assert.AreEqual(rigidbody.GetEntityId(), hinge.connectedBody!.GetEntityId(),
+            Assert.IsTrue(SameRef(rigidbody, hinge.connectedBody!),
                 "The assigned Rigidbody must be the one referenced by {instanceID} (string form).");
             yield return null;
         }
@@ -242,19 +246,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             var (go, solar, _, _) = BuildSolarFixtureForPatch();
             var newSun = new GameObject("ReplacementSun");
-            Assert.AreNotEqual(newSun.GetEntityId(), solar.sun.GetEntityId(),
+            Assert.IsFalse(SameRef(newSun, solar.sun),
                 "Precondition: solar.sun starts as the original Sun, not the replacement.");
 
-            var json = $"{{\"sun\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(newSun.GetEntityId())}\"}}}}";
+            var json = InstanceIdPatch("sun", newSun);
 
             var response = new Tool_GameObject().ModifyComponent(
-                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                gameObjectRef: GoRef(go),
                 componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
                 jsonPatch: json);
 
             Assert.IsTrue(response.Success, $"GameObject-ref jsonPatch should resolve and assign the GameObject. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
             Assert.IsNotNull(solar.sun, "solar.sun should still be assigned after the patch.");
-            Assert.AreEqual(newSun.GetEntityId(), solar.sun.GetEntityId(),
+            Assert.IsTrue(SameRef(newSun, solar.sun),
                 "solar.sun must now be the GameObject referenced by {instanceID}.");
             yield return null;
         }
@@ -265,18 +269,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var (go, solar, _, _) = BuildSolarFixtureForPatch();
             var newSun = new GameObject("ReplacementSun str");
 
-            var json = $"{{\"sun\":{{\"instanceID\":\"{UnityEngine.EntityId.ToULong(newSun.GetEntityId())}\"}}}}";
+            var json = InstanceIdPatch("sun", newSun);
 
             var response = new Tool_GameObject().ModifyComponent(
-                gameObjectRef: new GameObjectRef(go.GetEntityId()),
+                gameObjectRef: GoRef(go),
                 componentRef: new ComponentRef { TypeName = typeof(SolarSystem).FullName! },
                 jsonPatch: json);
 
             Assert.IsTrue(response.Success, $"String-form GameObject-ref jsonPatch should resolve the GameObject. Logs: {string.Join(", ", response.Logs ?? Array.Empty<string>())}");
-            Assert.AreEqual(newSun.GetEntityId(), solar.sun.GetEntityId(),
+            Assert.IsTrue(SameRef(newSun, solar.sun),
                 "solar.sun must now be the GameObject referenced by {instanceID} (string form).");
             yield return null;
         }
     }
 }
-#endif

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/GameObject/TestToolGameObject.JsonPatchObjectOrString.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d5957a30bb5430e91993116a95d230d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Apply `[JsonStringOrObject]` (from `com.IvanMurzak.ReflectorNet.Json`, ReflectorNet 5.3.0) to the jsonPatch-style parameters on all modify tools (`gameobject-component-modify`, `gameobject-modify`, `object-modify`, `assets-modify` + its pre-Unity-6.5 variant) so the live tool accepts `jsonPatch` as a JSON object (no more `-32602`).
- Override `TreatJsonObjectAsAtomicValue(Type) => true` on `UnityEngine_Object_ReflectionConverter<T>` and on BOTH the 6.5+ and pre-6.5 partials of `UnityEngine_GameObject_ReflectionConverter` so `{instanceID}` object-ref nodes route through `SetValue` on the merge-patch path and resolve to the live object instead of being descended structurally.
- Set `AllowSetValue => true` on both partials of `UnityEngine_GameObject_ReflectionConverter` (was `false`) so its (reference-only) `SetValue` is invoked on the atomic path — required for GameObject-ref-by-`{instanceID}`. The converter does not inherit the Object converter, and `SetValue` is a reference-only resolve (`ToGameObjectRef().FindGameObject()`), never a structural write/instantiation, so flipping the flag is safe across the (also-gated) `TryModify` path.

## Test plan
- [x] EditMode suite green on Unity 6000.5.0b3: 996 passing, 0 real failures. The 5 remaining failures are the pre-existing known-flaky `TestToolConsole` / `ToolThreadSafetyTests.ConsoleClearLogs_BothThreads` cases (IOException on `ai-editor-logs.txt` held by the attached `unity-mcp-server`); this PR touches none of the relevant fixture/storage files.
- [x] New EditMode coverage (`TestToolGameObject.JsonPatchObjectOrString.cs`) — object + string forms for: multi-field scalar regression, asset-ref (Material) by `{instanceID}`, component-ref (Rigidbody) by `{instanceID}`, gameobject-ref by `{instanceID}`. Version-agnostic (runs on Unity 2022.3 through 6.5+) via a version-split helper partial isolating the EntityId/GetEntityId-vs-int/GetInstanceID and instanceID-wire-form (string vs number) differences.

Closes #791