### PR TITLE
chore: bump to McpPlugin 6.5.5 (6h idle-timeout) + release 0.77.2

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Installer
     public static partial class Installer
     {
         public const string PackageId = "com.ivanmurzak.unity.mcp";
-        public const string Version = "0.77.1";
+        public const string Version = "0.77.2";
 
         static Installer()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.cs
@@ -26,7 +26,7 @@ namespace com.IvanMurzak.Unity.MCP
 
     public partial class UnityMcpPlugin : IDisposable
     {
-        public const string Version = "0.77.1";
+        public const string Version = "0.77.2";
 
         private static int _singletonCount = 0;
         public static bool HasAnyInstance => _singletonCount > 0;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/package.json
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/package.json
@@ -15,7 +15,7 @@
     "Unity MCP",
     "Unity Skills"
   ],
-  "version": "0.77.1",
+  "version": "0.77.2",
   "unity": "2022.3",
   "description": "AI Skills, MCP Tools, and CLI for Unity Engine. Full AI develop and test loop. Use cli for quick setup. Efficient token usage, advanced tools. Any C# method may be turned into a tool by a single line. Works with Claude Code, Gemini, Copilot, Cursor and any other absolutely for free.",
   "documentationUrl": "https://github.com/IvanMurzak/Unity-MCP/blob/main/README.md",

--- a/Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj
+++ b/Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>unity-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.Unity.MCP.Server</PackageId>
-    <Version>0.77.1</Version>
+    <Version>0.77.2</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2025 Ivan Murzak</Copyright>
@@ -46,7 +46,7 @@
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.5.4" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.5.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">

--- a/Unity-MCP-Server/server.json
+++ b/Unity-MCP-Server/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "Unity-MCP-Server"
   },
-  "version": "0.77.1",
+  "version": "0.77.2",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "ivanmurzakdev/unity-mcp-server",
-      "version": "0.77.1",
+      "version": "0.77.2",
       "transport": {
         "type": "stdio"
       },

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unity-mcp-cli",
-  "version": "0.77.1",
+  "version": "0.77.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unity-mcp-cli",
-      "version": "0.77.1",
+      "version": "0.77.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-mcp-cli",
-  "version": "0.77.1",
+  "version": "0.77.2",
   "description": "Cross-platform CLI tool for AI Game Developer (Skills & MCP). Full AI develop and test loop. Efficient token usage, advanced tools. Creates Unity project, installs plugins, configures tools, and manages HTTP connection with Unity Editor and a game made with Unity. Works with Claude Code, Gemini, Copilot, Cursor and any other absolutely for free.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
## What

- Bumps the `com.IvanMurzak.McpPlugin.Server` NuGet reference in `Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj` from **6.5.4 → 6.5.5**. (`com.IvanMurzak.McpPlugin.Common` 6.5.5 follows transitively.) ReflectorNet is unchanged (5.3.1), and the `UseLocalMcpPlugin` default-NuGet path is left intact.
- Releases Unity-MCP **0.77.1 → 0.77.2** via `commands/bump-version.ps1` (server csproj `<Version>` + `server.json`, Unity package.json, plugin/installer version constants, CLI package.json + lock).

## Why

6.5.5 ships the MCP-Plugin-dotnet streamableHttp idle-timeout fix — the default idle-timeout was raised to 6h, so clients no longer get `-32001 "Session not found"` after the session sits idle. Pinning the server to 6.5.5 carries that fix into the `ivanmurzakdev/unity-mcp-server` Docker image, which currently builds against 6.5.4.

## Verification

- `dotnet build Unity-MCP-Server/com.IvanMurzak.Unity.MCP.Server.csproj -c Release` succeeds with **0 errors / 0 warnings**.
- Restore resolves `com.IvanMurzak.McpPlugin.Server/6.5.5` and `com.IvanMurzak.McpPlugin.Common/6.5.5` (confirmed in `project.assets.json`).
- Unity editor tests not run locally (require a Unity install) — they run in CI on merge.

## Release impact

Merging to `main` triggers `release.yml`, which publishes `ivanmurzakdev/unity-mcp-server:0.77.2` to Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)