### PR TITLE
Add AI InputSystem extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Install extensions when need more tools or [create your own tools](#add-custom-t
 | --- | --- |
 | **[AI Animation](https://github.com/IvanMurzak/Unity-AI-Animation/)** | Set of additional tools for Unity Animations |
 | **[AI Cinemachine](https://github.com/IvanMurzak/Unity-AI-Cinemachine/)** | MCP Tools for Cinemachine |
+| **[AI InputSystem](https://github.com/IvanMurzak/Unity-AI-InputSystem/)** | MCP Tools for the Unity Input System |
 | **[AI ParticleSystem](https://github.com/IvanMurzak/Unity-AI-ParticleSystem/)** | Set of additional tools for Unity Particle System |
 | **[AI ProBuilder](https://github.com/IvanMurzak/Unity-AI-ProBuilder/)** | Set of additional tools for Unity ProBuilder |
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs
@@ -53,6 +53,22 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 }
             ),
             new(
+                name:        "InputSystem",
+                description: "AI-assisted Unity Input System authoring: InputActionAssets, maps, actions, bindings, and control schemes.",
+                packageId:   "com.ivanmurzak.unity.mcp.inputsystem",
+                gitUrl:      "https://github.com/IvanMurzak/Unity-AI-InputSystem.git",
+                tools: new[]
+                {
+                    ("inputsystem-asset-create",          "Create a new .inputactions InputActionAsset"),
+                    ("inputsystem-actionmap-add",         "Add an ActionMap to the asset"),
+                    ("inputsystem-action-add",            "Add an Action (type + expectedControlType)"),
+                    ("inputsystem-binding-add",           "Add a binding path to an Action"),
+                    ("inputsystem-binding-composite-add", "Add a composite binding (2DVector/1DAxis)"),
+                    ("inputsystem-controlscheme-add",     "Add a control scheme with device requirements"),
+                    ("inputsystem-get",                   "Read the asset's maps, actions, and bindings"),
+                }
+            ),
+            new(
                 name:        "ParticleSystem",
                 description: "AI-powered particle system creation and control tools.",
                 packageId:   "com.ivanmurzak.unity.mcp.particlesystem",

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -199,6 +199,7 @@ Instala extensiones cuando necesites más herramientas o [crea tus propias herra
 | --- | --- |
 | **[AI Animation](https://github.com/IvanMurzak/Unity-AI-Animation/)** | Conjunto de herramientas adicionales para animaciones de Unity |
 | **[AI Cinemachine](https://github.com/IvanMurzak/Unity-AI-Cinemachine/)** | Herramientas MCP para Cinemachine |
+| **[AI InputSystem](https://github.com/IvanMurzak/Unity-AI-InputSystem/)** | Herramientas MCP para el Input System de Unity |
 | **[AI ParticleSystem](https://github.com/IvanMurzak/Unity-AI-ParticleSystem/)** | Conjunto de herramientas adicionales para el sistema de partículas de Unity |
 | **[AI ProBuilder](https://github.com/IvanMurzak/Unity-AI-ProBuilder/)** | Conjunto de herramientas adicionales para Unity ProBuilder |
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -199,6 +199,7 @@ unity-mcp-cli open ./MyUnityProject
 | --- | --- |
 | **[AI Animation](https://github.com/IvanMurzak/Unity-AI-Animation/)** | Unity アニメーション用の追加ツールセット |
 | **[AI Cinemachine](https://github.com/IvanMurzak/Unity-AI-Cinemachine/)** | Cinemachine 用の MCP ツール |
+| **[AI InputSystem](https://github.com/IvanMurzak/Unity-AI-InputSystem/)** | Unity Input System 用の MCP ツール |
 | **[AI ParticleSystem](https://github.com/IvanMurzak/Unity-AI-ParticleSystem/)** | Unity パーティクルシステム用の追加ツールセット |
 | **[AI ProBuilder](https://github.com/IvanMurzak/Unity-AI-ProBuilder/)** | Unity ProBuilder 用の追加ツールセット |
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -199,6 +199,7 @@ unity-mcp-cli open ./MyUnityProject
 | --- | --- |
 | **[AI Animation](https://github.com/IvanMurzak/Unity-AI-Animation/)** | Unity 动画附加工具集 |
 | **[AI Cinemachine](https://github.com/IvanMurzak/Unity-AI-Cinemachine/)** | 用于 Cinemachine 的 MCP 工具 |
+| **[AI InputSystem](https://github.com/IvanMurzak/Unity-AI-InputSystem/)** | 用于 Unity 输入系统的 MCP 工具 |
 | **[AI ParticleSystem](https://github.com/IvanMurzak/Unity-AI-ParticleSystem/)** | Unity 粒子系统附加工具集 |
 | **[AI ProBuilder](https://github.com/IvanMurzak/Unity-AI-ProBuilder/)** | Unity ProBuilder 附加工具集 |
 


### PR DESCRIPTION
Registers the AI InputSystem extension in the plugin window + README listings.

- Adds an `InputSystem` entry to the `_extensions` array in `MainWindowEditor.Extensions.cs` (package `com.ivanmurzak.unity.mcp.inputsystem`, repo https://github.com/IvanMurzak/Unity-AI-InputSystem).
- Adds the `AI InputSystem` row to README.md and the es / ja / zh-CN translations.

Extension repo: https://github.com/IvanMurzak/Unity-AI-InputSystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)