### PR TITLE
docs: link to the ai-game.dev MCP tools registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ That's it. Ask your AI *"Create 3 cubes in a circle with radius 2"* and watch it
 
 The plugin ships with 70+ built-in tools across four categories. Each tool brings AI skill. All tools are available immediately after installation — no extra configuration required. See [docs/default-mcp-tools.md](docs/default-mcp-tools.md) for the full reference with detailed descriptions.
 
+> 🧰 Browse the full MCP tools registry online: [ai-game.dev/docs/tools](https://ai-game.dev/docs/tools)
+
 <details>
   <summary>Project & Assets</summary>
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -96,6 +96,8 @@ Eso es todo. Pídele a tu IA *"Crea 3 cubos en un círculo con radio 2"* y obser
 
 El plugin incluye más de 70 herramientas integradas en cuatro categorías. Cada herramienta aporta una habilidad a la IA. Todas las herramientas están disponibles inmediatamente después de la instalación — no se requiere configuración adicional. Consulta [docs/default-mcp-tools.md](docs/default-mcp-tools.md) para la referencia completa con descripciones detalladas.
 
+> 🧰 Explora el registro completo de herramientas MCP en línea: [ai-game.dev/docs/tools](https://ai-game.dev/docs/tools)
+
 <details>
   <summary>Proyecto y assets</summary>
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -96,6 +96,8 @@ unity-mcp-cli open ./MyUnityProject
 
 このプラグインには4つのカテゴリにまたがる70以上の組み込みツールが付属しています。各ツールが AI スキルを提供します。すべてのツールはインストール直後に利用可能で、追加の設定は不要です。詳細な説明付きの完全なリファレンスは [docs/default-mcp-tools.md](docs/default-mcp-tools.md) をご覧ください。
 
+> 🧰 MCP ツールレジストリの全体をオンラインで閲覧: [ai-game.dev/docs/tools](https://ai-game.dev/docs/tools)
+
 <details>
   <summary>プロジェクト＆アセット</summary>
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -96,6 +96,8 @@ unity-mcp-cli open ./MyUnityProject
 
 插件内置 70+ 个工具，分为四个类别。每个工具都为 AI 带来技能。安装后所有工具立即可用，无需额外配置。完整参考及详细说明请见 [docs/default-mcp-tools.md](docs/default-mcp-tools.md)。
 
+> 🧰 在线浏览完整的 MCP 工具注册表：[ai-game.dev/docs/tools](https://ai-game.dev/docs/tools)
+
 <details>
   <summary>项目与资产</summary>
 


### PR DESCRIPTION
## Summary

Adds a tasteful, one-line clickable link to the online MCP tools registry — **https://ai-game.dev/docs/tools** — in the Unity-MCP READMEs.

The link sits directly under the **Skills and Tools Reference** heading, right after the existing pointer to `docs/default-mcp-tools.md`, so readers browsing the tool docs get an obvious path to the searchable online registry.

## Changes

One link added per README, with a language-appropriate label, matching each file's existing style:

- `README.md` (English)
- `docs/README.es.md` (Spanish)
- `docs/README.ja.md` (Japanese)
- `docs/README.zh-CN.md` (Chinese, Simplified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)