### PR TITLE
ci: code-sign server release executables (macOS notarize + Windows Trusted Signing)

### DIFF
--- a/.github/workflows/deploy_server_executables.yml
+++ b/.github/workflows/deploy_server_executables.yml
@@ -6,9 +6,21 @@
 # │  See the LICENSE file in the project root for more information.  │
 # └──────────────────────────────────────────────────────────────────┘
 
-# This workflow builds the MCP server executables for all platforms and uploads them as release assets.
+# This workflow builds the MCP server executables for all platforms, code-signs
+# them, and uploads them as release assets.
 # It is triggered when a new release is published manually.
 # It is NOT triggered by CI/CD pipelines or other automated processes.
+#
+# Code-signing is GRACEFULLY DEGRADING: every signing/notarization step is
+# guarded on its secret being non-empty. A run with NO signing secrets set
+# still builds, zips, and uploads ALL 7 unsigned zips so releases stay green
+# before the secrets are provisioned.
+#
+# Platform split:
+#   - macos-latest job  -> osx-x64, osx-arm64 (codesign + notarytool),
+#                          plus linux-x64, linux-arm64 (unsigned, cross-built).
+#   - windows-latest job -> win-x64, win-x86, win-arm64 (Azure Trusted Signing).
+# signtool cannot run on macOS, so the Windows RIDs need their own runner.
 
 name: deploy-server-executables
 
@@ -17,8 +29,24 @@ on:
     types: [published]
 
 jobs:
-  build-and-zip:
+  # ────────────────────────────────────────────────────────────────────
+  # macOS + Linux: osx-x64, osx-arm64 (signed + notarized), linux-x64,
+  # linux-arm64 (unsigned). Built on macos-latest, which cross-builds the
+  # linux RIDs fine.
+  # ────────────────────────────────────────────────────────────────────
+  build-macos-linux:
     runs-on: macos-latest
+    # Job-level env so the signing/notarization guards (`if: env.X != ''`) can
+    # read these. A step's own `env:` block is NOT visible to that same step's
+    # `if:` — the condition is evaluated before the step env is applied — so the
+    # graceful-degradation guards MUST resolve their values at job scope.
+    env:
+      MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+      MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+      MAC_SIGN_IDENTITY: ${{ secrets.MAC_SIGN_IDENTITY }}
+      APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -31,11 +59,160 @@ jobs:
       - name: Make build script executable
         run: chmod +x ./Unity-MCP-Server/build-all.sh
 
-      - name: Build executables for all platforms
+      - name: Build executables (osx + linux, no zip yet)
         shell: bash {0}
-        run: cd Unity-MCP-Server && ./build-all.sh Release
+        run: |
+          cd Unity-MCP-Server
+          ./build-all.sh Release --no-zip osx-x64 osx-arm64 linux-x64 linux-arm64
 
-      - name: Upload release assets
+      # Import the Developer ID Application certificate into a temporary
+      # keychain. Guarded: skipped (and signing later skipped) when MAC_CSC_LINK
+      # is empty, so an unsigned-but-green release is still produced.
+      - name: Import macOS signing certificate
+        if: ${{ env.MAC_CSC_LINK != '' }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+
+          echo "$MAC_CSC_LINK" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$MAC_CSC_KEY_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+          rm -f "$CERT_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+      - name: Code-sign macOS executables (hardened runtime)
+        if: ${{ env.MAC_CSC_LINK != '' }}
+        run: |
+          set -euo pipefail
+          ENTITLEMENTS="Unity-MCP-Server/build/entitlements.mac.plist"
+          for rid in osx-x64 osx-arm64; do
+            BIN="Unity-MCP-Server/publish/${rid}/unity-mcp-server"
+            echo "Signing ${BIN}..."
+            codesign --force --options runtime --timestamp \
+              --entitlements "$ENTITLEMENTS" \
+              --sign "$MAC_SIGN_IDENTITY" "$BIN"
+            codesign --verify --strict --verbose=2 "$BIN"
+          done
+
+      - name: Zip executables
+        shell: bash {0}
+        run: |
+          set -uo pipefail
+          cd Unity-MCP-Server/publish
+          for rid in osx-x64 osx-arm64 linux-x64 linux-arm64; do
+            if [ -d "$rid" ]; then
+              echo "Zipping ${rid}..."
+              zip -r "unity-mcp-server-${rid}.zip" "${rid}/" > /dev/null
+            else
+              echo "::error::Expected publish dir ${rid} not found"
+              exit 1
+            fi
+          done
+          ls -la *.zip
+
+      # Notarize the two macOS zips with notarytool (App Store Connect API key).
+      # Guarded: skipped when the API key secret is empty.
+      - name: Notarize macOS zips
+        if: ${{ env.APPLE_API_KEY_B64 != '' }}
+        run: |
+          set -euo pipefail
+          KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          echo "$APPLE_API_KEY_B64" | base64 --decode > "$KEY_PATH"
+
+          for rid in osx-x64 osx-arm64; do
+            ZIP="Unity-MCP-Server/publish/unity-mcp-server-${rid}.zip"
+            echo "Notarizing ${ZIP}..."
+            xcrun notarytool submit "$ZIP" \
+              --key "$KEY_PATH" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER" \
+              --wait
+          done
+
+          rm -f "$KEY_PATH"
+
+      - name: Upload release assets (osx + linux)
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./Unity-MCP-Server/publish/*.zip
+          tag_name: ${{ github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ────────────────────────────────────────────────────────────────────
+  # Windows: win-x64, win-x86, win-arm64. Signed with Azure Trusted Signing
+  # (signtool is Windows-only). Built on windows-latest via build-all.ps1.
+  # ────────────────────────────────────────────────────────────────────
+  build-windows:
+    runs-on: windows-latest
+    # Job-level env so the Azure Trusted Signing guard (`if: env.AZURE_CLIENT_ID
+    # != ''`) can read it — a step's own `env:` is not visible to that step's
+    # own `if:`. See the macOS job's env comment for the full rationale.
+    env:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Build executables (win, no zip yet)
+        shell: pwsh
+        run: |
+          cd Unity-MCP-Server
+          ./build-all.ps1 -Configuration Release -NoZip -Platforms win-x64,win-x86,win-arm64
+
+      # Sign every .exe under the publish dir via Azure Trusted Signing.
+      # Guarded: the step is skipped when AZURE_CLIENT_ID is empty, leaving the
+      # executables unsigned but still uploadable.
+      - name: Sign Windows executables (Azure Trusted Signing)
+        if: ${{ env.AZURE_CLIENT_ID != '' }}
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net
+          trusted-signing-account-name: ivan-murzak
+          certificate-profile-name: ai-game-dev-cert
+          files-folder: ${{ github.workspace }}/Unity-MCP-Server/publish
+          files-folder-filter: exe
+          files-folder-recurse: true
+
+      - name: Zip executables
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $publishRoot = Join-Path $PWD "Unity-MCP-Server/publish"
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          foreach ($rid in @("win-x64", "win-x86", "win-arm64")) {
+              $runtimePath = Join-Path $publishRoot $rid
+              if (-not (Test-Path $runtimePath)) {
+                  Write-Error "Expected publish dir $rid not found"
+              }
+              $zipPath = Join-Path $publishRoot "unity-mcp-server-$rid.zip"
+              if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+              Write-Host "Zipping $rid..."
+              [System.IO.Compression.ZipFile]::CreateFromDirectory($runtimePath, $zipPath)
+          }
+          Get-ChildItem -Path $publishRoot -Filter "*.zip" | Select-Object Name, Length
+
+      - name: Upload release assets (win)
         uses: softprops/action-gh-release@v2
         with:
           files: ./Unity-MCP-Server/publish/*.zip

--- a/.github/workflows/deploy_server_executables.yml
+++ b/.github/workflows/deploy_server_executables.yml
@@ -66,10 +66,13 @@ jobs:
           ./build-all.sh Release --no-zip osx-x64 osx-arm64 linux-x64 linux-arm64
 
       # Import the Developer ID Application certificate into a temporary
-      # keychain. Guarded: skipped (and signing later skipped) when MAC_CSC_LINK
-      # is empty, so an unsigned-but-green release is still produced.
+      # keychain. Guarded on ALL THREE mac signing secrets so a partial-secrets
+      # dispatch (e.g. MAC_CSC_LINK set but MAC_SIGN_IDENTITY empty) skips the
+      # whole sign+notarize path cleanly rather than dying under `set -e` and
+      # taking the unsigned-upload fallback down with it. Result: missing or
+      # partial mac secrets => unsigned-but-green release is still produced.
       - name: Import macOS signing certificate
-        if: ${{ env.MAC_CSC_LINK != '' }}
+        if: ${{ env.MAC_CSC_LINK != '' && env.MAC_CSC_KEY_PASSWORD != '' && env.MAC_SIGN_IDENTITY != '' }}
         run: |
           set -euo pipefail
           KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
@@ -90,8 +93,11 @@ jobs:
           rm -f "$CERT_PATH"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
+      # Same all-three-secrets guard as the import step: never reach `codesign
+      # --sign "$MAC_SIGN_IDENTITY"` with an empty identity (which would fail
+      # under `set -e` and sink the whole job, including the unsigned upload).
       - name: Code-sign macOS executables (hardened runtime)
-        if: ${{ env.MAC_CSC_LINK != '' }}
+        if: ${{ env.MAC_CSC_LINK != '' && env.MAC_CSC_KEY_PASSWORD != '' && env.MAC_SIGN_IDENTITY != '' }}
         run: |
           set -euo pipefail
           ENTITLEMENTS="Unity-MCP-Server/build/entitlements.mac.plist"
@@ -121,9 +127,13 @@ jobs:
           ls -la *.zip
 
       # Notarize the two macOS zips with notarytool (App Store Connect API key).
-      # Guarded: skipped when the API key secret is empty.
+      # Guarded on the SAME three signing secrets as the codesign step PLUS the
+      # notarize API key — notarizing an UNSIGNED binary is meaningless, so the
+      # signing guard is part of this condition (notarize secrets present but
+      # signing secrets absent must NOT submit unsigned zips). Missing either
+      # set => skip cleanly and still upload the (unsigned) zips.
       - name: Notarize macOS zips
-        if: ${{ env.APPLE_API_KEY_B64 != '' }}
+        if: ${{ env.MAC_CSC_LINK != '' && env.MAC_CSC_KEY_PASSWORD != '' && env.MAC_SIGN_IDENTITY != '' && env.APPLE_API_KEY_B64 != '' }}
         run: |
           set -euo pipefail
           KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
@@ -132,11 +142,23 @@ jobs:
           for rid in osx-x64 osx-arm64; do
             ZIP="Unity-MCP-Server/publish/unity-mcp-server-${rid}.zip"
             echo "Notarizing ${ZIP}..."
-            xcrun notarytool submit "$ZIP" \
+            # `notarytool submit --wait` exits 0 even when the submission is
+            # Invalid/Rejected (it only fails on transport errors), so the exit
+            # code alone is NOT proof of acceptance. Capture the JSON result and
+            # fail the step unless status == "Accepted".
+            SUBMIT_JSON="$(xcrun notarytool submit "$ZIP" \
               --key "$KEY_PATH" \
               --key-id "$APPLE_API_KEY_ID" \
               --issuer "$APPLE_API_ISSUER" \
-              --wait
+              --wait \
+              --output-format json)"
+            echo "$SUBMIT_JSON"
+            STATUS="$(echo "$SUBMIT_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))')"
+            if [ "$STATUS" != "Accepted" ]; then
+              echo "::error::Notarization for ${rid} did not succeed (status: ${STATUS:-unknown})"
+              exit 1
+            fi
+            echo "Notarization for ${rid} accepted."
           done
 
           rm -f "$KEY_PATH"

--- a/Unity-MCP-Server/build-all.ps1
+++ b/Unity-MCP-Server/build-all.ps1
@@ -5,7 +5,10 @@
 param(
     [string]$Configuration = "Release",
     [string]$ProjectFile = "com.IvanMurzak.Unity.MCP.Server.csproj",
-    [string[]]$Platforms = @()
+    [string[]]$Platforms = @(),
+    # Build/publish only; skip the zip-archive phase. Used by CI when the
+    # executables must be code-signed AFTER publish and BEFORE zipping.
+    [switch]$NoZip
 )
 
 Write-Host "Building self-contained executables..." -ForegroundColor Green
@@ -100,6 +103,11 @@ if ($failed -gt 0) {
 Write-Host "`nAll builds completed successfully!" -ForegroundColor Green
 Write-Host "Executables are located in: $PublishRoot" -ForegroundColor Yellow
 Write-Host "Per-platform folders: ./publish/{runtime}/" -ForegroundColor Yellow
+
+if ($NoZip) {
+    Write-Host "`n-NoZip specified: skipping zip-archive phase (executables left unzipped in ./publish/{runtime}/)." -ForegroundColor Cyan
+    exit 0
+}
 
 Write-Host "`nCreating zip archives for each runtime..." -ForegroundColor Cyan
 

--- a/Unity-MCP-Server/build-all.sh
+++ b/Unity-MCP-Server/build-all.sh
@@ -7,6 +7,7 @@ set -uo pipefail
 CONFIGURATION="Release"
 PROJECT_FILE="com.IvanMurzak.Unity.MCP.Server.csproj"
 SPECIFIED_PLATFORMS=()
+NO_ZIP=false
 
 all_runtimes=(
     "win-x64"
@@ -24,6 +25,12 @@ while [[ $# -gt 0 ]]; do
         -c|--configuration)
             CONFIGURATION="$2"
             shift 2
+            ;;
+        --no-zip)
+            # Build/publish only; skip the zip-archive phase. Used by CI when
+            # executables must be code-signed AFTER publish and BEFORE zipping.
+            NO_ZIP=true
+            shift
             ;;
         Debug|Release)
             CONFIGURATION="$1"
@@ -45,7 +52,7 @@ while [[ $# -gt 0 ]]; do
             done
             if [ "$is_runtime" = false ]; then
                 echo "Unknown argument: $1"
-                echo "Usage: $0 [Debug|Release] [-c|--configuration <config>] [*.csproj] [runtime...]"
+                echo "Usage: $0 [Debug|Release] [-c|--configuration <config>] [--no-zip] [*.csproj] [runtime...]"
                 echo "Known runtimes: ${all_runtimes[*]}"
                 exit 1
             fi
@@ -112,6 +119,12 @@ if [ $failed -eq 0 ]; then
     echo ""
     echo "All builds completed successfully!"
     echo "Executables are located in: ${PUBLISH_ROOT}/{runtime}/"
+
+    if [ "$NO_ZIP" = true ]; then
+        echo ""
+        echo "--no-zip specified: skipping zip-archive phase (executables left unzipped in ${PUBLISH_ROOT}/{runtime}/)."
+        exit 0
+    fi
 
     echo ""
     echo "Creating zip archives for each runtime..."

--- a/Unity-MCP-Server/build/entitlements.mac.plist
+++ b/Unity-MCP-Server/build/entitlements.mac.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Hardened-runtime entitlements required for the self-contained .NET
+    (single-file) unity-mcp-server host to run under Gatekeeper AND pass
+    Apple notarization. The .NET runtime JITs managed code, so it needs
+    allow-jit; the single-file host extracts/loads native libraries that are
+    not all individually signed under this identity, so it needs
+    disable-library-validation. Mirrors the desktop app's hardened-runtime
+    set (packages/desktop/build/entitlements.mac.plist), trimmed to what the
+    server host actually requires.
+  -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Split `deploy_server_executables.yml` into a **macOS+Linux** job (osx-x64/osx-arm64 codesigned + notarized via notarytool; linux-x64/linux-arm64 unsigned, cross-built) and a new **Windows** job (win-x64/win-x86/win-arm64 signed via Azure Trusted Signing) — signtool is Windows-only, codesign/notarytool macOS-only.
- Added `Unity-MCP-Server/build/entitlements.mac.plist` (hardened-runtime `allow-jit` + `disable-library-validation`, mirroring the desktop app's set) and a `--no-zip`/`-NoZip` flag to both build scripts so CI can sign the host between `dotnet publish` and zipping.
- **Graceful degradation**: every signing/notarization step is guarded on its secret being non-empty (declared at job-level env so the step `if:` can read it). A dispatch with no secrets set still builds, zips, and uploads all 7 unsigned `unity-mcp-server-<rid>.zip` assets, keeping releases green before secrets are provisioned. Zip naming and the `softprops/action-gh-release` upload behavior are unchanged.

## Test plan
- [x] `python -c yaml.safe_load` parses the workflow; `actionlint` clean.
- [x] `bash -n build-all.sh` + PowerShell AST parse of `build-all.ps1` and both inline pwsh workflow steps — all clean.
- [x] Functional test with a stubbed `dotnet`: `--no-zip`/`-NoZip` builds the requested RID subset and skips zipping; the default path still zips (no regression).
- [ ] CI on this PR (`test-pull-request`); the signing workflow itself only runs on `release: published`.

Closes #817