### PR TITLE
feat(server): default streamable-http idle timeout to 6h for local server

### DIFF
--- a/Unity-MCP-Server/src/Program.cs
+++ b/Unity-MCP-Server/src/Program.cs
@@ -31,6 +31,14 @@ namespace com.IvanMurzak.Unity.MCP.Server
             // Configure NLog
             LogManager.Setup().LoadConfigurationFromFile("NLog.config");
 
+            // Default the streamableHttp idle-session window to 6 hours for this local server.
+            // The plugin's built-in default is 600s (10 min), which is too aggressive for a
+            // single-user local editor session and drops the MCP session mid-work. We only seed
+            // the env var when it is unset, and DataArguments parses CLI args after env vars, so an
+            // explicit MCP_PLUGIN_IDLE_TIMEOUT_SECONDS or --idle-timeout-seconds still overrides this.
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds)))
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds, "21600"); // 6 hours
+
             var dataArguments = new DataArguments(args);
 
             // In STDIO mode, redirect console logs to stderr to avoid polluting stdout with non-JSON content


### PR DESCRIPTION
## Problem

The local Unity-MCP-Server inherits the McpPlugin built-in idle-session default of **600s (10 min)** via `DataArguments.IdleTimeoutSeconds`. For a single-user local editor session this is too aggressive and drops the MCP session mid-work after 10 minutes idle.

## Fix

Seed `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS=21600` (6h) in `Program.Main` immediately before constructing `DataArguments`, **only when the env var is unset**. `DataArguments` parses env first then CLI, so an explicit `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` or `--idle-timeout-seconds` still overrides this default.

## Scope

LOCAL `Unity-MCP-Server` only. The cloud AI-Game-Dev-Server sets its own value via env and is unaffected.

## Verification

`dotnet build com.IvanMurzak.Unity.MCP.Server.csproj` → Build succeeded, 0 warnings, 0 errors.