### PR TITLE
fix: include DontDestroyOnLoad objects in gameobject-find search scope

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/GameObjectUtils.Editor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/GameObjectUtils.Editor.cs
@@ -1,16 +1,16 @@
 /*
-┌──────────────────────────────────────────────────────────────────┐
-│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
-│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
-│  Copyright (c) 2025 Ivan Murzak                                  │
-│  Licensed under the Apache License, Version 2.0.                 │
-│  See the LICENSE file in the project root for more information.  │
-└──────────────────────────────────────────────────────────────────┘
-*/
+ *  Author: Ivan Murzak (https://github.com/IvanMurzak)
+ *  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)
+ *  Copyright (c) 2025 Ivan Murzak
+ *  Licensed under the Apache License, Version 2.0.
+ *  See the LICENSE file in the project root for more information.
+ */
 
 #nullable enable
 #if UNITY_EDITOR && UNITY_6000_5_OR_NEWER
+using System.Linq;
 using com.IvanMurzak.McpPlugin.Common;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
@@ -18,36 +18,57 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
     public static partial class GameObjectUtils
     {
         /// <summary>
-        /// Find Root GameObject in opened Prefab. Of array of GameObjects in a scene.
+        /// Find Root GameObject in opened Prefab, active scene, and DontDestroyOnLoad.
         /// </summary>
         /// <param name="scene">Scene for the search, if null the current active scene would be used</param>
         /// <returns>Array of root GameObjects</returns>
-        public static UnityEngine.GameObject[] FindRootGameObjects(Scene? scene = null)
+        public static GameObject[] FindRootGameObjects(Scene? scene = null)
         {
             var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
             if (prefabStage != null)
                 return prefabStage.prefabContentsRoot.MakeArray();
 
+            GameObject[] rootGos;
+
             if (scene == null)
             {
-                var rootGos = UnityEditor.SceneManagement.EditorSceneManager
+                rootGos = UnityEditor.SceneManagement.EditorSceneManager
                     .GetActiveScene()
                     .GetRootGameObjects();
-
-                return rootGos;
             }
             else
             {
-                return scene.Value.GetRootGameObjects();
+                rootGos = scene.Value.GetRootGameObjects();
             }
+
+            // Include DontDestroyOnLoad root objects (only available at runtime)
+            if (UnityEditor.EditorApplication.isPlaying)
+            {
+                var ddolRoots = Resources.FindObjectsOfTypeAll<GameObject>()
+                    .Where(go => go.scene.name == "DontDestroyOnLoad"
+                        && go.transform.parent == null
+                        && (go.hideFlags == HideFlags.None || go.hideFlags == HideFlags.HideInHierarchy))
+                    .ToArray();
+
+                if (ddolRoots.Length > 0)
+                {
+                    var combined = new GameObject[rootGos.Length + ddolRoots.Length];
+                    rootGos.CopyTo(combined, 0);
+                    ddolRoots.CopyTo(combined, rootGos.Length);
+                    return combined;
+                }
+            }
+
+            return rootGos;
         }
-        public static UnityEngine.GameObject? FindByInstanceID(UnityEngine.EntityId instanceID)
+
+        public static GameObject? FindByInstanceID(EntityId instanceID)
         {
-            if (instanceID == UnityEngine.EntityId.None)
+            if (instanceID == EntityId.None)
                 return null;
 
             var obj = UnityEditor.EditorUtility.EntityIdToObject(instanceID);
-            if (obj is not UnityEngine.GameObject go)
+            if (obj is not GameObject go)
                 return null;
 
             return go;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/GameObjectUtils.Editor.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/GameObjectUtils.Editor.pre-Unity.6.5.cs
@@ -1,15 +1,14 @@
 /*
-┌──────────────────────────────────────────────────────────────────┐
-│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
-│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
-│  Copyright (c) 2025 Ivan Murzak                                  │
-│  Licensed under the Apache License, Version 2.0.                 │
-│  See the LICENSE file in the project root for more information.  │
-└──────────────────────────────────────────────────────────────────┘
-*/
+ *  Author: Ivan Murzak (https://github.com/IvanMurzak)
+ *  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)
+ *  Copyright (c) 2025 Ivan Murzak
+ *  Licensed under the Apache License, Version 2.0.
+ *  See the LICENSE file in the project root for more information.
+ */
 
 #nullable enable
 #if UNITY_EDITOR && !UNITY_6000_5_OR_NEWER
+using System.Linq;
 using com.IvanMurzak.McpPlugin.Common;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -19,7 +18,7 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
     public static partial class GameObjectUtils
     {
         /// <summary>
-        /// Find Root GameObject in opened Prefab. Of array of GameObjects in a scene.
+        /// Find Root GameObject in opened Prefab, active scene, and DontDestroyOnLoad.
         /// </summary>
         /// <param name="scene">Scene for the search, if null the current active scene would be used</param>
         /// <returns>Array of root GameObjects</returns>
@@ -29,26 +28,47 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
             if (prefabStage != null)
                 return prefabStage.prefabContentsRoot.MakeArray();
 
+            GameObject[] rootGos;
+
             if (scene == null)
             {
-                var rootGos = UnityEditor.SceneManagement.EditorSceneManager
+                rootGos = UnityEditor.SceneManagement.EditorSceneManager
                     .GetActiveScene()
                     .GetRootGameObjects();
-
-                return rootGos;
             }
             else
             {
-                return scene.Value.GetRootGameObjects();
+                rootGos = scene.Value.GetRootGameObjects();
             }
+
+            // Include DontDestroyOnLoad root objects (only available at runtime)
+            if (UnityEditor.EditorApplication.isPlaying)
+            {
+                var ddolRoots = Resources.FindObjectsOfTypeAll<GameObject>()
+                    .Where(go => go.scene.name == "DontDestroyOnLoad"
+                        && go.transform.parent == null
+                        && (go.hideFlags == HideFlags.None || go.hideFlags == HideFlags.HideInHierarchy))
+                    .ToArray();
+
+                if (ddolRoots.Length > 0)
+                {
+                    var combined = new GameObject[rootGos.Length + ddolRoots.Length];
+                    rootGos.CopyTo(combined, 0);
+                    ddolRoots.CopyTo(combined, rootGos.Length);
+                    return combined;
+                }
+            }
+
+            return rootGos;
         }
+
         public static GameObject? FindByInstanceID(int instanceID)
         {
             if (instanceID == 0)
                 return null;
 
 #if UNITY_6000_3_OR_NEWER
-            var obj = UnityEditor.EditorUtility.EntityIdToObject((UnityEngine.EntityId)instanceID);
+            var obj = UnityEditor.EditorUtility.EntityIdToObject((EntityId)instanceID);
 #else
             var obj = UnityEditor.EditorUtility.InstanceIDToObject(instanceID);
 #endif


### PR DESCRIPTION
## What changed

Added DontDestroyOnLoad scene root objects to the `gameobject-find` search scope in `FindRootGameObjects()`.

## Why

Many games use `DontDestroyOnLoad` to keep UI canvases alive across scene transitions. The existing `FindRootGameObjects()` only searched the active scene's root objects via `EditorSceneManager.GetActiveScene().GetRootGameObjects()`, which returned 0 results when all UI was in DontDestroyOnLoad.

This caused `gameobject-find` to fail with "Not found GameObject with name 'X'" even though the objects existed and were findable via `GameObject.Find()`.

## Root cause

`GameObjectUtils.Editor.cs` — `FindRootGameObjects()` only returned active scene roots. Objects in DontDestroyOnLoad were invisible to the search.

## Fix

When in Play mode, additionally search DontDestroyOnLoad root objects using `Resources.FindObjectsOfTypeAll` and combine them with the active scene roots.

## Verification

Tested in a Unity project where all UI canvases use DontDestroyOnLoad:
- Before: `gameobject-find` with name "BtnClose" → "Not found"
- After: `gameobject-find` with name "BtnClose" → found (sceneName: "DontDestroyOnLoad")

## Files changed

- `GameObjectUtils.Editor.cs` (Unity 6.5+)
- `GameObjectUtils.Editor.pre-Unity.6.5.cs` (pre-Unity 6.5)

Co-authored-by: AI (Codex) <noreply@openai.com>