### PR TITLE
feat(ui): dev-only inject/control HTTP bridge for the editor window

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 956cde4667f8b694bb76355f79260da0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlEnv.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlEnv.cs
@@ -1,0 +1,135 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.DevControl
+{
+    /// <summary>
+    /// PURE-MANAGED resolver for the DEV-ONLY bridge's two config vars, with precedence
+    /// <c>process env &gt; project-root <c>.env</c> file &gt; default</c>. Unity normally reads only
+    /// process env (<c>EnvironmentUtils</c>), but the editor is launched from the GUI / IDE with no
+    /// shell exports — so this adds a thin <c>.env</c>-file layer beneath the process env, letting a
+    /// developer (or the infra worktree provisioner) drop <c>UNITY_MCP_DEV_CONTROL=1</c> into the
+    /// project's <c>.env</c> without exporting anything. Mirrors Godot's <c>GodotMcpEnvFile.LookupRaw</c>.
+    ///
+    /// <para>No UnityEngine / UnityEditor types — the caller (<c>Startup</c>) passes the project-root
+    /// path in, so this stays unit-testable headless and never throws (a missing/unreadable
+    /// <c>.env</c> is the common case, not an error).</para>
+    /// </summary>
+    public static class DevControlEnv
+    {
+        /// <summary>Enable flag: the server starts ONLY when this resolves to exactly <c>"1"</c>.</summary>
+        public const string EnvEnable = "UNITY_MCP_DEV_CONTROL";
+
+        /// <summary>Port override; falls back to <see cref="DevControlServer.DefaultPort"/> when unset/unparseable.</summary>
+        public const string EnvPort = "UNITY_MCP_DEV_CONTROL_PORT";
+
+        /// <summary>
+        /// Resolve <paramref name="key"/> with precedence process-env &gt; <c>.env</c> file (at
+        /// <c>&lt;projectRoot&gt;/.env</c>) &gt; null. Returns the trimmed/unquoted value or null when
+        /// neither source carries a non-empty value. Never throws.
+        /// </summary>
+        public static string? Resolve(string key, string? projectRootPath)
+        {
+            var fromProcess = SafeGetEnv(key);
+            if (!string.IsNullOrEmpty(fromProcess))
+                return fromProcess;
+
+            if (string.IsNullOrEmpty(projectRootPath))
+                return null;
+
+            var envPath = Path.Combine(projectRootPath, ".env");
+            return LookupRaw(envPath, key);
+        }
+
+        /// <summary>
+        /// True when the dev-control bridge is enabled for the given project root (the enable var
+        /// resolves to exactly <c>"1"</c> through the precedence chain).
+        /// </summary>
+        public static bool IsEnabled(string? projectRootPath)
+            => Resolve(EnvEnable, projectRootPath) == "1";
+
+        /// <summary>
+        /// Resolve the port for the given project root, falling back to <paramref name="defaultPort"/>
+        /// when the var is unset or not a valid 1..65535 integer.
+        /// </summary>
+        public static int ResolvePort(string? projectRootPath, int defaultPort)
+        {
+            var raw = Resolve(EnvPort, projectRootPath);
+            if (!string.IsNullOrEmpty(raw) && int.TryParse(raw, out var parsed) && parsed > 0 && parsed <= 65535)
+                return parsed;
+            return defaultPort;
+        }
+
+        static string? SafeGetEnv(string key)
+        {
+            try { return Normalize(Environment.GetEnvironmentVariable(key)); }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Read ONE key's value from the <c>.env</c> file at <paramref name="path"/>. Skips blank /
+        /// <c>#</c>-comment lines, splits on the first <c>=</c>, trims the key, and normalizes the value
+        /// (trim + strip a single pair of wrapping quotes). Last occurrence wins. Returns null when the
+        /// file is missing/unreadable, the key is absent, or the value is blank. Never throws.
+        /// </summary>
+        public static string? LookupRaw(string? path, string key)
+        {
+            if (string.IsNullOrWhiteSpace(path) || string.IsNullOrEmpty(key))
+                return null;
+
+            string[] lines;
+            try
+            {
+                if (!File.Exists(path))
+                    return null;
+                lines = File.ReadAllLines(path);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            string? found = null; // last occurrence wins
+            foreach (var rawLine in lines)
+            {
+                if (rawLine == null)
+                    continue;
+                var line = rawLine.Trim();
+                if (line.Length == 0 || line[0] == '#')
+                    continue;
+                var eq = line.IndexOf('=');
+                if (eq <= 0)
+                    continue;
+                if (!string.Equals(line.Substring(0, eq).Trim(), key, StringComparison.Ordinal))
+                    continue;
+                var value = Normalize(line.Substring(eq + 1));
+                if (!string.IsNullOrEmpty(value))
+                    found = value;
+            }
+            return found;
+        }
+
+        /// <summary>Trim whitespace and strip a single pair of wrapping single or double quotes.</summary>
+        static string? Normalize(string? raw)
+        {
+            if (raw == null)
+                return null;
+            var trimmed = raw.Trim();
+            if (trimmed.Length >= 2 &&
+                ((trimmed[0] == '"' && trimmed[^1] == '"') || (trimmed[0] == '\'' && trimmed[^1] == '\'')))
+                trimmed = trimmed.Substring(1, trimmed.Length - 2);
+            return trimmed;
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlEnv.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlEnv.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f49824ac8545c7b469706e49192ed6e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlRouter.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlRouter.cs
@@ -1,0 +1,202 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.DevControl
+{
+    /// <summary>
+    /// PURE-MANAGED (no UnityEngine / UnityEditor types) routing + parsing core for the DEV-ONLY
+    /// inject/control HTTP bridge (<see cref="DevControlServer"/>). It owns the table-driven
+    /// <c>(method, path)</c> → command-id mapping plus the status/click-target parsers, so the
+    /// editor-side server stays a thin transport shell and ALL the routing decisions are
+    /// CI-unit-testable in the EditMode test host (NUnit) WITHOUT a live window. The
+    /// <see cref="DevControlServer"/> (which touches the live <c>MainWindowEditor</c>) consumes this;
+    /// this file references only BCL types so it could compile/run headless.
+    ///
+    /// <para>Mirrors the Godot/Unreal dev-control routers. Unity's "connection status" maps to the
+    /// three rendered states the window draws (Connected / Connecting / Disconnected — see
+    /// <c>MainWindowEditor.GetConnectionStatusText</c>); "server status" maps to
+    /// <c>McpServerManager.McpServerStatus</c> (Stopped / Starting / Running / Stopping / External).</para>
+    /// </summary>
+    public static class DevControlRouter
+    {
+        /// <summary>
+        /// The command a routed request maps to — the editor server switches on this instead of
+        /// re-parsing the raw <c>(method, path)</c>. <see cref="Unknown"/> is the sentinel for an
+        /// unmatched route (the server answers it with 404).
+        /// </summary>
+        public enum Command
+        {
+            Unknown = 0,
+            Health,
+            State,
+            InjectConnectionStatus,
+            InjectServerStatus,
+            ControlServerUrl,
+            ControlSelectAgent,
+            ControlClick,
+        }
+
+        /// <summary>
+        /// The three connection states the window renders. Parsed from the <c>/inject/connection-status</c>
+        /// body; the server maps each to the matching <c>HubConnectionState</c> + <c>KeepConnected</c> pair
+        /// the live UI expects (Connected → Connected+keep, Connecting → Disconnected+keep,
+        /// Disconnected → Disconnected+!keep). Pure-managed so the vocabulary is unit-tested here.
+        /// </summary>
+        public enum ConnectionStatus
+        {
+            Disconnected = 0,
+            Connecting,
+            Connected,
+        }
+
+        /// <summary>
+        /// The five MCP-server states the window renders (mirrors
+        /// <c>McpServerManager.McpServerStatus</c>). Kept as an independent pure-managed enum so the
+        /// router/tests carry no dependency on the editor-only manager type.
+        /// </summary>
+        public enum ServerStatus
+        {
+            Stopped = 0,
+            Starting,
+            Running,
+            Stopping,
+            External,
+        }
+
+        /// <summary>
+        /// The declarative route table: each entry maps an exact <c>(METHOD, /path)</c> to a
+        /// <see cref="Command"/>. Method is matched case-insensitively; path is matched exactly (no
+        /// trailing slash, no query string — the server strips both before calling <see cref="Route"/>).
+        /// </summary>
+        static readonly IReadOnlyList<(string Method, string Path, Command Command)> Routes = new[]
+        {
+            ("GET",  "/health",                   Command.Health),
+            ("GET",  "/state",                    Command.State),
+            ("POST", "/inject/connection-status", Command.InjectConnectionStatus),
+            ("POST", "/inject/server-status",     Command.InjectServerStatus),
+            ("POST", "/control/server-url",       Command.ControlServerUrl),
+            ("POST", "/control/select-agent",     Command.ControlSelectAgent),
+            ("POST", "/control/click",            Command.ControlClick),
+        };
+
+        /// <summary>
+        /// Resolve an HTTP <paramref name="method"/> + <paramref name="path"/> to a <see cref="Command"/>.
+        /// Method matching is case-insensitive; the path must match exactly (the caller is responsible
+        /// for stripping any trailing slash + query string first). Returns <see cref="Command.Unknown"/>
+        /// for an unmatched route (→ 404 at the server).
+        /// </summary>
+        public static Command Route(string? method, string? path)
+        {
+            if (method == null || path == null)
+                return Command.Unknown;
+
+            foreach (var route in Routes)
+            {
+                if (string.Equals(route.Method, method, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(route.Path, path, StringComparison.Ordinal))
+                    return route.Command;
+            }
+
+            return Command.Unknown;
+        }
+
+        /// <summary>
+        /// Parse a connection-status string ("Connected" / "Connecting" / "Disconnected",
+        /// case-insensitive) into a <see cref="ConnectionStatus"/>. Returns <c>false</c> (and a default
+        /// <paramref name="status"/>) for null / empty / unrecognized input so the server can answer a
+        /// 400 instead of throwing.
+        /// </summary>
+        public static bool TryParseConnectionStatus(string? value, out ConnectionStatus status)
+        {
+            switch ((value ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                case "connected":
+                    status = ConnectionStatus.Connected;
+                    return true;
+                case "connecting":
+                    status = ConnectionStatus.Connecting;
+                    return true;
+                case "disconnected":
+                    status = ConnectionStatus.Disconnected;
+                    return true;
+                default:
+                    status = ConnectionStatus.Disconnected;
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Parse a server-status string ("Stopped" / "Starting" / "Running" / "Stopping" / "External",
+        /// case-insensitive) into a <see cref="ServerStatus"/>. Returns <c>false</c> (and a default
+        /// <paramref name="status"/>) for null / empty / unrecognized input so the server can answer a 400.
+        /// </summary>
+        public static bool TryParseServerStatus(string? value, out ServerStatus status)
+        {
+            switch ((value ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                case "stopped":
+                    status = ServerStatus.Stopped;
+                    return true;
+                case "starting":
+                    status = ServerStatus.Starting;
+                    return true;
+                case "running":
+                    status = ServerStatus.Running;
+                    return true;
+                case "stopping":
+                    status = ServerStatus.Stopping;
+                    return true;
+                case "external":
+                    status = ServerStatus.External;
+                    return true;
+                default:
+                    status = ServerStatus.Stopped;
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// The set of click targets accepted by <c>POST /control/click</c>, normalized to lowercase.
+        /// The editor server maps a valid target to a live button (by UXML name) and dispatches its
+        /// click handler; an unrecognized target is a 400. Kept here (pure-managed) so the accepted
+        /// vocabulary is unit-tested. Targets mirror the window's primary buttons:
+        /// <c>connect</c> (Connect/Disconnect), <c>start-server</c> (MCP server Start/Stop),
+        /// <c>authorize</c> (Cloud authorize), <c>generate-token</c> (new auth token).
+        /// </summary>
+        static readonly HashSet<string> ClickTargets = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "connect", "disconnect", "start-server", "stop-server", "authorize", "generate-token",
+        };
+
+        /// <summary>
+        /// Validate + normalize a click <paramref name="target"/> (case-insensitive) to its canonical
+        /// lowercase form. Returns <c>false</c> for null / empty / unrecognized input. "disconnect" is a
+        /// synonym of "connect" (the same Connect/Disconnect button — its label flips with state), and
+        /// "stop-server" is a synonym of "start-server"; both are accepted here and the server collapses
+        /// them onto the one toggle button.
+        /// </summary>
+        public static bool TryNormalizeClickTarget(string? target, out string normalized)
+        {
+            var trimmed = (target ?? string.Empty).Trim();
+            if (ClickTargets.Contains(trimmed))
+            {
+                normalized = trimmed.ToLowerInvariant();
+                return true;
+            }
+
+            normalized = string.Empty;
+            return false;
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlRouter.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlRouter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2420015d9383de340aacd4788434f19a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlServer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlServer.cs
@@ -1,0 +1,354 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using com.IvanMurzak.ReflectorNet.Utils;
+using com.IvanMurzak.Unity.MCP.Editor.UI;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.DevControl
+{
+    /// <summary>
+    /// DEV-ONLY inject/control HTTP bridge for the "Game Developer" (AI Game Developer) editor window. A
+    /// <see cref="HttpListener"/> bound to <c>http://127.0.0.1:&lt;port&gt;/</c> (loopback ONLY) whose
+    /// accept loop runs on a background thread; it parses JSON in/out (<see cref="System.Text.Json"/>),
+    /// routes via the pure-managed <see cref="DevControlRouter"/>, and hops every window-touching handler
+    /// onto the editor main thread (<see cref="MainThread"/> — the Unity editor impl dispatches via
+    /// <c>EditorApplication.update</c>), because ALL Unity API / UI Toolkit access must happen there.
+    ///
+    /// <para>
+    /// SECURITY: the security boundary IS this server. It binds 127.0.0.1 only (never a routable
+    /// interface) and is started ONLY when <c>UNITY_MCP_DEV_CONTROL=1</c> (see
+    /// <c>Startup.StartDevControlIfEnabled</c>), so a shipped plugin never listens. Editor-only (lives
+    /// under <c>Editor/</c>); disposed on domain reload (<c>AssemblyReloadEvents.beforeAssemblyReload</c>)
+    /// and on editor quit.
+    /// </para>
+    /// </summary>
+    public sealed class DevControlServer : IDisposable
+    {
+        /// <summary>Default port when <c>UNITY_MCP_DEV_CONTROL_PORT</c> is unset (matches infra worktree.py).</summary>
+        public const int DefaultPort = 9922;
+
+        /// <summary>Loopback-only bind host — never a routable interface (the security boundary).</summary>
+        const string BindHost = "127.0.0.1";
+
+        readonly int _port;
+        readonly HttpListener _listener = new HttpListener();
+        readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        Thread? _acceptThread;
+        bool _disposed;
+
+        /// <summary>The base URL this server listens on (after <see cref="Start"/>).</summary>
+        public string BaseUrl => $"http://{BindHost}:{_port}/";
+
+        /// <summary>
+        /// Construct the bridge listening on <paramref name="port"/> (loopback only). Call
+        /// <see cref="Start"/> to begin accepting; the ctor does not open the socket.
+        /// </summary>
+        public DevControlServer(int port)
+        {
+            _port = port;
+        }
+
+        /// <summary>
+        /// Open the loopback listener and start the background accept loop. Logs
+        /// <c>[dev-control] Listening on http://127.0.0.1:&lt;port&gt;</c> on success; a bind failure
+        /// (port in use) is logged as an error and leaves the server inert rather than throwing into
+        /// editor boot.
+        /// </summary>
+        public void Start()
+        {
+            try
+            {
+                _listener.Prefixes.Add(BaseUrl);
+                _listener.Start();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[dev-control] failed to bind {BaseUrl}: {ex.Message}");
+                return;
+            }
+
+            _acceptThread = new Thread(AcceptLoop)
+            {
+                IsBackground = true,
+                Name = "unity-mcp-dev-control",
+            };
+            _acceptThread.Start();
+
+            Debug.Log($"[dev-control] Listening on http://{BindHost}:{_port}");
+        }
+
+        void AcceptLoop()
+        {
+            while (!_cts.IsCancellationRequested && _listener.IsListening)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = _listener.GetContext(); // blocks until a request or the listener is stopped
+                }
+                catch (Exception)
+                {
+                    // Listener stopped/disposed (teardown) or a transient accept error — exit on
+                    // cancellation, otherwise keep accepting. Never let one bad accept kill the server.
+                    if (_cts.IsCancellationRequested || !_listener.IsListening)
+                        break;
+                    continue;
+                }
+
+                try
+                {
+                    HandleRequest(context);
+                }
+                catch (Exception ex)
+                {
+                    // A handler-level failure must never kill the accept loop: answer 500 and keep serving.
+                    TryWrite(context, 500, $"{{\"ok\":false,\"error\":{JsonString(ex.Message)}}}");
+                }
+            }
+        }
+
+        void HandleRequest(HttpListenerContext context)
+        {
+            var request = context.Request;
+            var method = request.HttpMethod ?? string.Empty;
+            // Strip query string + a trailing slash so the router matches the canonical path.
+            var path = (request.Url?.AbsolutePath ?? string.Empty).TrimEnd('/');
+            if (path.Length == 0)
+                path = "/";
+
+            var command = DevControlRouter.Route(method, path);
+            if (command == DevControlRouter.Command.Unknown)
+            {
+                TryWrite(context, 404, $"{{\"ok\":false,\"error\":\"no route for {method} {JsonInner(path)}\"}}");
+                return;
+            }
+
+            if (command == DevControlRouter.Command.Health)
+            {
+                var (present, state) = RunOnMainThread(() =>
+                {
+                    var win = MainWindowEditor.DevFindOpenInstance();
+                    return (win != null, win?.DevStateJson() ?? "null");
+                });
+                TryWrite(context, 200, $"{{\"ok\":true,\"windowPresent\":{(present ? "true" : "false")},\"state\":{state}}}");
+                return;
+            }
+
+            if (command == DevControlRouter.Command.State)
+            {
+                var (present, state) = RunOnMainThread(() =>
+                {
+                    var win = MainWindowEditor.DevFindOpenInstance();
+                    return (win != null, win?.DevStateJson() ?? "null");
+                });
+                if (!present)
+                {
+                    TryWrite(context, 409, "{\"ok\":false,\"error\":\"window not open\"}");
+                    return;
+                }
+                TryWrite(context, 200, $"{{\"ok\":true,\"window\":{state}}}");
+                return;
+            }
+
+            // The remaining commands read a JSON body.
+            var body = ReadBody(request);
+            using var doc = ParseJson(body);
+            var root = doc?.RootElement;
+
+            switch (command)
+            {
+                case DevControlRouter.Command.InjectConnectionStatus:
+                {
+                    var value = GetString(root, "status");
+                    if (!DevControlRouter.TryParseConnectionStatus(value, out var status))
+                    {
+                        TryWrite(context, 400, $"{{\"ok\":false,\"error\":\"invalid connection-status {JsonInner(value)}\"}}");
+                        break;
+                    }
+                    var ok = RunOnMainThread(() =>
+                    {
+                        var win = MainWindowEditor.DevFindOpenInstance();
+                        if (win == null) return false;
+                        win.DevInjectConnectionStatus(status);
+                        return true;
+                    });
+                    WriteWindowResult(context, ok);
+                    break;
+                }
+                case DevControlRouter.Command.InjectServerStatus:
+                {
+                    var value = GetString(root, "status");
+                    if (!DevControlRouter.TryParseServerStatus(value, out var status))
+                    {
+                        TryWrite(context, 400, $"{{\"ok\":false,\"error\":\"invalid server-status {JsonInner(value)}\"}}");
+                        break;
+                    }
+                    var ok = RunOnMainThread(() =>
+                    {
+                        var win = MainWindowEditor.DevFindOpenInstance();
+                        if (win == null) return false;
+                        win.DevInjectServerStatus(status);
+                        return true;
+                    });
+                    WriteWindowResult(context, ok);
+                    break;
+                }
+                case DevControlRouter.Command.ControlServerUrl:
+                {
+                    var url = GetString(root, "url");
+                    var ok = RunOnMainThread(() =>
+                    {
+                        var win = MainWindowEditor.DevFindOpenInstance();
+                        if (win == null) return false;
+                        win.DevSetServerUrl(url ?? string.Empty);
+                        return true;
+                    });
+                    WriteWindowResult(context, ok);
+                    break;
+                }
+                case DevControlRouter.Command.ControlSelectAgent:
+                {
+                    // Accept either {agent} or {agentId} (the spec uses both across endpoint docs).
+                    var agent = GetString(root, "agent") ?? GetString(root, "agentId");
+                    var (windowPresent, selected) = RunOnMainThread(() =>
+                    {
+                        var win = MainWindowEditor.DevFindOpenInstance();
+                        if (win == null) return (false, false);
+                        return (true, win.DevSelectAgent(agent ?? string.Empty));
+                    });
+                    if (!windowPresent)
+                    {
+                        TryWrite(context, 409, "{\"ok\":false,\"error\":\"window not open\"}");
+                        break;
+                    }
+                    TryWrite(context, selected ? 200 : 404,
+                        selected ? "{\"ok\":true}" : $"{{\"ok\":false,\"error\":\"unknown agent {JsonInner(agent)}\"}}");
+                    break;
+                }
+                case DevControlRouter.Command.ControlClick:
+                {
+                    var target = GetString(root, "target");
+                    if (!DevControlRouter.TryNormalizeClickTarget(target, out var normalized))
+                    {
+                        TryWrite(context, 400, $"{{\"ok\":false,\"error\":\"invalid click target {JsonInner(target)}\"}}");
+                        break;
+                    }
+                    var (windowPresent, clicked) = RunOnMainThread(() =>
+                    {
+                        var win = MainWindowEditor.DevFindOpenInstance();
+                        if (win == null) return (false, false);
+                        return (true, win.DevClick(normalized));
+                    });
+                    if (!windowPresent)
+                    {
+                        TryWrite(context, 409, "{\"ok\":false,\"error\":\"window not open\"}");
+                        break;
+                    }
+                    TryWrite(context, clicked ? 200 : 409,
+                        clicked ? "{\"ok\":true}" : $"{{\"ok\":false,\"error\":\"target not clickable {JsonInner(target)}\"}}");
+                    break;
+                }
+                default:
+                    TryWrite(context, 404, "{\"ok\":false,\"error\":\"unhandled command\"}");
+                    break;
+            }
+        }
+
+        void WriteWindowResult(HttpListenerContext context, bool windowPresent)
+            => TryWrite(context, windowPresent ? 200 : 409,
+                windowPresent ? "{\"ok\":true}" : "{\"ok\":false,\"error\":\"window not open\"}");
+
+        /// <summary>
+        /// Run <paramref name="work"/> on the editor main thread and return its result, marshalling any
+        /// exception back to this background thread. <see cref="MainThread.Run{T}(System.Func{T})"/>
+        /// dispatches onto <c>EditorApplication.update</c> in the Unity editor impl and blocks until the
+        /// result is available (or runs inline when already on the main thread).
+        /// </summary>
+        static T RunOnMainThread<T>(Func<T> work) => MainThread.Instance.Run(work);
+
+        static string ReadBody(HttpListenerRequest request)
+        {
+            if (!request.HasEntityBody)
+                return string.Empty;
+            using var reader = new StreamReader(request.InputStream, request.ContentEncoding ?? Encoding.UTF8);
+            return reader.ReadToEnd();
+        }
+
+        static JsonDocument? ParseJson(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+            try { return JsonDocument.Parse(body); }
+            catch { return null; }
+        }
+
+        static string? GetString(JsonElement? root, string property)
+        {
+            if (root is not { ValueKind: JsonValueKind.Object } obj)
+                return null;
+            if (!obj.TryGetProperty(property, out var el))
+                return null;
+            return el.ValueKind == JsonValueKind.String ? el.GetString() : el.ToString();
+        }
+
+        static void TryWrite(HttpListenerContext context, int statusCode, string json)
+        {
+            try
+            {
+                var bytes = Encoding.UTF8.GetBytes(json);
+                context.Response.StatusCode = statusCode;
+                context.Response.ContentType = "application/json";
+                context.Response.ContentLength64 = bytes.Length;
+                context.Response.OutputStream.Write(bytes, 0, bytes.Length);
+                context.Response.OutputStream.Close();
+            }
+            catch
+            {
+                // Client hung up mid-write — nothing actionable; the accept loop keeps serving.
+            }
+        }
+
+        /// <summary>JSON-encode a string AS a complete JSON string literal (with surrounding quotes).</summary>
+        // Fully-qualified: `using com.IvanMurzak.ReflectorNet.Utils` also defines a JsonSerializer (CS0104 ambiguity).
+        static string JsonString(string? value) => System.Text.Json.JsonSerializer.Serialize(value ?? string.Empty);
+
+        /// <summary>JSON-escape a string WITHOUT surrounding quotes (for embedding inside a larger literal).</summary>
+        static string JsonInner(string? value)
+        {
+            var s = JsonString(value);
+            return s.Length >= 2 ? s.Substring(1, s.Length - 2) : s;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            try { _cts.Cancel(); } catch { /* already disposed */ }
+
+            // Stop unblocks the GetContext() call in the accept loop.
+            try { if (_listener.IsListening) _listener.Stop(); } catch { }
+            try { _listener.Close(); } catch { }
+
+            try { _acceptThread?.Join(TimeSpan.FromSeconds(2)); } catch { }
+
+            _cts.Dispose();
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlServer.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/DevControlServer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c2c577e274bc664f80452f1a1125e41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/Startup.DevControl.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/Startup.DevControl.cs
@@ -1,0 +1,73 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.Unity.MCP.Editor.DevControl;
+using Microsoft.Extensions.Logging;
+
+namespace com.IvanMurzak.Unity.MCP.Editor
+{
+    public static partial class Startup
+    {
+        /// <summary>
+        /// The DEV-ONLY inject/control bridge instance, started gated on <c>UNITY_MCP_DEV_CONTROL=1</c>
+        /// (process env &gt; project-root <c>.env</c> &gt; default). Null when the flag is off (a shipped
+        /// plugin never listens) or when a previous instance was torn down for domain reload / quit.
+        /// </summary>
+        static DevControlServer? _devControlServer;
+
+        /// <summary>
+        /// Start the DEV-ONLY inject/control bridge when the enable flag resolves to <c>"1"</c>. The port
+        /// comes from <c>UNITY_MCP_DEV_CONTROL_PORT</c> (default <see cref="DevControlServer.DefaultPort"/>)
+        /// — an unset or unparseable value falls back to the default. No-op (and never listens) when the
+        /// flag is not exactly <c>"1"</c>. Defensively wrapped so a bridge failure cannot take down editor
+        /// boot. Idempotent: a second call while a server is live is a no-op.
+        /// </summary>
+        static void StartDevControlIfEnabled()
+        {
+            if (_devControlServer != null)
+                return;
+
+            var projectRoot = UnityMcpPluginEditor.ProjectRootPath;
+            if (!DevControlEnv.IsEnabled(projectRoot))
+                return;
+
+            var port = DevControlEnv.ResolvePort(projectRoot, DevControlServer.DefaultPort);
+            try
+            {
+                _devControlServer = new DevControlServer(port);
+                _devControlServer.Start();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[dev-control] failed to start: {message}", ex.Message);
+                _devControlServer = null;
+            }
+        }
+
+        /// <summary>
+        /// Stop + dispose the dev-control bridge so a domain reload / editor quit does not leak the bound
+        /// port (the HttpListener accept thread holds the socket otherwise). Safe to call when no server
+        /// is running. Wired into <see cref="TryDisconnectAndCleanup"/> (beforeAssemblyReload + quit).
+        /// </summary>
+        static void StopDevControl()
+        {
+            if (_devControlServer == null)
+                return;
+            try { _devControlServer.Dispose(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[dev-control] exception during dispose (non-blocking): {message}", ex.Message);
+            }
+            finally { _devControlServer = null; }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/Startup.DevControl.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/DevControl/Startup.DevControl.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdbeaa5c4cab1b844bf03fc3c6ca1a3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.Editor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.Editor.cs
@@ -44,6 +44,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         /// Note: Log collector disposal always occurs regardless of this flag.</param>
         static void TryDisconnectAndCleanup(string callerName, bool onlyIfConnected = false)
         {
+            // DEV-ONLY: tear down the inject/control bridge first so a domain reload / quit never leaks
+            // the bound 127.0.0.1 port (the HttpListener accept thread holds the socket otherwise).
+            // Runs regardless of plugin-instance presence (the early-return below would skip it).
+            StopDevControl();
+
             if (!UnityMcpPluginEditor.HasInstance)
             {
                 _logger.LogDebug("{class} {method} triggered: No UnityMcpPluginEditor instance to disconnect",

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.cs
@@ -46,6 +46,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 UnityMcpPluginEditor.SkillsPath = agent.SkillsPath!;
                 UnityMcpPluginEditor.Instance.McpPluginInstance!.GenerateSkillFiles(UnityMcpPluginEditor.ProjectRootPath);
             }
+
+            // DEV-ONLY: start the 127.0.0.1 inject/control bridge, gated on UNITY_MCP_DEV_CONTROL=1
+            // (process env > project-root .env > default). No-op / never listens in a shipped plugin.
+            StartDevControlIfEnabled();
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
@@ -105,6 +105,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 || _btnConnect == null || _connectionStatusCircle == null)
                 return;
 
+            // DEV-ONLY: a dev-injected connection status pins the row — skip the live re-sync so the
+            // injection sticks on screen (see _devConnectionStatusOverride). Never set in a shipped plugin.
+            if (_devConnectionStatusOverride != null)
+                return;
+
             UpdateHostFieldState(_inputFieldHost, keepConnected, state);
             _connectionStatusText.text = "Unity: " + GetConnectionStatusText(state, keepConnected);
             _btnConnect.text = GetButtonText(state, keepConnected);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.DevControl.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.DevControl.cs
@@ -1,0 +1,313 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Text;
+using com.IvanMurzak.Unity.MCP.Editor.DevControl;
+using Microsoft.AspNetCore.SignalR.Client;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.UI
+{
+    // ===================================================================================================
+    //  DEV-ONLY inject / control / state API for the "Game Developer" (AI Game Developer) window.
+    // ---------------------------------------------------------------------------------------------------
+    //  Surface for the env-gated, 127.0.0.1-bound DevControlServer (Editor/Scripts/DevControl/) so a
+    //  terminal / AI agent can (a) INJECT fake states onto the LIVE window to test UI rendering and
+    //  (b) CONTROL it — simulate user actions (set Server URL, switch agent, click Connect / Start
+    //  server / Authorize) — without clicking by hand. INERT in a shipped plugin: the server only
+    //  starts when UNITY_MCP_DEV_CONTROL=1.
+    //
+    //  The window is a UI Toolkit EditorWindow (not a singleton). The live instance is reached via
+    //  Resources.FindObjectsOfTypeAll (does NOT force-open a window — returns it only if already open),
+    //  and we drive the REAL named UXML controls (set value + send the change/click events that the UI
+    //  registered) so the same code paths a human action would hit run.
+    //
+    //  ALL of these MUST be called on the editor main thread — the DevControlServer hops via
+    //  MainThread.Instance.Run(...). They touch UnityEngine.UIElements + EditorWindow, so they live
+    //  OUTSIDE the pure-managed DevControlRouter (which the EditMode tests exercise headless).
+    // ===================================================================================================
+    public partial class MainWindowEditor
+    {
+        /// <summary>
+        /// A dev-injected connection status PINS the connection row: <see cref="UpdateConnectionUI"/>
+        /// short-circuits while this is non-null so the reactive re-sync (driven by the throttled
+        /// ConnectionState/KeepConnected observable in <see cref="SubscribeToConnectionState"/>) does not
+        /// overwrite the injected label on the next tick. DEV-ONLY — never set in a shipped plugin.
+        /// Mirrors Godot's <c>_devStatusOverride</c>.
+        /// </summary>
+        private DevControlRouter.ConnectionStatus? _devConnectionStatusOverride;
+
+        /// <summary>
+        /// DEV-ONLY: the live window instance if one is open, else null. Uses
+        /// <see cref="Resources.FindObjectsOfTypeAll{T}()"/> so it never force-opens a window (unlike
+        /// <c>GetWindow</c>) — the dev bridge reports "no window" rather than spawning one. Must be
+        /// called on the main thread.
+        /// </summary>
+        internal static MainWindowEditor? DevFindOpenInstance()
+            => Resources.FindObjectsOfTypeAll<MainWindowEditor>().FirstOrDefault();
+
+        /// <summary>DEV-ONLY: true while a connection-status injection is pinning the connection row.</summary>
+        internal bool DevHasConnectionStatusOverride => _devConnectionStatusOverride != null;
+
+        /// <summary>
+        /// DEV-ONLY: paint a fake connection status onto the window and PIN it — the reactive re-sync is
+        /// suppressed (see <see cref="_devConnectionStatusOverride"/>) so the injected status sticks until
+        /// <see cref="DevClearConnectionStatusOverride"/>. Maps the parsed status to the
+        /// (HubConnectionState, keepConnected) pair the real <see cref="UpdateConnectionUI"/> renders.
+        /// </summary>
+        internal void DevInjectConnectionStatus(DevControlRouter.ConnectionStatus status)
+        {
+            _devConnectionStatusOverride = status;
+
+            var (state, keepConnected) = status switch
+            {
+                DevControlRouter.ConnectionStatus.Connected => (HubConnectionState.Connected, true),
+                DevControlRouter.ConnectionStatus.Connecting => (HubConnectionState.Disconnected, true),
+                _ => (HubConnectionState.Disconnected, false),
+            };
+            DevRenderConnection(state, keepConnected);
+        }
+
+        /// <summary>
+        /// DEV-ONLY: clear the connection-status injection so the row resumes reflecting the real
+        /// connection state on the next reactive tick (and immediately re-render the live state). Pairs
+        /// with <see cref="DevInjectConnectionStatus"/>.
+        /// </summary>
+        internal void DevClearConnectionStatusOverride()
+        {
+            _devConnectionStatusOverride = null;
+            RefreshConnectionUI();
+        }
+
+        /// <summary>
+        /// Render a connection (state, keepConnected) pair onto the row, BYPASSING the override guard —
+        /// used by <see cref="DevInjectConnectionStatus"/> so the injection itself paints even while the
+        /// override is set (which would otherwise short-circuit <see cref="UpdateConnectionUI"/>).
+        /// </summary>
+        private void DevRenderConnection(HubConnectionState state, bool keepConnected)
+        {
+            if (_inputFieldHost == null || _connectionStatusText == null
+                || _btnConnect == null || _connectionStatusCircle == null)
+                return;
+
+            _connectionStatusText.text = "Unity: " + GetConnectionStatusText(state, keepConnected);
+            _btnConnect.text = GetButtonText(state, keepConnected);
+            var isConnect = _btnConnect.text == ServerButtonText_Connect;
+            _btnConnect.EnableInClassList("btn-primary", isConnect);
+            _btnConnect.EnableInClassList("btn-secondary", !isConnect);
+            SetStatusIndicator(_connectionStatusCircle, GetConnectionStatusClass(state, keepConnected));
+        }
+
+        /// <summary>
+        /// DEV-ONLY: paint a fake MCP-server status onto the window. There is no override field for the
+        /// server row (unlike the connection row it has no continuously-firing re-sync that would
+        /// immediately clobber a one-shot paint — it updates only when ServerStatus/IsConnected change),
+        /// so this writes the same three elements <see cref="SetMcpServerData"/> writes.
+        /// </summary>
+        internal void DevInjectServerStatus(DevControlRouter.ServerStatus status)
+        {
+            var root = rootVisualElement;
+            var btn = root.Q<Button>("btnStartStopServer");
+            var circle = root.Q<VisualElement>("mcpServerStatusCircle");
+            var label = root.Q<Label>("mcpServerLabel");
+            if (btn == null || circle == null || label == null)
+                throw new InvalidOperationException("MCP server row not present in the window.");
+
+            var mapped = status switch
+            {
+                DevControlRouter.ServerStatus.Stopped => McpServerStatus.Stopped,
+                DevControlRouter.ServerStatus.Starting => McpServerStatus.Starting,
+                DevControlRouter.ServerStatus.Running => McpServerStatus.Running,
+                DevControlRouter.ServerStatus.Stopping => McpServerStatus.Stopping,
+                _ => McpServerStatus.External,
+            };
+
+            btn.text = GetServerButtonText(mapped);
+            var isStart = mapped == McpServerStatus.Stopped;
+            btn.EnableInClassList("btn-primary", isStart);
+            btn.EnableInClassList("btn-secondary", !isStart);
+            btn.SetEnabled(IsServerButtonEnabled(mapped));
+            label.text = GetServerLabelText(mapped, null);
+            SetStatusIndicator(circle, GetServerStatusClass(mapped));
+        }
+
+        /// <summary>
+        /// DEV-ONLY: drive the Custom-mode Server URL field as a user would — set the TextField value and
+        /// fire the FocusOut path the field registered (it commits + reconnects on focus-out). We set the
+        /// value then call the same commit work by blurring; UI Toolkit has no synthetic FocusOutEvent
+        /// dispatch that re-runs the registered callback reliably headless, so we set the value, persist,
+        /// and re-run the connect path directly to mirror the handler.
+        /// </summary>
+        internal void DevSetServerUrl(string url)
+        {
+            var field = rootVisualElement.Q<TextField>("InputServerURL")
+                ?? throw new InvalidOperationException("InputServerURL field not found (Custom mode may be hidden).");
+
+            var newValue = url ?? string.Empty;
+            field.value = newValue;
+
+            if (UnityMcpPluginEditor.LocalHost == newValue)
+                return;
+
+            UnityMcpPluginEditor.LocalHost = newValue;
+            SaveChanges($"[{nameof(MainWindowEditor)}] Dev Host Changed: {newValue}");
+            Invalidate();
+
+            UnityMcpPluginEditor.Instance.DisposeMcpPluginInstance();
+            UnityBuildAndConnect();
+        }
+
+        /// <summary>
+        /// DEV-ONLY: select an AI agent by its registry agent-id (preferred, stable) or its visible
+        /// display NAME — sets the DropdownField value and dispatches its change event so the window runs
+        /// its real persist (PlayerPrefs) + reload-agent-UI path. Returns false when no agent matches.
+        /// </summary>
+        internal bool DevSelectAgent(string idOrName)
+        {
+            var dropdown = rootVisualElement.Q<DropdownField>("aiAgentDropdown")
+                ?? throw new InvalidOperationException("aiAgentDropdown not found.");
+
+            var names = AiAgentConfiguratorRegistry.GetAgentNames();
+
+            // Resolve by registry agent-id first (stable), then fall back to the visible display name.
+            var index = AiAgentConfiguratorRegistry.GetIndexByAgentId(idOrName);
+            if (index < 0)
+                index = AiAgentConfiguratorRegistry.GetIndexByAgentName(idOrName);
+            if (index < 0 || index >= names.Count)
+                return false;
+
+            var newName = names[index];
+            var previous = dropdown.value;
+            if (string.Equals(previous, newName, StringComparison.Ordinal))
+            {
+                // Already selected — still run the persist/reload to mirror an explicit user re-pick.
+                var cfg = AiAgentConfiguratorRegistry.All[index];
+                selectedAiAgentId.Value = cfg.AgentId;
+                InvalidateAndReloadAgentUI();
+                return true;
+            }
+
+            dropdown.value = newName; // triggers the registered RegisterValueChangedCallback
+            return true;
+        }
+
+        /// <summary>
+        /// DEV-ONLY: simulate a click on one of the window's primary buttons by invoking the same handler
+        /// a human click runs. Returns false when the target's button is not present / not actionable in
+        /// the current state (e.g. Authorize only exists in Cloud mode, the server button is disabled
+        /// mid-transition). Targets: connect|disconnect|start-server|stop-server|authorize|generate-token.
+        /// </summary>
+        internal bool DevClick(string normalizedTarget)
+        {
+            var root = rootVisualElement;
+            switch (normalizedTarget)
+            {
+                case "connect":
+                case "disconnect":
+                {
+                    var btn = root.Q<Button>("btnConnectOrDisconnect");
+                    if (btn == null) return false;
+                    HandleConnectButton(btn.text);
+                    return true;
+                }
+                case "start-server":
+                case "stop-server":
+                {
+                    var btn = root.Q<Button>("btnStartStopServer");
+                    var label = root.Q<Label>("mcpServerLabel");
+                    if (btn == null || label == null || !btn.enabledSelf) return false;
+                    HandleServerButton(btn, label);
+                    return true;
+                }
+                case "authorize":
+                {
+                    if (_startAuthorizeAction == null) return false;
+                    _startAuthorizeAction.Invoke();
+                    return true;
+                }
+                case "generate-token":
+                {
+                    var btn = root.Q<Button>("btnGenerateToken");
+                    if (btn == null) return false;
+                    using var evt = ClickEvent.GetPooled();
+                    btn.SendEvent(evt);
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// DEV-ONLY: a JSON snapshot of what the window is currently rendering — connection status label,
+        /// Connect-button text, the Server URL field, the MCP-server label + button, the selected agent,
+        /// the connection mode, and whether a status injection is pinned. Read by <c>GET /state</c> and
+        /// <c>GET /health</c> so a terminal / AI agent can assert on the live UI without scraping pixels.
+        /// Hand-built JSON (all values escaped) to keep this file free of a serializer dependency.
+        /// </summary>
+        internal string DevStateJson()
+        {
+            var root = rootVisualElement;
+            string? Label(string name) => root.Q<Label>(name)?.text;
+            string? ButtonText(string name) => root.Q<Button>(name)?.text;
+
+            var hostField = root.Q<TextField>("InputServerURL");
+            var dropdown = root.Q<DropdownField>("aiAgentDropdown");
+
+            var sb = new StringBuilder();
+            sb.Append('{');
+            AppendJsonField(sb, "windowTitle", WindowTitle); sb.Append(',');
+            AppendJsonField(sb, "connectionStatus", Label("connectionStatusText")); sb.Append(',');
+            AppendJsonField(sb, "connectButtonText", ButtonText("btnConnectOrDisconnect")); sb.Append(',');
+            AppendJsonField(sb, "serverUrl", hostField?.value); sb.Append(',');
+            AppendJsonField(sb, "mcpServerStatus", Label("mcpServerLabel")); sb.Append(',');
+            AppendJsonField(sb, "mcpServerButtonText", ButtonText("btnStartStopServer")); sb.Append(',');
+            AppendJsonField(sb, "selectedAgent", dropdown?.value); sb.Append(',');
+            AppendJsonField(sb, "connectionMode", UnityMcpPluginEditor.ConnectionMode.ToString()); sb.Append(',');
+            sb.Append("\"connectionStatusPinned\":").Append(_devConnectionStatusOverride != null ? "true" : "false");
+            sb.Append('}');
+            return sb.ToString();
+        }
+
+        /// <summary>Append a JSON <c>"key":"value"</c> pair (value JSON-escaped; null → JSON null).</summary>
+        private static void AppendJsonField(StringBuilder sb, string key, string? value)
+        {
+            sb.Append('"').Append(key).Append("\":");
+            if (value == null)
+            {
+                sb.Append("null");
+                return;
+            }
+            sb.Append('"');
+            foreach (var ch in value)
+            {
+                switch (ch)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (ch < 0x20)
+                            sb.Append("\\u").Append(((int)ch).ToString("x4"));
+                        else
+                            sb.Append(ch);
+                        break;
+                }
+            }
+            sb.Append('"');
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.DevControl.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.DevControl.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db06695c416f65641b5476c2c17d17ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6774837b350303948a16285d3128426c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlEnvTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlEnvTests.cs
@@ -1,0 +1,127 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using com.IvanMurzak.Unity.MCP.Editor.DevControl;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// EditMode unit tests for the PURE-MANAGED <see cref="DevControlEnv"/> — the .env-file layer of the
+    /// process-env &gt; .env &gt; default precedence chain. Process-env precedence is exercised against a
+    /// uniquely-named var so the test never collides with a real export. File parsing is exercised
+    /// against a temp .env written per-test.
+    /// </summary>
+    public class DevControlEnvTests
+    {
+        string _tempDir = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "unity-mcp-devctrl-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); }
+            catch { /* best effort */ }
+        }
+
+        void WriteEnv(string contents) => File.WriteAllText(Path.Combine(_tempDir, ".env"), contents);
+
+        // ── LookupRaw (file parsing) ────────────────────────────────────────────────
+
+        [Test]
+        public void LookupRaw_ReadsKey_SkipsCommentsAndBlanks()
+        {
+            WriteEnv("# a comment\n\nUNITY_MCP_DEV_CONTROL=1\nOTHER=x\n");
+            Assert.AreEqual("1", DevControlEnv.LookupRaw(Path.Combine(_tempDir, ".env"), "UNITY_MCP_DEV_CONTROL"));
+        }
+
+        [Test]
+        public void LookupRaw_StripsWrappingQuotes_AndWhitespace()
+        {
+            WriteEnv("UNITY_MCP_DEV_CONTROL_PORT = \"9933\" \n");
+            Assert.AreEqual("9933", DevControlEnv.LookupRaw(Path.Combine(_tempDir, ".env"), "UNITY_MCP_DEV_CONTROL_PORT"));
+        }
+
+        [Test]
+        public void LookupRaw_LastOccurrenceWins()
+        {
+            WriteEnv("K=first\nK=second\n");
+            Assert.AreEqual("second", DevControlEnv.LookupRaw(Path.Combine(_tempDir, ".env"), "K"));
+        }
+
+        [Test]
+        public void LookupRaw_MissingFileOrKeyOrBlank_ReturnsNull()
+        {
+            Assert.IsNull(DevControlEnv.LookupRaw(Path.Combine(_tempDir, "nope.env"), "K"));
+            WriteEnv("K=\nOTHER=y\n");
+            Assert.IsNull(DevControlEnv.LookupRaw(Path.Combine(_tempDir, ".env"), "K"));      // blank value
+            Assert.IsNull(DevControlEnv.LookupRaw(Path.Combine(_tempDir, ".env"), "ABSENT")); // absent key
+        }
+
+        // ── Resolve / IsEnabled / ResolvePort ───────────────────────────────────────
+
+        [Test]
+        public void Resolve_FileLayer_UsedWhenProcessEnvUnset()
+        {
+            WriteEnv("UNITY_MCP_DEV_CONTROL=1\n");
+            Assert.AreEqual("1", DevControlEnv.Resolve("UNITY_MCP_DEV_CONTROL", _tempDir));
+            Assert.IsTrue(DevControlEnv.IsEnabled(_tempDir));
+        }
+
+        [Test]
+        public void IsEnabled_FalseWhenFlagMissingOrNotOne()
+        {
+            Assert.IsFalse(DevControlEnv.IsEnabled(_tempDir)); // no .env at all
+            WriteEnv("UNITY_MCP_DEV_CONTROL=0\n");
+            Assert.IsFalse(DevControlEnv.IsEnabled(_tempDir));
+            WriteEnv("UNITY_MCP_DEV_CONTROL=true\n");
+            Assert.IsFalse(DevControlEnv.IsEnabled(_tempDir)); // only exactly "1" enables
+        }
+
+        [Test]
+        public void ResolvePort_FallsBackToDefault_OnUnsetOrInvalid()
+        {
+            Assert.AreEqual(9922, DevControlEnv.ResolvePort(_tempDir, 9922)); // unset
+            WriteEnv("UNITY_MCP_DEV_CONTROL_PORT=not-a-number\n");
+            Assert.AreEqual(9922, DevControlEnv.ResolvePort(_tempDir, 9922)); // unparseable
+            WriteEnv("UNITY_MCP_DEV_CONTROL_PORT=70000\n");
+            Assert.AreEqual(9922, DevControlEnv.ResolvePort(_tempDir, 9922)); // out of range
+            WriteEnv("UNITY_MCP_DEV_CONTROL_PORT=9933\n");
+            Assert.AreEqual(9933, DevControlEnv.ResolvePort(_tempDir, 9922)); // valid override
+        }
+
+        [Test]
+        public void Resolve_ProcessEnv_OutranksFile()
+        {
+            const string key = "UNITY_MCP_DEVCTRL_TEST_PRECEDENCE";
+            WriteEnv($"{key}=from-file\n");
+            try
+            {
+                Environment.SetEnvironmentVariable(key, "from-process");
+                Assert.AreEqual("from-process", DevControlEnv.Resolve(key, _tempDir));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+            // With the process env cleared, the file layer is used.
+            Assert.AreEqual("from-file", DevControlEnv.Resolve(key, _tempDir));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlEnvTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlEnvTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9382a0926aaac3c448fcab137d71174d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlRouterTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlRouterTests.cs
@@ -1,0 +1,136 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.Unity.MCP.Editor.DevControl;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// EditMode unit tests for the PURE-MANAGED <see cref="DevControlRouter"/> — the routing + parsing
+    /// core of the DEV-ONLY inject/control bridge. These never touch the live window / HttpListener, so
+    /// they run headless in CI (no Unity Editor UI required).
+    /// </summary>
+    public class DevControlRouterTests
+    {
+        // ── Route table ─────────────────────────────────────────────────────────────
+
+        [TestCase("GET", "/health", DevControlRouter.Command.Health)]
+        [TestCase("GET", "/state", DevControlRouter.Command.State)]
+        [TestCase("POST", "/inject/connection-status", DevControlRouter.Command.InjectConnectionStatus)]
+        [TestCase("POST", "/inject/server-status", DevControlRouter.Command.InjectServerStatus)]
+        [TestCase("POST", "/control/server-url", DevControlRouter.Command.ControlServerUrl)]
+        [TestCase("POST", "/control/select-agent", DevControlRouter.Command.ControlSelectAgent)]
+        [TestCase("POST", "/control/click", DevControlRouter.Command.ControlClick)]
+        public void Route_KnownRoutes_ResolveToCommand(string method, string path, DevControlRouter.Command expected)
+        {
+            Assert.AreEqual(expected, DevControlRouter.Route(method, path));
+        }
+
+        [TestCase("get", "/health", DevControlRouter.Command.Health)]
+        [TestCase("PoSt", "/control/click", DevControlRouter.Command.ControlClick)]
+        public void Route_MethodIsCaseInsensitive(string method, string path, DevControlRouter.Command expected)
+        {
+            Assert.AreEqual(expected, DevControlRouter.Route(method, path));
+        }
+
+        [TestCase("POST", "/health")]                  // right path, wrong method
+        [TestCase("GET", "/inject/connection-status")] // right path, wrong method
+        [TestCase("GET", "/HEALTH")]                    // path is case-sensitive
+        [TestCase("GET", "/health/")]                   // trailing slash not stripped by the router
+        [TestCase("GET", "/unknown")]
+        [TestCase("DELETE", "/state")]
+        public void Route_UnknownRoutes_ReturnUnknown(string method, string path)
+        {
+            Assert.AreEqual(DevControlRouter.Command.Unknown, DevControlRouter.Route(method, path));
+        }
+
+        [Test]
+        public void Route_NullArgs_ReturnUnknown()
+        {
+            Assert.AreEqual(DevControlRouter.Command.Unknown, DevControlRouter.Route(null, "/health"));
+            Assert.AreEqual(DevControlRouter.Command.Unknown, DevControlRouter.Route("GET", null));
+            Assert.AreEqual(DevControlRouter.Command.Unknown, DevControlRouter.Route(null, null));
+        }
+
+        // ── Connection-status parsing ───────────────────────────────────────────────
+
+        [TestCase("connected", DevControlRouter.ConnectionStatus.Connected)]
+        [TestCase("Connected", DevControlRouter.ConnectionStatus.Connected)]
+        [TestCase("  CONNECTED  ", DevControlRouter.ConnectionStatus.Connected)]
+        [TestCase("connecting", DevControlRouter.ConnectionStatus.Connecting)]
+        [TestCase("disconnected", DevControlRouter.ConnectionStatus.Disconnected)]
+        public void TryParseConnectionStatus_Valid_ReturnsTrue(string value, DevControlRouter.ConnectionStatus expected)
+        {
+            Assert.IsTrue(DevControlRouter.TryParseConnectionStatus(value, out var status));
+            Assert.AreEqual(expected, status);
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("online")]
+        [TestCase("running")]
+        public void TryParseConnectionStatus_Invalid_ReturnsFalse(string? value)
+        {
+            Assert.IsFalse(DevControlRouter.TryParseConnectionStatus(value, out var status));
+            Assert.AreEqual(DevControlRouter.ConnectionStatus.Disconnected, status); // documented default
+        }
+
+        // ── Server-status parsing ───────────────────────────────────────────────────
+
+        [TestCase("stopped", DevControlRouter.ServerStatus.Stopped)]
+        [TestCase("Starting", DevControlRouter.ServerStatus.Starting)]
+        [TestCase("RUNNING", DevControlRouter.ServerStatus.Running)]
+        [TestCase("  stopping ", DevControlRouter.ServerStatus.Stopping)]
+        [TestCase("external", DevControlRouter.ServerStatus.External)]
+        public void TryParseServerStatus_Valid_ReturnsTrue(string value, DevControlRouter.ServerStatus expected)
+        {
+            Assert.IsTrue(DevControlRouter.TryParseServerStatus(value, out var status));
+            Assert.AreEqual(expected, status);
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("connected")]
+        [TestCase("paused")]
+        public void TryParseServerStatus_Invalid_ReturnsFalse(string? value)
+        {
+            Assert.IsFalse(DevControlRouter.TryParseServerStatus(value, out var status));
+            Assert.AreEqual(DevControlRouter.ServerStatus.Stopped, status); // documented default
+        }
+
+        // ── Click-target normalization ──────────────────────────────────────────────
+
+        [TestCase("connect", "connect")]
+        [TestCase("Connect", "connect")]
+        [TestCase("  DISCONNECT  ", "disconnect")]
+        [TestCase("start-server", "start-server")]
+        [TestCase("stop-server", "stop-server")]
+        [TestCase("authorize", "authorize")]
+        [TestCase("generate-token", "generate-token")]
+        public void TryNormalizeClickTarget_Valid_ReturnsTrueAndLowercases(string target, string expected)
+        {
+            Assert.IsTrue(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));
+            Assert.AreEqual(expected, normalized);
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("configure")]   // a Godot target, not a Unity one
+        [TestCase("remove")]
+        [TestCase("nonsense")]
+        public void TryNormalizeClickTarget_Invalid_ReturnsFalse(string? target)
+        {
+            Assert.IsFalse(DevControlRouter.TryNormalizeClickTarget(target, out var normalized));
+            Assert.AreEqual(string.Empty, normalized);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlRouterTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/DevControl/DevControlRouterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 649ceb117dc159d4fbb6298b82f02120
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A **dev-only** HTTP bridge so a terminal / AI agent can **inject fake states** into the live "Game Developer" editor window and **simulate user actions** — for tests + AI-driven dev. Completes the set (Godot-MCP + Unreal-MCP already merged).

## Security (the boundary is the server)
- Binds **127.0.0.1 only**; starts **only** when `UNITY_MCP_DEV_CONTROL` resolves to `"1"` with precedence **process env > project `.env` > default**; port `UNITY_MCP_DEV_CONTROL_PORT` (default 9922). **OFF by default.** `.scripts/worktree.py` allocates the port per-worktree + sets the flag.

## Design
- `DevControlServer` — `HttpListener`; window access marshalled to the main thread via `MainThread.Instance.Run`; stopped on `AssemblyReloadEvents.beforeAssemblyReload` so a domain reload never leaks the bound port.
- `DevControlRouter` + `DevControlEnv` — pure-managed (no Unity types) router + `.env` resolver, **EditMode-unit-tested**.
- `MainWindowEditor` dev API — inject connection/server status (a `_devConnectionStatusOverride` pins an injected status against the reactive UI re-sync), drive the real Connect/Disconnect/Start/agent-dropdown handlers, read `/state`.

## Endpoints
`GET /health`, `/state`; `POST /inject/connection-status`, `/inject/server-status`, `/control/server-url`, `/control/select-agent`, `/control/click`.

## Verification
- **Live-verified against the running Unity editor**: compiled clean (fixed one `JsonSerializer` CS0104 ambiguity vs ReflectorNet), `/health` + `/state` return the live window state, injected "Connected" sticks (`pinned=True`), `select-agent`→Cursor applies, bad route → 404. EditMode tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)