### PR TITLE
Skip plugin auto-start in headless batchmode (fix CI / -runTests)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.cs
@@ -26,6 +26,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         static Startup()
         {
+            // Skip auto-start in headless batchmode (e.g. CI / `-batchmode -runTests`). Otherwise the
+            // plugin connects to the shared local MCP server — forcibly disconnecting an interactive
+            // Editor running on the same machine — and, with no token in a clean CI checkout, logs an
+            // authorization error from a background connection callback that Unity's Test Framework
+            // converts into a test failure (it cannot be suppressed via LogAssert, being off the test's
+            // main-thread scope). Opt in for intentional headless use by setting UNITY_MCP_BATCHMODE=1.
+            if (Application.isBatchMode && System.Environment.GetEnvironmentVariable("UNITY_MCP_BATCHMODE") != "1")
+                return;
+
             UnityMcpPluginEditor.Instance.BuildMcpPluginIfNeeded();
             UnityMcpPluginEditor.Instance.AddUnityLogCollectorIfNeeded(() => new BufferedFileLogStorage());
 


### PR DESCRIPTION
## Problem
The Editor plugin auto-starts and connects to the local MCP server on every domain load via `Startup` (`[InitializeOnLoad]` → `UnityMcpPluginEditor.Instance.BuildMcpPluginIfNeeded()` in `Editor/Scripts/Startup.cs`). This also fires under headless `-batchmode -runTests`. When the package is committed to a project whose CI runs Unity headless:

1. The headless instance connects to the **same** local MCP server as the developer's interactive Editor on that machine and **forcibly disconnects the interactive client** — log: `McpManagerClientHub: Server forcefully disconnected this plugin. Reason: Authorization failed. Token may be missing, invalid, or revoked.`
2. In a clean CI checkout there's no token, so the plugin logs an `[Error]` from a **background SignalR connection callback**. Unity's Test Framework converts that stray error into a **test failure**, so *every* PlayMode test goes red regardless of its own assertions. It can't be suppressed with `LogAssert.ignoreFailingMessages` because the log isn't raised on the test's main-thread scope.

## Fix
Return early from `Startup`'s static constructor when `Application.isBatchMode`, so the plugin neither builds nor connects during headless runs. Intentional headless use (e.g. running the MCP server in CI on purpose) is preserved via an opt-in environment variable `UNITY_MCP_BATCHMODE=1`.

```csharp
if (Application.isBatchMode && System.Environment.GetEnvironmentVariable("UNITY_MCP_BATCHMODE") != "1")
    return;
```

## Notes
- Minimal, behavior-preserving for interactive use (the common path is unaffected).
- Workaround without this change: strip the package from the CI worktree before `-runTests`. A built-in gate removes that need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)