### PR TITLE
feat: verify downloaded mcp-server zip against SHA256SUMS before execute (fail-closed)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerChecksum.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerChecksum.cs
@@ -1,0 +1,231 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace com.IvanMurzak.Unity.MCP.Editor
+{
+    /// <summary>
+    /// Pure-managed (no UnityEngine / UnityEditor API) download-integrity logic for the shared
+    /// <c>GameDev-MCP-Server</c> binary: the <c>SHA256SUMS</c> manifest URL builder, the coreutils-format
+    /// parser, the exact-key RID digest lookup, the case-insensitive digest compare, and the single
+    /// fail-closed <see cref="VerifyZipChecksum"/> verdict. The editor manager
+    /// (<see cref="McpServerManager"/>.<c>DownloadAndUnpackBinary</c>) calls this BEFORE
+    /// <c>ZipFile.ExtractToDirectory</c> / <c>Process.Start</c> — so a downloaded server zip is NEVER
+    /// extracted or launched unless its SHA256 matches the release's published <c>SHA256SUMS</c> manifest
+    /// (issue #841). A compromised release asset or a trusted-CA MITM would otherwise yield arbitrary code
+    /// execution on the developer's machine.
+    ///
+    /// <para>
+    /// Keeping this logic here — rather than inline in <see cref="McpServerManager"/> (which touches
+    /// UnityEngine/UnityEditor APIs in nearly every method) — makes every decision unit-testable in an
+    /// EditMode/NUnit test with no running editor and no real download: each method below is a deterministic
+    /// string/enum/dictionary transform. The HTTP fetch + SHA256 compute + file IO that surround this verdict
+    /// live in the editor-coupled manager. Mirrors Godot-MCP's <c>GodotMcpServerView</c> checksum seam
+    /// (Godot leg = PR #193).
+    /// </para>
+    /// </summary>
+    public static class McpServerChecksum
+    {
+        /// <summary>
+        /// The name of the integrity manifest asset attached to every GameDev-MCP-Server release: a standard
+        /// coreutils <c>sha256sum</c> output file listing one <c>&lt;hex&gt;␠␠&lt;filename&gt;</c> line per
+        /// per-RID server zip. LIVE on the pinned <c>v8.0.0</c> release (and every future release).
+        /// </summary>
+        public const string Sha256SumsAssetName = "SHA256SUMS";
+
+        /// <summary>
+        /// The URL of a release's <c>SHA256SUMS</c> manifest — the SIBLING of the per-RID zip
+        /// (<see cref="McpServerManager.ExecutableZipUrl"/>) under the SAME <c>v&lt;serverVersion&gt;</c>
+        /// release tag:
+        /// <c>https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v&lt;serverVersion&gt;/SHA256SUMS</c>.
+        /// The downloaded zip's SHA256 is verified against this manifest BEFORE extraction/execution
+        /// (fail-closed). Uses <see cref="McpServerManager.ServerReleaseTag"/> so the manifest tag can never
+        /// drift from the zip tag. Pure string build — unit-testable with no editor.
+        /// </summary>
+        public static string Sha256SumsUrl(string serverVersion)
+            => $"https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/{McpServerManager.ServerReleaseTag(serverVersion)}/{Sha256SumsAssetName}";
+
+        /// <summary>
+        /// The <c>SHA256SUMS</c> manifest URL for the PINNED <see cref="McpServerManager.ServerVersion"/> —
+        /// the production path, taking NO version parameter so the manifest tag can never drift from the zip
+        /// tag (which also pins <see cref="McpServerManager.ServerVersion"/>).
+        /// </summary>
+        public static string Sha256SumsUrl()
+            => Sha256SumsUrl(McpServerManager.ServerVersion);
+
+        /// <summary>
+        /// Parse a coreutils <c>sha256sum</c> manifest into a <c>{filename → lowercase-hex-digest}</c> map.
+        /// The exact LIVE format is one line per file: a 64-character lowercase hex digest, then TWO spaces
+        /// (the coreutils text-mode separator), then the file name —
+        /// <c>844d4ad8…53319␠␠gamedev-mcp-server-linux-x64.zip</c>. Tolerances applied (so a hand-edited or
+        /// CRLF manifest still parses, while a malformed one yields no usable entry):
+        /// <list type="bullet">
+        /// <item>CRLF and bare-LF line endings; blank lines skipped.</item>
+        /// <item>Leading/trailing whitespace on each line trimmed.</item>
+        /// <item>The coreutils binary-mode <c>'*'</c> marker before the filename (<c>&lt;hex&gt; *&lt;name&gt;</c>)
+        /// is stripped.</item>
+        /// <item>A line whose first token is NOT a 64-char hex string, or which has no filename, is SKIPPED
+        /// (it never produces a spurious entry — fail-closed at the lookup layer).</item>
+        /// </list>
+        /// Digests are normalized to lowercase; filenames are kept verbatim (case-sensitive, matching the
+        /// asset names). On a duplicate filename the LAST entry wins. Never throws — a null/empty/garbage
+        /// input yields an empty map. Pure managed; unit-testable with no editor.
+        /// </summary>
+        public static IReadOnlyDictionary<string, string> ParseSha256Sums(string? sha256SumsText)
+        {
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (string.IsNullOrEmpty(sha256SumsText))
+                return map;
+
+            foreach (var rawLine in sha256SumsText!.Replace("\r\n", "\n").Split('\n'))
+            {
+                var line = rawLine.Trim();
+                if (line.Length == 0)
+                    continue;
+
+                // Split into the digest token and the remainder (the filename). The coreutils separator is two
+                // spaces, but we split on the FIRST run of whitespace so a single-space or tab variant still
+                // parses — the digest token is fixed-width 64 hex, the filename is everything after.
+                var sepIndex = -1;
+                for (var i = 0; i < line.Length; i++)
+                {
+                    if (line[i] == ' ' || line[i] == '\t')
+                    {
+                        sepIndex = i;
+                        break;
+                    }
+                }
+                if (sepIndex <= 0 || sepIndex >= line.Length - 1)
+                    continue;
+
+                var digestToken = line.Substring(0, sepIndex);
+                if (!IsHex64(digestToken))
+                    continue;
+
+                var fileName = line.Substring(sepIndex + 1).TrimStart(' ', '\t');
+                // coreutils binary-mode marker: `<hex> *<name>`. Strip a single leading '*'.
+                if (fileName.StartsWith("*", StringComparison.Ordinal))
+                    fileName = fileName.Substring(1);
+                fileName = fileName.Trim();
+                if (fileName.Length == 0)
+                    continue;
+
+                map[fileName] = digestToken.ToLowerInvariant();
+            }
+
+            return map;
+        }
+
+        /// <summary>True when <paramref name="value"/> is exactly 64 ASCII hex characters (a SHA256 hex digest).</summary>
+        static bool IsHex64(string value)
+        {
+            if (value.Length != 64)
+                return false;
+            foreach (var c in value)
+            {
+                var isHex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+                if (!isHex)
+                    return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Look up the expected SHA256 digest for <paramref name="assetZipName"/> (e.g.
+        /// <c>gamedev-mcp-server-win-x64.zip</c>) in a parsed <see cref="ParseSha256Sums"/> map. The lookup is
+        /// EXACT-key Ordinal — <c>linux-x64</c> never cross-matches <c>linux-arm64</c>, <c>win-x64</c> never
+        /// cross-matches <c>win-x86</c> (no substring/prefix match). Returns the lowercase hex digest, or null
+        /// when the manifest has no entry for that asset (the MISSING-entry fail-closed case). Pure managed.
+        /// </summary>
+        public static string? LookupDigest(
+            IReadOnlyDictionary<string, string> parsedSha256Sums,
+            string assetZipName)
+        {
+            if (parsedSha256Sums == null || string.IsNullOrEmpty(assetZipName))
+                return null;
+            return parsedSha256Sums.TryGetValue(assetZipName, out var digest) ? digest : null;
+        }
+
+        /// <summary>
+        /// Case-insensitive hex-digest equality (both sides trimmed). A null/empty/whitespace digest on either
+        /// side is NEVER a match (fail-closed: an unknown digest must not pass). Pure managed.
+        /// </summary>
+        public static bool DigestMatches(string? expectedHexDigest, string? actualHexDigest)
+        {
+            if (string.IsNullOrWhiteSpace(expectedHexDigest) || string.IsNullOrWhiteSpace(actualHexDigest))
+                return false;
+            return string.Equals(expectedHexDigest!.Trim(), actualHexDigest!.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// The verdict of verifying a downloaded zip against a release <c>SHA256SUMS</c> manifest.
+        /// </summary>
+        public enum ChecksumVerdict
+        {
+            /// <summary>The manifest parsed, contained this asset's entry, and the digest matched. SAFE to extract/execute.</summary>
+            Verified,
+
+            /// <summary>The manifest text was missing/empty/unparsable (no usable entries). Fail-closed.</summary>
+            ManifestUnparsable,
+
+            /// <summary>The manifest parsed but had no line for this asset's zip name. Fail-closed.</summary>
+            MissingEntry,
+
+            /// <summary>The manifest's entry for this asset did NOT match the downloaded zip's digest. Fail-closed.</summary>
+            DigestMismatch
+        }
+
+        /// <summary>
+        /// The single fail-closed integrity decision the editor manager calls BEFORE
+        /// <c>ZipFile.ExtractToDirectory</c> / <c>Process.Start</c>: parse the release's <c>SHA256SUMS</c>,
+        /// find the entry for <paramref name="assetZipName"/>, and compare it (case-insensitive hex) against
+        /// the locally-computed SHA256 of the downloaded zip (<paramref name="actualZipHexDigest"/>). Returns
+        /// <see cref="ChecksumVerdict.Verified"/> ONLY when the manifest parsed, contained the asset, and the
+        /// digest matched; every other outcome is a distinct fail-closed verdict the caller MUST treat as
+        /// "do NOT extract, do NOT launch". Keeping this here (not inline in the editor manager) makes the
+        /// entire decision unit-testable with no editor and no real download. Never throws.
+        /// </summary>
+        /// <param name="sha256SumsText">The raw downloaded <c>SHA256SUMS</c> manifest text.</param>
+        /// <param name="assetZipName">This RID's zip name, e.g. <c>gamedev-mcp-server-win-x64.zip</c>.</param>
+        /// <param name="actualZipHexDigest">The SHA256 of the downloaded zip, as lowercase/any-case hex.</param>
+        public static ChecksumVerdict VerifyZipChecksum(string? sha256SumsText, string assetZipName, string? actualZipHexDigest)
+        {
+            var parsed = ParseSha256Sums(sha256SumsText);
+            if (parsed.Count == 0)
+                return ChecksumVerdict.ManifestUnparsable;
+
+            var expected = LookupDigest(parsed, assetZipName);
+            if (expected == null)
+                return ChecksumVerdict.MissingEntry;
+
+            return DigestMatches(expected, actualZipHexDigest)
+                ? ChecksumVerdict.Verified
+                : ChecksumVerdict.DigestMismatch;
+        }
+
+        /// <summary>
+        /// A short, actionable human-readable reason for a non-<see cref="ChecksumVerdict.Verified"/> verdict,
+        /// for the editor manager's fail-closed log line. Pure string transform.
+        /// </summary>
+        public static string ChecksumFailureReason(ChecksumVerdict verdict, string assetZipName) => verdict switch
+        {
+            ChecksumVerdict.ManifestUnparsable =>
+                $"the downloaded {Sha256SumsAssetName} manifest was empty or unparsable",
+            ChecksumVerdict.MissingEntry =>
+                $"the {Sha256SumsAssetName} manifest has no entry for '{assetZipName}'",
+            ChecksumVerdict.DigestMismatch =>
+                $"the downloaded '{assetZipName}' SHA256 did not match the {Sha256SumsAssetName} manifest entry",
+            _ => "the checksum was verified"
+        };
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerChecksum.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerChecksum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aea964dce8104190886598d228205f2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -14,7 +14,9 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -193,11 +195,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         }
 
         /// <summary>
+        /// The release-asset zip NAME for the current platform: <c>gamedev-mcp-server-&lt;rid&gt;.zip</c>
+        /// (e.g. <c>gamedev-mcp-server-win-x64.zip</c>). This is the exact key looked up in the release's
+        /// <c>SHA256SUMS</c> integrity manifest (exact-key Ordinal — see <see cref="McpServerChecksum"/>), and
+        /// the trailing segment of <see cref="ExecutableZipUrl"/> — so the verified asset name can never drift
+        /// from the downloaded asset name.
+        /// </summary>
+        public static string ExecutableZipName
+            => $"{ExecutableName.ToLowerInvariant()}-{PlatformName}.zip";
+
+        /// <summary>
         /// The download URL of the shared GameDev-MCP-Server release zip for the current platform,
         /// pinned by <see cref="ServerVersion"/> — NEVER the plugin version (the two diverge).
         /// </summary>
         public static string ExecutableZipUrl
-            => $"https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/{ServerReleaseTag(ServerVersion)}/{ExecutableName.ToLowerInvariant()}-{PlatformName}.zip";
+            => $"https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/{ServerReleaseTag(ServerVersion)}/{ExecutableZipName}";
 
         #endregion // Binary Metadata
 
@@ -344,6 +356,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                     await client.DownloadFileTaskAsync(ExecutableZipUrl, archiveFilePath);
                 }
 
+                // FAIL-CLOSED INTEGRITY GATE (verify-before-execute). The zip is on disk but UNTRUSTED. Before
+                // extracting or launching it, download the release's SHA256SUMS manifest (sibling of the zip URL
+                // under the same v<ServerVersion> tag), compute the downloaded zip's SHA256 (pure BCL), and
+                // compare against the manifest entry for THIS RID. On MISMATCH / MISSING entry / unparsable-or-
+                // unfetchable manifest we delete the temp zip and return WITHOUT extracting or launching — an
+                // unverified binary must NEVER be executed (a compromised release asset or a trusted-CA MITM
+                // would otherwise yield arbitrary code execution; issue #841).
+                if (!await VerifyDownloadedArchive(archiveFilePath, ServerVersion, ExecutableZipName))
+                {
+                    try { File.Delete(archiveFilePath); } catch { /* best effort */ }
+                    return false;
+                }
+
                 // Unpack zip archive.
                 // The shared GameDev-MCP-Server release zips are NOT layout-uniform: the win zips are
                 // FLAT (gamedev-mcp-server.exe + its sidecar files at the zip root) while the osx/linux
@@ -464,6 +489,116 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 }
             }
             return best;
+        }
+
+        /// <summary>
+        /// The number of attempts for the SHA256SUMS manifest fetch (1 initial + retries) before we
+        /// fail-closed. A TRANSIENT network error on the manifest fetch is retried (the binary is already
+        /// downloaded; only the integrity manifest is missing) — but a persistent failure NEVER falls through
+        /// to executing an unverified binary.
+        /// </summary>
+        const int Sha256SumsFetchAttempts = 3;
+
+        /// <summary>Backoff between SHA256SUMS fetch attempts.</summary>
+        static readonly TimeSpan Sha256SumsRetryDelay = TimeSpan.FromSeconds(1.0);
+
+        /// <summary>
+        /// Fail-closed verify-before-execute gate. Downloads the release's <c>SHA256SUMS</c> manifest (with a
+        /// bounded transient-retry), computes the downloaded zip's SHA256 (pure BCL — the same
+        /// <c>SHA256.Create().ComputeHash</c> idiom the plugin already uses in <c>UnityMcpPlugin</c>, so it is
+        /// .NET-Standard-2.1-safe on the Unity 2022.3 floor; no new deps), and compares against the manifest
+        /// entry for <paramref name="assetZipName"/> via the pure-managed
+        /// <see cref="McpServerChecksum.VerifyZipChecksum"/>. Returns true ONLY when the digest matched the
+        /// manifest. Every failure path — a manifest we could not fetch after all retries, an unparsable
+        /// manifest, a missing entry, or a digest mismatch — returns false with a clear, actionable error so
+        /// the caller skips extraction/launch. Never throws.
+        /// </summary>
+        static async Task<bool> VerifyDownloadedArchive(string archiveFilePath, string serverVersion, string assetZipName)
+        {
+            var sumsUrl = McpServerChecksum.Sha256SumsUrl(serverVersion);
+
+            // 1) Fetch the integrity manifest (bounded transient-retry). A null result means every attempt
+            //    failed — fail-closed (do NOT execute an unverified binary).
+            var sha256SumsText = await FetchSha256SumsText(sumsUrl);
+            if (sha256SumsText == null)
+            {
+                UnityEngine.Debug.LogError(
+                    $"Refusing to launch MCP server: could not download the {McpServerChecksum.Sha256SumsAssetName} " +
+                    $"integrity manifest from {sumsUrl} after {Sha256SumsFetchAttempts} attempt(s). " +
+                    "The downloaded binary was NOT verified and will not be executed (fail-closed).");
+                return false;
+            }
+
+            // 2) Compute the downloaded zip's SHA256 (pure BCL; .NET-Standard-2.1-safe on the Unity 2022.3
+            //    floor — SHA256.HashDataAsync / Convert.ToHexString are .NET 5+ and would not compile there).
+            string actualHexDigest;
+            try
+            {
+                byte[] hashBytes;
+                using (var sha256 = SHA256.Create())
+                using (var zipStream = File.OpenRead(archiveFilePath))
+                {
+                    hashBytes = sha256.ComputeHash(zipStream);
+                }
+                actualHexDigest = BitConverter.ToString(hashBytes).Replace("-", string.Empty); // upper-case hex; compare is case-insensitive
+            }
+            catch (Exception ex)
+            {
+                UnityEngine.Debug.LogError(
+                    $"Refusing to launch MCP server: failed to compute the downloaded zip's SHA256: {ex.Message}");
+                return false;
+            }
+
+            // 3) Parse + compare via the pure-managed verifier (unit-tested with no editor).
+            var verdict = McpServerChecksum.VerifyZipChecksum(sha256SumsText, assetZipName, actualHexDigest);
+            if (verdict != McpServerChecksum.ChecksumVerdict.Verified)
+            {
+                UnityEngine.Debug.LogError(
+                    $"Refusing to launch MCP server: {McpServerChecksum.ChecksumFailureReason(verdict, assetZipName)}. " +
+                    "The binary will not be extracted or executed (fail-closed).");
+                return false;
+            }
+
+            UnityEngine.Debug.Log(
+                $"Verified '{assetZipName}' against {McpServerChecksum.Sha256SumsAssetName} (SHA256 OK).");
+            return true;
+        }
+
+        /// <summary>
+        /// Download the <c>SHA256SUMS</c> manifest text with a bounded transient-retry. Returns the manifest
+        /// body, or null when every attempt failed (the fail-closed signal). The manifest is small text — read
+        /// it fully into a string. Never throws.
+        /// </summary>
+        static async Task<string?> FetchSha256SumsText(string sumsUrl)
+        {
+            for (var attempt = 1; attempt <= Sha256SumsFetchAttempts; attempt++)
+            {
+                try
+                {
+                    using var client = new HttpClient();
+                    using var response = await client.GetAsync(sumsUrl);
+                    response.EnsureSuccessStatusCode();
+                    return await response.Content.ReadAsStringAsync();
+                }
+                catch (Exception ex)
+                {
+                    if (attempt < Sha256SumsFetchAttempts)
+                    {
+                        UnityEngine.Debug.LogWarning(
+                            $"{McpServerChecksum.Sha256SumsAssetName} fetch attempt {attempt}/{Sha256SumsFetchAttempts} " +
+                            $"failed ({ex.Message}); retrying…");
+                        try { await Task.Delay(Sha256SumsRetryDelay); } catch { /* ignore */ }
+                    }
+                    else
+                    {
+                        UnityEngine.Debug.LogWarning(
+                            $"{McpServerChecksum.Sha256SumsAssetName} fetch attempt {attempt}/{Sha256SumsFetchAttempts} " +
+                            $"failed ({ex.Message}).");
+                    }
+                }
+            }
+
+            return null;
         }
 
         #endregion // Binary Lifecycle

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerChecksumTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerChecksumTests.cs
@@ -1,0 +1,271 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Pins the pure-managed, fail-closed download-integrity logic (<see cref="McpServerChecksum"/>'s
+    /// SHA256SUMS URL builder, coreutils-format parser, exact-key RID digest lookup/compare, and the single
+    /// <see cref="McpServerChecksum.VerifyZipChecksum"/> verdict) that the editor manager
+    /// (<see cref="McpServerManager"/>.<c>DownloadAndUnpackBinary</c>) calls BEFORE
+    /// <c>ZipFile.ExtractToDirectory</c> / <c>Process.Start</c> — so a downloaded server zip is NEVER extracted
+    /// or launched unless its SHA256 matches the release's published <c>SHA256SUMS</c> manifest (issue #841).
+    /// Every assertion is a deterministic string/enum/dictionary transform with NO running editor and NO real
+    /// download. The HTTP fetch + SHA256 compute + file IO that surround this verdict live in the editor-only
+    /// manager. Mirrors Godot-MCP's GodotMcpServerChecksumTests (Godot leg = PR #193).
+    ///
+    /// <para>
+    /// The <see cref="LiveV8Sha256Sums"/> fixture is the VERBATIM content of the real <c>v8.0.0</c> release
+    /// manifest (the version this plugin pins) at
+    /// https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS — so the parser is
+    /// proven against the exact two-space coreutils format that production will see, and the win-x64 digest is
+    /// the real one (operator-confirmable: <c>gh release download v8.0.0 --pattern gamedev-mcp-server-win-x64.zip</c>
+    /// then <c>sha256sum</c> equals <see cref="LiveWinX64Digest"/>). Updating the pinned
+    /// <see cref="McpServerManager.ServerVersion"/> in future does not invalidate these tests: they assert the
+    /// FORMAT contract, not a moving digest.
+    /// </para>
+    /// </summary>
+    public class McpServerChecksumTests
+    {
+        /// <summary>
+        /// The verbatim live <c>SHA256SUMS</c> from the GameDev-MCP-Server <c>v8.0.0</c> release — standard
+        /// coreutils output: <c>&lt;64-lowercase-hex&gt;␠␠&lt;filename&gt;</c>, one line per RID zip, LF-terminated.
+        /// All 7 published RIDs are present.
+        /// </summary>
+        const string LiveV8Sha256Sums =
+            "5f17508e92812fbf9522eb552641d21dc2383fc2f6cf371f5413ad06c9820282  gamedev-mcp-server-linux-arm64.zip\n" +
+            "844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319  gamedev-mcp-server-linux-x64.zip\n" +
+            "ad0f50042dfa1edde26a9f26968538146ba792cc0188a47f6bfc1ae573bb513e  gamedev-mcp-server-osx-arm64.zip\n" +
+            "d25993216e610401c8925716d9ad0f8ecaf3dc93443b12cfd057a75495ef9952  gamedev-mcp-server-osx-x64.zip\n" +
+            "702f1d708c25dde6a58d3335c7adb92aa5fe36be618003821ceb040a9b59c51b  gamedev-mcp-server-win-arm64.zip\n" +
+            "7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb  gamedev-mcp-server-win-x64.zip\n" +
+            "b171e1d8318d0ce4e88d30a5e86ad1cac1acea946ef1a71cd410a27f917c9799  gamedev-mcp-server-win-x86.zip\n";
+
+        /// <summary>The real win-x64 digest from the live v8.0.0 manifest (verbatim).</summary>
+        const string LiveWinX64Digest = "7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb";
+
+        const string WinX64Asset = "gamedev-mcp-server-win-x64.zip";
+
+        // --- SHA256SUMS URL builder (sibling of the zip URL, same v-tag) ---
+
+        [Test]
+        public void Sha256SumsUrl_IsSiblingOfZipUrlUnderSameVTag()
+        {
+            // The manifest MUST live under the same v<version> release tag as the zip, with the fixed
+            // `SHA256SUMS` asset name — so the integrity manifest can never drift from the binary it covers.
+            var sumsUrl = McpServerChecksum.Sha256SumsUrl("8.0.0");
+            Assert.AreEqual(
+                "https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS",
+                sumsUrl);
+        }
+
+        [Test]
+        public void Sha256SumsUrl_DefaultOverload_PinsServerVersion()
+        {
+            var sumsUrl = McpServerChecksum.Sha256SumsUrl();
+            Assert.AreEqual(McpServerChecksum.Sha256SumsUrl(McpServerManager.ServerVersion), sumsUrl);
+            StringAssert.Contains($"/releases/download/v{McpServerManager.ServerVersion}/SHA256SUMS", sumsUrl);
+        }
+
+        [Test]
+        public void Sha256SumsUrl_PrePrefixedVersion_NotDoublePrefixed()
+        {
+            Assert.AreEqual(
+                "https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v8.0.0/SHA256SUMS",
+                McpServerChecksum.Sha256SumsUrl("v8.0.0"));
+        }
+
+        [Test]
+        public void Sha256SumsUrl_SharesReleaseDirectoryWithZipUrl()
+        {
+            // The manifest URL shares the release-download directory prefix with the per-RID zip URL — so a
+            // verified manifest can never be fetched from a different release than the downloaded zip.
+            var sumsUrl = McpServerChecksum.Sha256SumsUrl(McpServerManager.ServerVersion);
+            var zipUrl = McpServerManager.ExecutableZipUrl;
+            var zipDir = zipUrl.Substring(0, zipUrl.LastIndexOf('/') + 1);
+            StringAssert.StartsWith(zipDir, sumsUrl);
+        }
+
+        // --- Parser: the exact two-space coreutils line format ---
+
+        [Test]
+        public void ParseSha256Sums_LiveManifest_ParsesAllSevenEntriesWithLowercaseDigests()
+        {
+            var map = McpServerChecksum.ParseSha256Sums(LiveV8Sha256Sums);
+
+            Assert.AreEqual(7, map.Count);
+            // The RIGHT RID is selected among the 7 — win-x64 maps to ITS digest, not a neighbour's.
+            Assert.AreEqual(LiveWinX64Digest, map[WinX64Asset]);
+            Assert.AreEqual("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319",
+                map["gamedev-mcp-server-linux-x64.zip"]);
+            Assert.AreEqual("b171e1d8318d0ce4e88d30a5e86ad1cac1acea946ef1a71cd410a27f917c9799",
+                map["gamedev-mcp-server-win-x86.zip"]);
+            // Every value is a 64-char lowercase hex digest.
+            foreach (var digest in map.Values)
+            {
+                Assert.AreEqual(64, digest.Length);
+                Assert.AreEqual(digest.ToLowerInvariant(), digest);
+            }
+        }
+
+        [Test]
+        public void ParseSha256Sums_TolerantOfCrlfAndBlankLinesAndUppercaseHex()
+        {
+            const string text =
+                "\r\n" +
+                "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789  gamedev-mcp-server-win-x64.zip\r\n" +
+                "\r\n";
+            var map = McpServerChecksum.ParseSha256Sums(text);
+            Assert.AreEqual(1, map.Count);
+            // Digest normalized to lowercase.
+            Assert.AreEqual("abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+                map[WinX64Asset]);
+        }
+
+        [Test]
+        public void ParseSha256Sums_StripsBinaryModeStarMarker()
+        {
+            // coreutils binary mode emits `<hex> *<name>`; the '*' is not part of the filename.
+            const string text =
+                "7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb *gamedev-mcp-server-win-x64.zip\n";
+            var map = McpServerChecksum.ParseSha256Sums(text);
+            Assert.IsTrue(map.ContainsKey(WinX64Asset));
+            Assert.AreEqual(LiveWinX64Digest, map[WinX64Asset]);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   \n  \n")]                                              // only whitespace
+        [TestCase("not-a-digest  gamedev-mcp-server-win-x64.zip\n")]        // first token isn't 64-hex
+        [TestCase("7383638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d065681\n")] // hex too short, no filename
+        [TestCase("zzz3638dbc1cad84cf3b85617405c29c7885a51e34b1ef7b8b8864d0656814cb  x.zip\n")] // non-hex chars
+        public void ParseSha256Sums_MalformedOrEmpty_YieldsNoUsableEntry(string? text)
+        {
+            var map = McpServerChecksum.ParseSha256Sums(text);
+            Assert.AreEqual(0, map.Count);
+        }
+
+        // --- Lookup + compare (exact-key RID, no cross-match) ---
+
+        [Test]
+        public void LookupDigest_ReturnsEntryForRid_NullWhenMissing()
+        {
+            var map = McpServerChecksum.ParseSha256Sums(LiveV8Sha256Sums);
+            Assert.AreEqual(LiveWinX64Digest, McpServerChecksum.LookupDigest(map, WinX64Asset));
+            Assert.IsNull(McpServerChecksum.LookupDigest(map, "gamedev-mcp-server-freebsd-x64.zip"));
+        }
+
+        [Test]
+        public void LookupDigest_ExactKey_DoesNotCrossMatchSiblingRids()
+        {
+            // linux-x64 must NOT cross-match linux-arm64; win-x64 must NOT cross-match win-x86. Each RID's
+            // digest is distinct, so a substring/prefix match would surface the wrong digest — the exact-key
+            // Ordinal lookup is what keeps a win-x86 zip from being "verified" against the win-x64 digest.
+            var map = McpServerChecksum.ParseSha256Sums(LiveV8Sha256Sums);
+
+            Assert.AreEqual("844d4ad8cd152df44287341235ca2ae67cdb69b496252678eb6491f0bdc53319",
+                McpServerChecksum.LookupDigest(map, "gamedev-mcp-server-linux-x64.zip"));
+            Assert.AreEqual("5f17508e92812fbf9522eb552641d21dc2383fc2f6cf371f5413ad06c9820282",
+                McpServerChecksum.LookupDigest(map, "gamedev-mcp-server-linux-arm64.zip"));
+            Assert.AreNotEqual(
+                McpServerChecksum.LookupDigest(map, "gamedev-mcp-server-win-x64.zip"),
+                McpServerChecksum.LookupDigest(map, "gamedev-mcp-server-win-x86.zip"));
+        }
+
+        [Test]
+        public void DigestMatches_IsCaseInsensitive_AndFailsClosedOnNullOrEmpty()
+        {
+            Assert.IsTrue(McpServerChecksum.DigestMatches(LiveWinX64Digest, LiveWinX64Digest.ToUpperInvariant()));
+            Assert.IsTrue(McpServerChecksum.DigestMatches("  " + LiveWinX64Digest + "  ", LiveWinX64Digest));
+            Assert.IsFalse(McpServerChecksum.DigestMatches(LiveWinX64Digest, null));
+            Assert.IsFalse(McpServerChecksum.DigestMatches(null, LiveWinX64Digest));
+            Assert.IsFalse(McpServerChecksum.DigestMatches("", ""));
+            Assert.IsFalse(McpServerChecksum.DigestMatches(LiveWinX64Digest, "deadbeef"));
+        }
+
+        // --- The single fail-closed verdict (what the editor manager calls) ---
+
+        [Test]
+        public void VerifyZipChecksum_RealPair_IsVerified()
+        {
+            // The real win-x64 digest against the real live manifest → SAFE to extract/execute. This is the
+            // exact pair production sees.
+            var verdict = McpServerChecksum.VerifyZipChecksum(LiveV8Sha256Sums, WinX64Asset, LiveWinX64Digest);
+            Assert.AreEqual(McpServerChecksum.ChecksumVerdict.Verified, verdict);
+        }
+
+        [Test]
+        public void VerifyZipChecksum_RealPair_VerifiedWithUppercaseComputedDigest()
+        {
+            // The editor manager computes the digest via BitConverter.ToString(...).Replace("-", "") which
+            // emits UPPER-case hex; the verdict must accept it (case-insensitive compare).
+            var verdict = McpServerChecksum.VerifyZipChecksum(
+                LiveV8Sha256Sums, WinX64Asset, LiveWinX64Digest.ToUpperInvariant());
+            Assert.AreEqual(McpServerChecksum.ChecksumVerdict.Verified, verdict);
+        }
+
+        [Test]
+        public void VerifyZipChecksum_TamperedDigest_IsRejected()
+        {
+            // A tampered/compromised zip whose SHA256 differs by a single nibble must be REJECTED (fail-closed).
+            var tampered = "0" + LiveWinX64Digest.Substring(1);
+            var verdict = McpServerChecksum.VerifyZipChecksum(LiveV8Sha256Sums, WinX64Asset, tampered);
+            Assert.AreEqual(McpServerChecksum.ChecksumVerdict.DigestMismatch, verdict);
+        }
+
+        [Test]
+        public void VerifyZipChecksum_MissingEntryForRid_IsRejected()
+        {
+            // The manifest parsed fine but has no line for THIS RID's asset → fail-closed (MissingEntry).
+            var verdict = McpServerChecksum.VerifyZipChecksum(
+                LiveV8Sha256Sums, "gamedev-mcp-server-freebsd-x64.zip", LiveWinX64Digest);
+            Assert.AreEqual(McpServerChecksum.ChecksumVerdict.MissingEntry, verdict);
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("garbage with no valid sha lines\n")]
+        public void VerifyZipChecksum_UnparsableManifest_IsRejected(string? manifest)
+        {
+            // An empty/unparsable manifest must NEVER pass (do not execute an unverified binary).
+            var verdict = McpServerChecksum.VerifyZipChecksum(manifest, WinX64Asset, LiveWinX64Digest);
+            Assert.AreEqual(McpServerChecksum.ChecksumVerdict.ManifestUnparsable, verdict);
+        }
+
+        [Test]
+        public void ChecksumFailureReason_NamesTheActionableCause()
+        {
+            // The editor fail-closed log line must be actionable: it names the manifest, the asset, and the cause.
+            StringAssert.Contains(WinX64Asset,
+                McpServerChecksum.ChecksumFailureReason(McpServerChecksum.ChecksumVerdict.DigestMismatch, WinX64Asset));
+            StringAssert.Contains(WinX64Asset,
+                McpServerChecksum.ChecksumFailureReason(McpServerChecksum.ChecksumVerdict.MissingEntry, WinX64Asset));
+            StringAssert.Contains("SHA256SUMS",
+                McpServerChecksum.ChecksumFailureReason(McpServerChecksum.ChecksumVerdict.ManifestUnparsable, WinX64Asset));
+        }
+
+        // --- The asset-name builder the manager passes to the verifier ---
+
+        [Test]
+        public void ExecutableZipName_IsTrailingSegmentOfZipUrl()
+        {
+            // The verified asset name MUST be the exact key looked up in SHA256SUMS, and the same trailing
+            // segment as the downloaded zip URL — so the verified name can never drift from the downloaded name.
+            var zipUrl = McpServerManager.ExecutableZipUrl;
+            var trailing = zipUrl.Substring(zipUrl.LastIndexOf('/') + 1);
+            Assert.AreEqual(trailing, McpServerManager.ExecutableZipName);
+            StringAssert.StartsWith("gamedev-mcp-server-", McpServerManager.ExecutableZipName);
+            StringAssert.EndsWith(".zip", McpServerManager.ExecutableZipName);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerChecksumTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerChecksumTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b1f8ee0416b47b3a7974a389b71b772
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Add a fail-closed **verify-before-execute** integrity gate in `McpServerManager.DownloadAndUnpackBinary`: after the `gamedev-mcp-server-<rid>.zip` download and **before** `ZipFile.ExtractToDirectory` / `Process.Start`, download the release's `SHA256SUMS` manifest (sibling of `ExecutableZipUrl` under the same `v<ServerVersion>` tag, with a bounded 3-attempt transient retry), compute the downloaded zip's SHA256 (pure BCL `SHA256.Create().ComputeHash` + `BitConverter` — the same .NET-Standard-2.1-safe idiom `UnityMcpPlugin` already uses; no new deps), and compare against the manifest entry for THIS RID. On MISMATCH / MISSING entry / unparsable-or-unfetchable manifest: delete the temp zip, do NOT extract, do NOT launch (fail-closed).
- New pure-managed `McpServerChecksum` helper (no UnityEngine/UnityEditor API) holds the `SHA256SUMS` URL builder, coreutils-format parser, **exact-key Ordinal** RID lookup (linux-x64 never cross-matches linux-arm64; win-x64 vs win-x86), case-insensitive digest compare, and a single `VerifyZipChecksum` verdict — so the whole decision is CI-unit-testable with no running editor and no real download.
- `ServerVersion` stays `8.0.0`; no dependency bumps. Mirrors the Godot leg (Godot-MCP #193).

## Test plan

- [x] Target-specific local tests passed (Unity EditMode, see profile `test.md`). The new `McpServerChecksumTests` class — 25 cases — passes against the VERBATIM live `v8.0.0` `SHA256SUMS`: valid digest passes, tampered rejected, missing-entry rejected, malformed/empty manifest rejected, the two-space coreutils format parses (incl. CRLF / uppercase-hex / binary-mode `*` marker tolerance), and the correct RID is selected among the 7 (no cross-match).
- The only 2 local EditMode failures (`DevControlEnvTests.IsEnabled_FalseWhenFlagMissingOrNotOne`, `ResolvePort_FallsBackToDefault_OnUnsetOrInvalid`) are a pre-existing test-isolation issue triggered by the worktree's `.worktree.env` injecting `UNITY_MCP_DEV_CONTROL=1` / `UNITY_MCP_DEV_CONTROL_PORT=5138` into the editor process env; they are unrelated to this diff and do not fire on CI (no `.worktree.env` there).

Closes #841