### PR TITLE
fix: download server binary atomically + recover from missing/failed download (#845)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -44,7 +44,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         Starting,
         Running,
         Stopping,
-        External
+        External,
+        // The server binary is being downloaded/unpacked (issue #845). Distinct from Starting so the UI
+        // can show an honest "Downloading server…" state instead of a misleading "Starting…" while the
+        // process has not been launched yet.
+        Downloading
     }
 
     /// <summary>
@@ -59,14 +63,31 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         static readonly ILogger _logger = UnityLoggerFactory.LoggerFactory.CreateLogger(typeof(McpServerManager));
         static readonly ReactiveProperty<McpServerStatus> _serverStatus = new(McpServerStatus.Stopped);
+        // Last server-binary download/extract/checksum failure reason, or null when there is no outstanding
+        // failure. The editor window observes this to surface the error + a "Download / Retry server" button
+        // (issue #845). Cleared at the start of every download attempt and on a confirmed-current binary.
+        static readonly ReactiveProperty<string?> _lastDownloadError = new(null);
         static readonly object _processMutex = new();
 
         static Process? _serverProcess;
 
         public static ReadOnlyReactiveProperty<McpServerStatus> ServerStatus => _serverStatus;
 
+        /// <summary>
+        /// Last server-binary download failure reason (null when none). The AI Game Developer window
+        /// subscribes to surface the failure + a retry button instead of silently dead-ending (issue #845).
+        /// </summary>
+        public static ReadOnlyReactiveProperty<string?> LastDownloadError => _lastDownloadError;
+
         public static bool IsRunning => _serverStatus.CurrentValue == McpServerStatus.Running;
         public static bool IsStarting => _serverStatus.CurrentValue == McpServerStatus.Starting;
+
+        /// <summary>
+        /// True when a verified, version-matching server binary is present on disk and can be launched
+        /// without a download. The Start path (<c>HandleServerButton</c>) uses this to decide whether to
+        /// recover a missing/outdated binary before launching (issue #845).
+        /// </summary>
+        public static bool IsBinaryReadyToStart() => IsBinaryExists() && IsVersionMatches();
 
         static McpServerManager()
         {
@@ -76,7 +97,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             // Check if server process is still running (e.g., after domain reload)
             EditorApplication.update += CheckExistingProcess;
 
-            DownloadServerBinaryIfNeeded()
+            DownloadServerBinaryIfNeeded(unattended: true)
                 .ContinueWith(task =>
                 {
                     if (task.IsFaulted || !task.Result)
@@ -242,17 +263,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             return binaryVersion == ServerVersion;
         }
 
-        public static bool DeleteBinaryFolderIfExists()
+        /// <param name="interactive">
+        /// When true (menu / user-initiated paths) a blocking <see cref="EditorUtility.DisplayDialog"/> asks the
+        /// user to retry/skip if the folder can't be deleted (e.g. the server is still holding a file lock).
+        /// When false (the unattended <c>[InitializeOnLoad]</c> / package-update download path) the blocking
+        /// dialog is SKIPPED — after the silent retries the failure is rethrown so the caller surfaces it via the
+        /// non-modal failure popup + retry button instead of freezing editor startup behind a modal (issue #845).
+        /// </param>
+        public static bool DeleteBinaryFolderIfExists(bool interactive = true)
         {
             if (Directory.Exists(ExecutableFolderRootPath))
             {
-                // Intentional infinite loop:
+                // Intentional infinite loop (interactive path only):
                 // - Deletion can fail while the MCP server binaries are in use (e.g., server still running).
                 // - On the first failure, we automatically attempt to stop the server process via McpServerManager.
                 // - The retry/exit behavior is fully controlled by the user via the dialog below.
                 // - We do not impose a fixed maximum retry count so the user can take as long as needed
                 //   to shut down their MCP client and release file locks before trying again.
                 // - The loop terminates when the user selects "Skip", at which point the exception is rethrown.
+                // In the unattended path the blocking dialog is skipped: after the silent retries the exception
+                // is rethrown so the download path fails-loud (non-modal popup) instead of blocking startup.
                 var silentRetries = 0;
                 while (true)
                 {
@@ -295,6 +325,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                             continue;
                         }
 
+                        // Unattended path: never block startup behind a modal — rethrow so the caller
+                        // surfaces the failure via the non-modal popup + retry button (issue #845).
+                        if (!interactive)
+                        {
+                            UnityEngine.Debug.LogError(
+                                $"Failed to delete MCP server folder (unattended): {ex.Message}");
+                            throw;
+                        }
+
                         var retry = EditorUtility.DisplayDialog(
                             title: "Failed to Delete MCP Server Binaries",
                             message: $"The current gamedev-mcp-server binaries can't be deleted. " +
@@ -317,7 +356,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             return false;
         }
 
-        public static Task<bool> DownloadServerBinaryIfNeeded()
+        /// <param name="unattended">
+        /// When true (the <c>[InitializeOnLoad]</c> editor-startup path and the package-update re-check) the
+        /// download runs without any blocking modal and without the result popup — failures are surfaced only
+        /// through <see cref="LastDownloadError"/> (the in-window error + retry button). When false (menu /
+        /// Start button / retry button — user-initiated) the result popup is shown and the delete step may
+        /// prompt interactively. See <see cref="DownloadAndUnpackBinary"/>.
+        /// </param>
+        public static Task<bool> DownloadServerBinaryIfNeeded(bool unattended = false)
         {
             if (EnvironmentUtils.IsCi())
             {
@@ -327,25 +373,47 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             }
 
             if (IsBinaryExists() && IsVersionMatches())
+            {
+                // Binary is present and current — clear any stale failure so the window hides the error/retry UI.
+                _lastDownloadError.Value = null;
                 return Task.FromResult(true);
+            }
 
-            return DownloadAndUnpackBinary();
+            return DownloadAndUnpackBinary(unattended);
         }
 
-        public static async Task<bool> DownloadAndUnpackBinary()
+        /// <summary>
+        /// Downloads, verifies, and ATOMICALLY publishes the pinned GameDev-MCP-Server binary for this RID.
+        ///
+        /// <para>Atomicity (issue #845): the previous flow wiped the cache folder, pre-created an EMPTY
+        /// <c>Library/mcp-server/&lt;rid&gt;/</c>, then downloaded + extracted + wrote the version file LAST — so an
+        /// interrupted run (process kill, crash, cancelled domain reload) left an empty per-RID folder behind,
+        /// which then read as "binary present but version missing" forever while the UI hung on "Starting…".
+        /// This implementation instead extracts into a SAME-VOLUME staging folder, fully prepares the payload
+        /// there (binary + sidecars + exec bit + version marker), and only then performs a single
+        /// <see cref="Directory.Move"/> rename into the per-RID cache folder. The destination folder therefore
+        /// never exists in a partial state: it is either absent (download not finished) or complete. The old
+        /// working binary is left untouched until the replacement is fully staged + verified.</para>
+        /// </summary>
+        /// <param name="unattended">
+        /// When true ([InitializeOnLoad] startup / package-update re-check) no blocking modal and no result
+        /// popup are shown — failures surface only via <see cref="LastDownloadError"/> (the in-window error +
+        /// retry button) so editor startup is never blocked and is not spammed with a popup on every reload.
+        /// When false (menu / Start button / retry button — user-initiated) the result popup is shown on BOTH
+        /// success and EVERY failure branch, and the delete step may prompt interactively.
+        /// </param>
+        public static async Task<bool> DownloadAndUnpackBinary(bool unattended = false)
         {
             UnityEngine.Debug.Log($"Downloading GameDev-MCP-Server binary from: <color=yellow>{ExecutableZipUrl}</color>");
 
+            // Clear any prior failure + reflect the in-progress download in the status machine.
+            _lastDownloadError.Value = null;
+            SetDownloadingStatus();
+
+            string? stagingRoot = null;
             try
             {
                 var previousKeepServerRunning = UnityMcpPluginEditor.KeepServerRunning;
-
-                // Clear existed server folder
-                DeleteBinaryFolderIfExists();
-
-                // Create folder if needed
-                if (!Directory.Exists(ExecutableFolderPath))
-                    Directory.CreateDirectory(ExecutableFolderPath);
 
                 var archiveFilePath = Path.GetFullPath($"{Application.temporaryCachePath}/{ExecutableName.ToLowerInvariant()}-{PlatformName}-{ServerVersion}.zip");
                 UnityEngine.Debug.Log($"Temporary archive file path: <color=yellow>{archiveFilePath}</color>");
@@ -366,106 +434,169 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 if (!await VerifyDownloadedArchive(archiveFilePath, ServerVersion, ExecutableZipName))
                 {
                     try { File.Delete(archiveFilePath); } catch { /* best effort */ }
-                    return false;
+                    return FailDownload(
+                        "Checksum verification failed for the downloaded server binary (see logs).", unattended);
                 }
 
-                // Unpack zip archive.
-                // The shared GameDev-MCP-Server release zips are NOT layout-uniform: the win zips are
-                // FLAT (gamedev-mcp-server.exe + its sidecar files at the zip root) while the osx/linux
-                // zips wrap everything in a <rid>/ folder. Extract to a throwaway staging folder, FIND
-                // the binary wherever it landed, then move its containing folder's files into the
-                // per-platform cache folder — so BOTH layouts (and any future re-arrangement) resolve
-                // correctly. The sidecar files (appsettings.json, NLog.config, server.json, ...) are
-                // LOAD-BEARING and must travel with the binary.
-                UnityEngine.Debug.Log($"Unpacking GameDev-MCP-Server binary to: <color=yellow>{ExecutableFolderPath}</color>");
-                var stagingFolder = Path.GetFullPath($"{Application.temporaryCachePath}/{ExecutableName.ToLowerInvariant()}-extract-{Guid.NewGuid():N}");
-                try
+                // Unpack zip archive into a SAME-VOLUME staging root (a sibling of the cache root, so the final
+                // publish is an atomic rename, never a cross-volume copy that could be interrupted mid-write).
+                // The shared GameDev-MCP-Server release zips are NOT layout-uniform: the win zips are FLAT
+                // (gamedev-mcp-server.exe + its sidecar files at the zip root) while the osx/linux zips wrap
+                // everything in a <rid>/ folder. Extract, FIND the binary wherever it landed, prepare the
+                // payload folder, then atomically Move it into the per-platform cache folder — so BOTH layouts
+                // (and any future re-arrangement) resolve correctly. The sidecar files (appsettings.json,
+                // NLog.config, server.json, ...) are LOAD-BEARING and must travel with the binary.
+                stagingRoot = Path.GetFullPath($"{ExecutableFolderRootPath}-staging-{Guid.NewGuid():N}");
+                var extractFolder = Path.Combine(stagingRoot, "extract");
+                Directory.CreateDirectory(extractFolder);
+                UnityEngine.Debug.Log($"Unpacking GameDev-MCP-Server binary to staging: <color=yellow>{extractFolder}</color>");
+                ZipFile.ExtractToDirectory(archiveFilePath, extractFolder, overwriteFiles: true);
+                try { File.Delete(archiveFilePath); } catch { /* best effort */ }
+
+                var extractedBinary = FindExtractedBinary(extractFolder, ExecutableFullName);
+                if (extractedBinary == null)
                 {
-                    ZipFile.ExtractToDirectory(archiveFilePath, stagingFolder, overwriteFiles: true);
-
-                    var extractedBinary = FindExtractedBinary(stagingFolder, ExecutableFullName);
-                    if (extractedBinary == null)
-                    {
-                        UnityEngine.Debug.LogError($"Failed to unpack server binary: '{ExecutableFullName}' not found inside the downloaded zip.");
-                        return false;
-                    }
-
-                    // Move the binary plus every sidecar file beside it into the cache folder.
-                    var sourceFolder = Path.GetDirectoryName(extractedBinary)!;
-                    foreach (var file in Directory.GetFiles(sourceFolder))
-                    {
-                        var destination = Path.Combine(ExecutableFolderPath, Path.GetFileName(file));
-                        if (File.Exists(destination))
-                            File.Delete(destination);
-                        File.Move(file, destination);
-                    }
+                    return FailDownload(
+                        $"'{ExecutableFullName}' not found inside the downloaded zip.", unattended);
                 }
-                finally
+
+                // The folder that holds the binary + its sidecars is the payload we publish.
+                var payloadFolder = Path.GetDirectoryName(extractedBinary)!;
+
+                // Set executable permission on macOS and Linux BEFORE publishing, so the published payload is
+                // launch-ready the instant it appears under the cache folder.
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    try { Directory.Delete(stagingFolder, recursive: true); } catch { /* best effort */ }
-                    try { File.Delete(archiveFilePath); } catch { /* best effort */ }
+                    UnityEngine.Debug.Log($"Setting executable permission for: <color=green>{extractedBinary}</color>");
+                    UnixUtils.Set0755(extractedBinary);
                 }
+
+                // Write the version marker INTO the staged payload, so the published per-RID folder is complete
+                // the instant it appears — there is no window where the binary exists without its version file.
+                File.WriteAllText(Path.Combine(payloadFolder, "version"), ServerVersion);
+
+                // Stop the running server + remove the OLD cache folder. Only now do we touch the live binary;
+                // everything above operated on staging, so a failure before this point leaves the working copy
+                // intact. Unattended path never blocks behind a modal (see DeleteBinaryFolderIfExists).
+                DeleteBinaryFolderIfExists(interactive: !unattended);
+
+                // Atomic publish: a single same-volume rename of the fully-prepared payload into the per-RID
+                // cache folder. Either it lands complete or not at all.
+                PublishStagedBinary(payloadFolder, ExecutableFolderPath);
 
                 if (!File.Exists(ExecutableFullPath))
                 {
-                    UnityEngine.Debug.LogError($"Failed to unpack server binary to: {ExecutableFolderRootPath}");
-                    UnityEngine.Debug.LogError($"Binary file not found at: {ExecutableFullPath}");
-                    return false;
+                    return FailDownload(
+                        $"Server binary missing after publish at: {ExecutableFullPath}", unattended);
+                }
+
+                var success = IsBinaryExists() && IsVersionMatches();
+                if (!success)
+                {
+                    return FailDownload(
+                        "The published server binary failed the post-publish version check.", unattended);
                 }
 
                 UnityEngine.Debug.Log($"Downloaded and unpacked GameDev-MCP-Server binary to: <color=green>{ExecutableFullPath}</color>");
-
-                // Set executable permission on macOS and Linux
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    UnityEngine.Debug.Log($"Setting executable permission for: <color=green>{ExecutableFullPath}</color>");
-                    UnixUtils.Set0755(ExecutableFullPath);
-                }
-
-                File.WriteAllText(VersionFullPath, ServerVersion);
-
                 UnityEngine.Debug.Log($"MCP server version file created at: <color=green><b>COMPLETED</b></color>");
 
-                var binaryExists = IsBinaryExists();
-                var versionMatches = IsVersionMatches();
-                var success = binaryExists && versionMatches;
-
-                if (success && previousKeepServerRunning)
+                if (previousKeepServerRunning && IsAutoStartAllowedForMode(UnityMcpPluginEditor.ConnectionMode))
                 {
-                    if (IsAutoStartAllowedForMode(UnityMcpPluginEditor.ConnectionMode))
-                    {
-                        if (!StartServer())
-                            UnityEngine.Debug.LogError($"Failed to start MCP server after updating binary. Please try starting the server manually.");
-                    }
-                    else
-                    {
+                    // StartServer() moves the status machine Downloading -> Starting.
+                    if (!StartServer())
+                        UnityEngine.Debug.LogError($"Failed to start MCP server after updating binary. Please try starting the server manually.");
+                }
+                else
+                {
+                    if (previousKeepServerRunning)
                         _logger.LogDebug("DownloadAndUnpackBinary: Cloud mode active, skipping local server auto-start after binary update");
-                    }
+                    ResetDownloadingToStopped();
                 }
 
-                NotificationPopupWindow.Show(
-                    windowTitle: success
-                        ? "Updated"
-                        : "Update Failed",
-                    height: 235,
-                    minHeight: 235,
-                    title: success
-                        ? "Server Binary Updated"
-                        : "Server Binary Update Failed",
-                    message: success
-                        ? "The MCP server binary was successfully downloaded and updated. \n\n" +
-                            $"Version: {GetBinaryVersion()}\n\n" +
-                            "You may need to restart your AI agent to reconnect to the updated server."
-                        : "Failed to download and update the MCP server binary. Please check the logs for details.");
+                if (!unattended)
+                    ShowUpdateResultPopup(success: true);
 
-                return success;
+                return true;
             }
             catch (Exception ex)
             {
                 UnityEngine.Debug.LogException(ex);
-                UnityEngine.Debug.LogError($"Failed to download and unpack server binary: {ex.Message}");
-                return false;
+                return FailDownload($"Failed to download and unpack server binary: {ex.Message}", unattended);
             }
+            finally
+            {
+                if (stagingRoot != null)
+                {
+                    try { if (Directory.Exists(stagingRoot)) Directory.Delete(stagingRoot, recursive: true); }
+                    catch { /* best effort */ }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Records a download failure: logs it, stores the reason in <see cref="LastDownloadError"/> (so the
+        /// window shows the error + retry button), returns the status machine to Stopped, and — for
+        /// user-initiated (non-unattended) calls — shows the "Update Failed" popup. Always returns false so it
+        /// can be used as the single return expression of every failure branch.
+        /// </summary>
+        static bool FailDownload(string reason, bool unattended)
+        {
+            UnityEngine.Debug.LogError($"MCP server binary download failed: {reason}");
+            _lastDownloadError.Value = reason;
+            ResetDownloadingToStopped();
+            if (!unattended)
+                ShowUpdateResultPopup(success: false);
+            return false;
+        }
+
+        /// <summary>Moves the status machine into Downloading from an idle state (Stopped/Downloading only).</summary>
+        static void SetDownloadingStatus()
+        {
+            var current = _serverStatus.CurrentValue;
+            if (current == McpServerStatus.Stopped || current == McpServerStatus.Downloading)
+                _serverStatus.Value = McpServerStatus.Downloading;
+        }
+
+        /// <summary>Returns the status machine to Stopped, but ONLY if it is still Downloading (so it never
+        /// stomps a Starting/Running/Stopping state that a concurrent path may have moved it to).</summary>
+        static void ResetDownloadingToStopped()
+        {
+            if (_serverStatus.CurrentValue == McpServerStatus.Downloading)
+                _serverStatus.Value = McpServerStatus.Stopped;
+        }
+
+        /// <summary>Shows the non-modal server-binary download result popup (success or failure).</summary>
+        static void ShowUpdateResultPopup(bool success)
+        {
+            NotificationPopupWindow.Show(
+                windowTitle: success ? "Updated" : "Update Failed",
+                height: 235,
+                minHeight: 235,
+                title: success ? "Server Binary Updated" : "Server Binary Update Failed",
+                message: success
+                    ? "The MCP server binary was successfully downloaded and updated. \n\n" +
+                        $"Version: {GetBinaryVersion()}\n\n" +
+                        "You may need to restart your AI agent to reconnect to the updated server."
+                    : "Failed to download and update the MCP server binary. Please check the logs for details.");
+        }
+
+        /// <summary>
+        /// Atomically publishes a fully-prepared staged payload folder into <paramref name="destFolder"/> via a
+        /// single same-volume <see cref="Directory.Move"/>. Ensures the destination's parent exists and removes
+        /// any existing destination first (Directory.Move requires the target to not exist). The caller
+        /// guarantees <paramref name="stagedFolder"/> and <paramref name="destFolder"/> share a volume (staging
+        /// is a sibling of the cache root) so the rename is atomic, never a partial cross-volume copy.
+        /// </summary>
+        internal static void PublishStagedBinary(string stagedFolder, string destFolder)
+        {
+            var parent = Path.GetDirectoryName(destFolder);
+            if (!string.IsNullOrEmpty(parent) && !Directory.Exists(parent))
+                Directory.CreateDirectory(parent);
+
+            if (Directory.Exists(destFolder))
+                Directory.Delete(destFolder, recursive: true);
+
+            Directory.Move(stagedFolder, destFolder);
         }
 
         /// <summary>

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -372,6 +372,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 return Task.FromResult(false);
             }
 
+            // Deduplication guard (issue #845): UPM fires MULTIPLE registeredPackages events for a single
+            // package install/update, and ServerBinaryUpdateWatcher's _isRechecking flag resets synchronously
+            // (in its finally) before the fire-and-forget download Task completes. Without this guard, each
+            // event past the flag would start its own DownloadAndUnpackBinary, and the two would race at the
+            // shared archive path (corrupting the zip → checksum failure) and at PublishStagedBinary (one Move
+            // deleting the folder the other just installed). The Downloading status the lifecycle machine
+            // already tracks is the real idempotency guard: if a download is in flight, let it complete.
+            if (_serverStatus.CurrentValue == McpServerStatus.Downloading)
+                return Task.FromResult(true); // download already in progress; let it complete
+
             if (IsBinaryExists() && IsVersionMatches())
             {
                 // Binary is present and current — clear any stale failure so the window hides the error/retry UI.
@@ -411,11 +421,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             SetDownloadingStatus();
 
             string? stagingRoot = null;
+            string? archiveFilePath = null;
             try
             {
                 var previousKeepServerRunning = UnityMcpPluginEditor.KeepServerRunning;
 
-                var archiveFilePath = Path.GetFullPath($"{Application.temporaryCachePath}/{ExecutableName.ToLowerInvariant()}-{PlatformName}-{ServerVersion}.zip");
+                archiveFilePath = Path.GetFullPath($"{Application.temporaryCachePath}/{ExecutableName.ToLowerInvariant()}-{PlatformName}-{ServerVersion}.zip");
                 UnityEngine.Debug.Log($"Temporary archive file path: <color=yellow>{archiveFilePath}</color>");
 
                 // Download the zip file from the GitHub release notes
@@ -528,6 +539,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 if (stagingRoot != null)
                 {
                     try { if (Directory.Exists(stagingRoot)) Directory.Delete(stagingRoot, recursive: true); }
+                    catch { /* best effort */ }
+                }
+                // Clean up the downloaded temp zip on EVERY exit path. The inline File.Delete calls above
+                // free it on the happy/checksum-fail paths, but if ZipFile.ExtractToDirectory (or the download
+                // itself) throws, neither runs and the zip would leak in Application.temporaryCachePath. The
+                // File.Exists guard makes this a no-op when the inline delete already removed it.
+                if (archiveFilePath != null)
+                {
+                    try { if (File.Exists(archiveFilePath)) File.Delete(archiveFilePath); }
                     catch { /* best effort */ }
                 }
             }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -513,9 +513,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
                 if (previousKeepServerRunning && IsAutoStartAllowedForMode(UnityMcpPluginEditor.ConnectionMode))
                 {
-                    // StartServer() moves the status machine Downloading -> Starting.
+                    // StartServer() moves the status machine Downloading -> Starting. If it early-returns false
+                    // on its !IsBinaryExists() path it never wrote Starting, so the status is still Downloading
+                    // — reset it to Stopped (no-op for the Running/Starting/Stopping early-return) so the UI does
+                    // not hang on "Downloading server…" with the Start button permanently disabled (issue #845).
                     if (!StartServer())
+                    {
                         UnityEngine.Debug.LogError($"Failed to start MCP server after updating binary. Please try starting the server manually.");
+                        ResetDownloadingToStopped();
+                    }
                 }
                 else
                 {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/ServerBinaryUpdateWatcher.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/ServerBinaryUpdateWatcher.cs
@@ -1,0 +1,132 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEngine;
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
+using PackageManagerEvents = UnityEditor.PackageManager.Events;
+
+namespace com.IvanMurzak.Unity.MCP.Editor
+{
+    /// <summary>
+    /// Re-checks (and, if needed, re-downloads) the pinned GameDev-MCP-Server binary whenever the Unity-MCP
+    /// UPM package itself is added/updated — issue #845: "re-download/version-check on package update".
+    ///
+    /// <para>Why a dedicated <c>registeredPackages</c> watcher in addition to
+    /// <see cref="McpServerManager"/>'s own <c>[InitializeOnLoad]</c> check: the server-version pin
+    /// (<see cref="McpServerManager.ServerVersion"/>) is bumped IN this package's code, so updating the package
+    /// can change which server release should be on disk. <c>PackageManager.Events.registeredPackages</c> fires
+    /// from the still-alive previous AppDomain right after UPM writes the new package files — i.e. BEFORE the
+    /// recompile/domain reload that would re-run the manager's static constructor — so the binary re-check is
+    /// triggered promptly on a package upgrade even when the subsequent reload is delayed or blocked. The
+    /// underlying <see cref="McpServerManager.DownloadServerBinaryIfNeeded"/> is a no-op when the cached binary
+    /// already matches the pin, so this watcher is safe to fire on any package change. Mirrors the
+    /// subscription pattern in <c>NuGetDependencyResolver</c> (see Unity-MCP#707).</para>
+    /// </summary>
+    [InitializeOnLoad]
+    static class ServerBinaryUpdateWatcher
+    {
+        const string Tag = "[Unity-MCP ServerBinaryUpdateWatcher]";
+
+        /// <summary>The UPM package id whose version bumps may change the pinned server release.</summary>
+        internal const string UnityMcpPackageName = "com.ivanmurzak.unity.mcp";
+
+        /// <summary>
+        /// Guards against the multiple <c>registeredPackages</c> events UPM can fire for a single user action
+        /// kicking off overlapping re-checks.
+        /// </summary>
+        static bool _isRechecking;
+
+        static ServerBinaryUpdateWatcher()
+        {
+            // -= before += guards against double-subscription if this constructor ever re-runs without a full
+            // domain swap (mirrors NuGetDependencyResolver).
+            PackageManagerEvents.registeredPackages -= OnRegisteredPackages;
+            PackageManagerEvents.registeredPackages += OnRegisteredPackages;
+        }
+
+        static void OnRegisteredPackages(PackageRegistrationEventArgs args)
+        {
+            if (!AffectsUnityMcpPackage(args))
+                return;
+
+            if (_isRechecking)
+                return;
+
+            _isRechecking = true;
+            try
+            {
+                Debug.Log($"{Tag} Unity-MCP package change detected — re-checking server binary version.");
+                // Fire-and-forget: unattended path (no blocking modal, no result popup; failures surface via
+                // McpServerManager.LastDownloadError -> the AI Game Developer window's error + retry button).
+                _ = McpServerManager.DownloadServerBinaryIfNeeded(unattended: true);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"{Tag} Server binary re-check failed: {ex}");
+            }
+            finally
+            {
+                _isRechecking = false;
+            }
+        }
+
+        /// <summary>
+        /// True when the UPM package-registration event involves the Unity-MCP package (added, or changed
+        /// in either direction). Extracts the package names and defers to the pure overload so the decision is
+        /// unit-testable without constructing UnityEditor PackageManager types.
+        /// </summary>
+        internal static bool AffectsUnityMcpPackage(PackageRegistrationEventArgs args)
+        {
+            if (args == null)
+                return false;
+
+            return ContainsUnityMcp(Names(args.added))
+                || ContainsUnityMcp(Names(args.changedTo))
+                || ContainsUnityMcp(Names(args.changedFrom));
+
+            static IEnumerable<string?> Names(IEnumerable<PackageInfo>? packages)
+            {
+                if (packages == null)
+                    yield break;
+                foreach (var p in packages)
+                    yield return p?.name;
+            }
+        }
+
+        /// <summary>
+        /// Pure decision: does any of the supplied package-name collections name the Unity-MCP package
+        /// (case-insensitive)? Unit-testable with plain strings.
+        /// </summary>
+        internal static bool AffectsUnityMcpPackage(
+            IEnumerable<string?>? added,
+            IEnumerable<string?>? changedTo,
+            IEnumerable<string?>? changedFrom)
+            => ContainsUnityMcp(added) || ContainsUnityMcp(changedTo) || ContainsUnityMcp(changedFrom);
+
+        /// <summary>True when <paramref name="packageNames"/> contains the Unity-MCP package id (case-insensitive).</summary>
+        internal static bool ContainsUnityMcp(IEnumerable<string?>? packageNames)
+        {
+            if (packageNames == null)
+                return false;
+
+            foreach (var name in packageNames)
+            {
+                if (string.Equals(name, UnityMcpPackageName, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/ServerBinaryUpdateWatcher.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/ServerBinaryUpdateWatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1bb61081fdfa214c996a2eb3d74242b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.McpServer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.McpServer.cs
@@ -246,8 +246,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     }
 
                     // On success the download path may have auto-started the server already
-                    // (KeepServerRunning was set true above). If so, nothing more to do.
-                    if (McpServerManager.IsRunning || McpServerManager.IsStarting)
+                    // (KeepServerRunning was set true above), or another download (e.g. the package-update
+                    // watcher) may still be in flight — DownloadServerBinaryIfNeeded's dedup guard returns
+                    // true immediately in that case. In any of these the server is being driven centrally;
+                    // do NOT fall through to StartServer() and launch a (possibly stale) binary mid-download.
+                    if (McpServerManager.IsRunning || McpServerManager.IsStarting
+                        || McpServerManager.ServerStatus.CurrentValue == McpServerStatus.Downloading)
                         return;
                 }
 
@@ -301,7 +305,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 if (downloaded
                     && UnityMcpPluginEditor.KeepServerRunning
                     && !McpServerManager.IsRunning
-                    && !McpServerManager.IsStarting)
+                    && !McpServerManager.IsStarting
+                    && McpServerManager.ServerStatus.CurrentValue != McpServerStatus.Downloading)
                 {
                     // Honor StartServer()'s bool: the download succeeded but this launch can still fail
                     // (e.g. the binary was just installed but the process won't start). Surface it instead of

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.McpServer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.McpServer.cs
@@ -49,6 +49,25 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             btnStartStop.RegisterCallback<ClickEvent>(evt => HandleServerButton(btnStartStop, statusLabel));
 
+            // Issue #845: surface a server-binary download failure in the window with a visible retry button,
+            // instead of dead-ending silently. Both elements are optional in the UXML (null-tolerant) so an
+            // older UXML never crashes setup; they default hidden and are toggled by LastDownloadError.
+            var btnDownloadRetryServer = root.Q<Button>("btnDownloadRetryServer");
+            var mcpServerErrorLabel = root.Q<Label>("mcpServerErrorLabel");
+            if (btnDownloadRetryServer != null)
+            {
+                btnDownloadRetryServer.style.display = DisplayStyle.None;
+                btnDownloadRetryServer.RegisterCallback<ClickEvent>(evt =>
+                    HandleDownloadRetryButton(btnDownloadRetryServer, statusLabel));
+            }
+            if (mcpServerErrorLabel != null)
+                mcpServerErrorLabel.style.display = DisplayStyle.None;
+
+            McpServerManager.LastDownloadError
+                .ObserveOnCurrentSynchronizationContext()
+                .Subscribe(error => UpdateDownloadErrorUI(error, btnDownloadRetryServer, mcpServerErrorLabel))
+                .AddTo(_disposables);
+
             // MCP server authorization configuration UI elements
             var labelAuthorizationToken = root.Q<Label>("labelAuthorizationToken");
             var segmentAuthorization = root.Q<VisualElement>("segmentAuthorization");
@@ -158,6 +177,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             McpServerStatus.Running => "Stop",
             McpServerStatus.Starting => "Starting...",
             McpServerStatus.Stopping => "Stopping...",
+            McpServerStatus.Downloading => "Downloading...",
             McpServerStatus.External => "External",
             _ => "Start"
         };
@@ -167,6 +187,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             McpServerStatus.Running => "MCP server: Running (http)",
             McpServerStatus.Starting => "MCP server: Starting... (http)",
             McpServerStatus.Stopping => "MCP server: Stopping... (http)",
+            McpServerStatus.Downloading => "MCP server: Downloading server...",
             McpServerStatus.External => "MCP server: External" + serverTransport switch
             {
                 TransportMethod.stdio => " (stdio)",
@@ -179,15 +200,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         internal static string GetServerStatusClass(McpServerStatus status) => status switch
         {
             McpServerStatus.Running => USS_Connected,
-            McpServerStatus.Starting or McpServerStatus.Stopping => USS_Connecting,
+            McpServerStatus.Starting or McpServerStatus.Stopping or McpServerStatus.Downloading => USS_Connecting,
             McpServerStatus.External => USS_External,
             _ => USS_Disconnected
         };
 
+        // The button is interactive only in the two stable states (Running -> Stop, Stopped -> Start).
+        // Starting/Stopping/Downloading are transient and keep the button disabled.
         internal static bool IsServerButtonEnabled(McpServerStatus status) =>
             status == McpServerStatus.Running || status == McpServerStatus.Stopped;
 
-        private static void HandleServerButton(Button btnStartStop, Label statusLabel)
+        private static async void HandleServerButton(Button btnStartStop, Label statusLabel)
         {
             // Disable button immediately to prevent double-clicks
             btnStartStop.SetEnabled(false);
@@ -201,21 +224,91 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     UnityMcpPluginEditor.Instance.Save();
                     statusLabel.text = "MCP server: Stopping...";
                     McpServerManager.StopServer();
+                    return;
                 }
-                else
+
+                // User is starting the server - remember to auto-start
+                UnityMcpPluginEditor.KeepServerRunning = true;
+                UnityMcpPluginEditor.Instance.Save();
+
+                // Issue #845: if the server binary is missing/outdated, recover it before launching instead of
+                // calling StartServer() (which would return false and leave the UI stuck on "Starting…").
+                if (!McpServerManager.IsBinaryReadyToStart())
                 {
-                    // User is starting the server - remember to auto-start
-                    UnityMcpPluginEditor.KeepServerRunning = true;
-                    UnityMcpPluginEditor.Instance.Save();
-                    statusLabel.text = "MCP server: Starting...";
-                    McpServerManager.StartServer();
+                    statusLabel.text = "MCP server: Downloading server...";
+                    var downloaded = await McpServerManager.DownloadServerBinaryIfNeeded();
+                    if (!downloaded)
+                    {
+                        // Failure is already surfaced (popup + LastDownloadError -> error label + retry button).
+                        // The reactive subscription re-enables the button via the Stopped status; reset the label.
+                        ResetServerButtonAfterFailedStart(btnStartStop, statusLabel);
+                        return;
+                    }
+
+                    // On success the download path may have auto-started the server already
+                    // (KeepServerRunning was set true above). If so, nothing more to do.
+                    if (McpServerManager.IsRunning || McpServerManager.IsStarting)
+                        return;
                 }
+
+                statusLabel.text = "MCP server: Starting...";
+
+                // Honor StartServer()'s bool: a false return must NOT leave the UI stuck on "Starting…".
+                if (!McpServerManager.StartServer())
+                    ResetServerButtonAfterFailedStart(btnStartStop, statusLabel);
             }
             catch
             {
                 // Re-enable button on exception to avoid infinite lock
                 btnStartStop.SetEnabled(true);
                 throw;
+            }
+        }
+
+        // Recovers the Start button + label after a start attempt that did not transition the status machine
+        // (StartServer returned false, or the recovery download failed). The reactive subscription also handles
+        // this via the Stopped status, but resetting here gives immediate, deterministic feedback.
+        private static void ResetServerButtonAfterFailedStart(Button btnStartStop, Label statusLabel)
+        {
+            statusLabel.text = GetServerLabelText(McpServerManager.ServerStatus.CurrentValue, null);
+            btnStartStop.SetEnabled(IsServerButtonEnabled(McpServerManager.ServerStatus.CurrentValue));
+        }
+
+        // Shows/hides the in-window server-binary error message + retry button based on the current
+        // McpServerManager.LastDownloadError value (issue #845). Both controls are optional (null-tolerant).
+        private static void UpdateDownloadErrorUI(string? error, Button? btnDownloadRetryServer, Label? mcpServerErrorLabel)
+        {
+            var hasError = !string.IsNullOrEmpty(error);
+            if (mcpServerErrorLabel != null)
+            {
+                mcpServerErrorLabel.text = hasError ? $"Server binary error: {error}" : string.Empty;
+                mcpServerErrorLabel.style.display = hasError ? DisplayStyle.Flex : DisplayStyle.None;
+            }
+            if (btnDownloadRetryServer != null)
+                btnDownloadRetryServer.style.display = hasError ? DisplayStyle.Flex : DisplayStyle.None;
+        }
+
+        // "Download / Retry server" button handler: re-runs the (user-initiated) download — which shows the
+        // result popup and updates LastDownloadError — and, on success, launches the server if the user wants
+        // it running. Reuses the same DownloadServerBinaryIfNeeded path as Tools ▸ Server ▸ Download Binaries.
+        private static async void HandleDownloadRetryButton(Button btnDownloadRetryServer, Label statusLabel)
+        {
+            btnDownloadRetryServer.SetEnabled(false);
+            try
+            {
+                statusLabel.text = "MCP server: Downloading server...";
+                var downloaded = await McpServerManager.DownloadServerBinaryIfNeeded();
+                if (downloaded
+                    && UnityMcpPluginEditor.KeepServerRunning
+                    && !McpServerManager.IsRunning
+                    && !McpServerManager.IsStarting)
+                {
+                    McpServerManager.StartServer();
+                }
+            }
+            finally
+            {
+                btnDownloadRetryServer.SetEnabled(true);
             }
         }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.McpServer.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.McpServer.cs
@@ -303,7 +303,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     && !McpServerManager.IsRunning
                     && !McpServerManager.IsStarting)
                 {
-                    McpServerManager.StartServer();
+                    // Honor StartServer()'s bool: the download succeeded but this launch can still fail
+                    // (e.g. the binary was just installed but the process won't start). Surface it instead of
+                    // showing the "Updated" popup over a silently-not-running server (issue #845).
+                    if (!McpServerManager.StartServer())
+                        UnityEngine.Debug.LogWarning(
+                            "[Unity-MCP] Server binary installed but auto-start failed. Click Start to retry.");
                 }
             }
             finally

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
@@ -144,10 +144,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             var currentStatus = McpServerManager.ServerStatus.CurrentValue;
             if (currentStatus == McpServerStatus.Running || currentStatus == McpServerStatus.Starting ||
-                currentStatus == McpServerStatus.Stopping)
+                currentStatus == McpServerStatus.Stopping || currentStatus == McpServerStatus.Downloading)
             {
-                installButton.text = "Stopping server...";
-                if (currentStatus != McpServerStatus.Stopping)
+                // Downloading is a transient busy state too (issue #845): wait for it to settle to Stopped
+                // (the binary download/start path will land there on completion) before installing the update.
+                installButton.text = currentStatus == McpServerStatus.Downloading
+                    ? "Waiting for server download..."
+                    : "Stopping server...";
+                if (currentStatus == McpServerStatus.Running || currentStatus == McpServerStatus.Starting)
                     McpServerManager.StopServer();
                 _stopSubscription = McpServerManager.ServerStatus
                     .Where(status => status == McpServerStatus.Stopped)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/UpdatePopupWindow.cs
@@ -146,18 +146,32 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             if (currentStatus == McpServerStatus.Running || currentStatus == McpServerStatus.Starting ||
                 currentStatus == McpServerStatus.Stopping || currentStatus == McpServerStatus.Downloading)
             {
-                // Downloading is a transient busy state too (issue #845): wait for it to settle to Stopped
-                // (the binary download/start path will land there on completion) before installing the update.
+                // The server is busy (running, mid-transition, or downloading its binary — issue #845). Drive it
+                // to Stopped before installing the update. The subscription must react to EVERY state, not just
+                // Stopped: a binary download that auto-starts the server lands on Downloading -> Starting ->
+                // Running, so a Stopped-only wait would hang the popup on "Waiting for server download..." while
+                // the server is actually running. Stop the server whenever it (re)starts, keep waiting through
+                // the Downloading/Stopping busy states, and install once it reaches Stopped.
                 installButton.text = currentStatus == McpServerStatus.Downloading
                     ? "Waiting for server download..."
                     : "Stopping server...";
-                if (currentStatus == McpServerStatus.Running || currentStatus == McpServerStatus.Starting)
-                    McpServerManager.StopServer();
                 _stopSubscription = McpServerManager.ServerStatus
-                    .Where(status => status == McpServerStatus.Stopped)
-                    .Take(1)
                     .ObserveOnCurrentSynchronizationContext()
-                    .Subscribe(_ => StartPackageInstall());
+                    .Subscribe(status =>
+                    {
+                        switch (status)
+                        {
+                            case McpServerStatus.Running:
+                            case McpServerStatus.Starting:
+                                installButton.text = "Stopping server...";
+                                McpServerManager.StopServer();
+                                break;
+                            case McpServerStatus.Stopped:
+                                StartPackageInstall();
+                                break;
+                            // Downloading / Stopping: transient busy states — keep waiting.
+                        }
+                    });
             }
             else
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/UI/uxml/MainWindow.uxml
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/UI/uxml/MainWindow.uxml
@@ -55,6 +55,11 @@
                             <ui:Label text="MCP server" name="mcpServerLabel" class="timeline-label" />
                             <ui:Button name="btnStartStopServer" text="Start" class="btn-secondary timeline-btn" />
                         </ui:VisualElement>
+                        <!-- Row 1b: Server binary download error + retry (issue #845; hidden unless a download failed) -->
+                        <ui:VisualElement name="mcpServerErrorRow" style="flex-direction: column; margin-top: 2px; margin-bottom: 2px;">
+                            <ui:Label name="mcpServerErrorLabel" text="" class="section-desc" style="display: none; white-space: normal; color: rgb(220, 120, 120);" />
+                            <ui:Button name="btnDownloadRetryServer" text="Download / Retry server" class="btn-secondary" style="display: none;" />
+                        </ui:VisualElement>
                         <!-- Row 2: Transport -->
                         <ui:VisualElement style="flex-direction: row; align-items: center; justify-content: space-between; margin-top: 2px; margin-bottom: 2px;">
                             <ui:Label name="labelTransport" text="Transport" class="section-desc" style="margin-bottom: 0;" />

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerBinaryDownloadTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerBinaryDownloadTests.cs
@@ -1,0 +1,230 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using NUnit.Framework;
+using com.IvanMurzak.Unity.MCP.Editor.UI;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Regression tests for issue #845 (server binary not downloaded on Linux; UI stuck on "Starting…").
+    /// Covers the deterministic, editor-free pieces of the fix:
+    ///   • <see cref="McpServerManager.PublishStagedBinary"/> — the ATOMIC same-volume publish that replaces the
+    ///     old "pre-create empty rid dir + write files in place" flow, so an interrupted download can never leave
+    ///     a half-populated <c>Library/mcp-server/&lt;rid&gt;/</c> behind.
+    ///   • <see cref="McpServerManager.FindExtractedBinary"/> — the layout-agnostic binary locator (flat win zip
+    ///     vs nested &lt;rid&gt;/ osx-linux zip).
+    ///   • The <see cref="McpServerStatus.Downloading"/> UI mappings (button/label/status-class/enabled) that let
+    ///     the window show an honest "Downloading…" instead of a misleading "Starting…".
+    ///   • <see cref="ServerBinaryUpdateWatcher"/>'s pure package-change filter (re-check on plugin update).
+    /// File IO runs in an isolated OS temp directory; nothing here touches a running Editor, the network, or the
+    /// real project's Library folder.
+    /// </summary>
+    public class McpServerBinaryDownloadTests
+    {
+        string _tempRoot = string.Empty;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempRoot = Path.Combine(Path.GetTempPath(), "mcp-server-845-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempRoot);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try { if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, recursive: true); }
+            catch { /* best effort */ }
+        }
+
+        // --- PublishStagedBinary: the atomic publish ---
+
+        [Test]
+        public void PublishStagedBinary_MovesCompletePayload_AndRemovesStaging()
+        {
+            var staged = Path.Combine(_tempRoot, "staging", "payload");
+            Directory.CreateDirectory(staged);
+            File.WriteAllText(Path.Combine(staged, "gamedev-mcp-server.exe"), "binary");
+            File.WriteAllText(Path.Combine(staged, "appsettings.json"), "{}");
+            File.WriteAllText(Path.Combine(staged, "version"), "8.0.1");
+
+            var dest = Path.Combine(_tempRoot, "cache", "win-x64");
+
+            McpServerManager.PublishStagedBinary(staged, dest);
+
+            // The destination is fully populated...
+            Assert.IsTrue(File.Exists(Path.Combine(dest, "gamedev-mcp-server.exe")), "binary must be published");
+            Assert.IsTrue(File.Exists(Path.Combine(dest, "appsettings.json")), "sidecar must travel with the binary");
+            Assert.AreEqual("8.0.1", File.ReadAllText(Path.Combine(dest, "version")), "version marker must be present");
+            // ...and the staged folder is gone (it was renamed, not copied).
+            Assert.IsFalse(Directory.Exists(staged), "staged folder must be consumed by the move");
+        }
+
+        [Test]
+        public void PublishStagedBinary_ReplacesExistingDestination_NoLeftoverFromOldPayload()
+        {
+            var dest = Path.Combine(_tempRoot, "cache", "win-x64");
+            Directory.CreateDirectory(dest);
+            // An OLD payload with a stale extra file that must NOT survive the republish.
+            File.WriteAllText(Path.Combine(dest, "gamedev-mcp-server.exe"), "OLD");
+            File.WriteAllText(Path.Combine(dest, "stale-leftover.txt"), "stale");
+
+            var staged = Path.Combine(_tempRoot, "staging", "payload");
+            Directory.CreateDirectory(staged);
+            File.WriteAllText(Path.Combine(staged, "gamedev-mcp-server.exe"), "NEW");
+            File.WriteAllText(Path.Combine(staged, "version"), "8.0.1");
+
+            McpServerManager.PublishStagedBinary(staged, dest);
+
+            Assert.AreEqual("NEW", File.ReadAllText(Path.Combine(dest, "gamedev-mcp-server.exe")),
+                "the new binary must replace the old one");
+            Assert.IsFalse(File.Exists(Path.Combine(dest, "stale-leftover.txt")),
+                "the previous payload (and any stale files) must be removed before publish");
+        }
+
+        [Test]
+        public void PublishStagedBinary_CreatesMissingParentDirectory()
+        {
+            var staged = Path.Combine(_tempRoot, "staging", "payload");
+            Directory.CreateDirectory(staged);
+            File.WriteAllText(Path.Combine(staged, "gamedev-mcp-server.exe"), "binary");
+
+            // Parent ("cache") does NOT exist yet — mirrors the post-DeleteBinaryFolderIfExists state where the
+            // whole mcp-server root was removed.
+            var dest = Path.Combine(_tempRoot, "cache", "win-x64");
+            Assert.IsFalse(Directory.Exists(Path.Combine(_tempRoot, "cache")));
+
+            McpServerManager.PublishStagedBinary(staged, dest);
+
+            Assert.IsTrue(File.Exists(Path.Combine(dest, "gamedev-mcp-server.exe")));
+        }
+
+        // --- FindExtractedBinary: layout-agnostic locator ---
+
+        [Test]
+        public void FindExtractedBinary_FlatLayout_FindsBinaryAtRoot()
+        {
+            // Windows release zips are FLAT: the binary sits at the extract root.
+            File.WriteAllText(Path.Combine(_tempRoot, "gamedev-mcp-server.exe"), "binary");
+
+            var found = McpServerManager.FindExtractedBinary(_tempRoot, "gamedev-mcp-server.exe");
+
+            Assert.IsNotNull(found);
+            Assert.AreEqual(_tempRoot, Path.GetDirectoryName(found));
+        }
+
+        [Test]
+        public void FindExtractedBinary_NestedLayout_FindsBinaryInsideRidFolder()
+        {
+            // osx/linux release zips wrap the payload in a <rid>/ folder.
+            var ridFolder = Path.Combine(_tempRoot, "linux-x64");
+            Directory.CreateDirectory(ridFolder);
+            File.WriteAllText(Path.Combine(ridFolder, "gamedev-mcp-server"), "binary");
+
+            var found = McpServerManager.FindExtractedBinary(_tempRoot, "gamedev-mcp-server");
+
+            Assert.IsNotNull(found);
+            Assert.AreEqual(ridFolder, Path.GetDirectoryName(found));
+        }
+
+        [Test]
+        public void FindExtractedBinary_PrefersShallowestMatch()
+        {
+            // A root-level binary must win over a deeper duplicate (the deep one cannot shadow the real one).
+            File.WriteAllText(Path.Combine(_tempRoot, "gamedev-mcp-server.exe"), "root");
+            var deep = Path.Combine(_tempRoot, "nested", "deeper");
+            Directory.CreateDirectory(deep);
+            File.WriteAllText(Path.Combine(deep, "gamedev-mcp-server.exe"), "deep");
+
+            var found = McpServerManager.FindExtractedBinary(_tempRoot, "gamedev-mcp-server.exe");
+
+            Assert.AreEqual(_tempRoot, Path.GetDirectoryName(found));
+        }
+
+        [Test]
+        public void FindExtractedBinary_Missing_ReturnsNull()
+        {
+            File.WriteAllText(Path.Combine(_tempRoot, "some-other-file.txt"), "x");
+            Assert.IsNull(McpServerManager.FindExtractedBinary(_tempRoot, "gamedev-mcp-server.exe"));
+        }
+
+        // --- Downloading status UI mappings (issue #845: honest UI instead of stuck "Starting…") ---
+
+        [Test]
+        public void DownloadingStatus_ButtonText_IsDownloading()
+        {
+            Assert.AreEqual("Downloading...", MainWindowEditor.GetServerButtonText(McpServerStatus.Downloading));
+        }
+
+        [Test]
+        public void DownloadingStatus_LabelText_NamesTheDownload()
+        {
+            var label = MainWindowEditor.GetServerLabelText(McpServerStatus.Downloading, null);
+            StringAssert.Contains("Downloading", label);
+            // Must NOT masquerade as the "Starting…" state that was the bug's hallmark.
+            Assert.AreNotEqual(MainWindowEditor.GetServerLabelText(McpServerStatus.Starting, null), label);
+        }
+
+        [Test]
+        public void DownloadingStatus_StatusClass_IsConnecting()
+        {
+            Assert.AreEqual(
+                MainWindowEditor.GetServerStatusClass(McpServerStatus.Starting),
+                MainWindowEditor.GetServerStatusClass(McpServerStatus.Downloading),
+                "Downloading shares the amber 'connecting' indicator with Starting/Stopping.");
+        }
+
+        [Test]
+        public void DownloadingStatus_ButtonDisabled_DuringTransientDownload()
+        {
+            Assert.IsFalse(MainWindowEditor.IsServerButtonEnabled(McpServerStatus.Downloading),
+                "the start/stop button must stay disabled while the binary is downloading");
+        }
+
+        // --- ServerBinaryUpdateWatcher: pure package-change filter (re-check on plugin update) ---
+
+        [Test]
+        public void AffectsUnityMcpPackage_True_WhenAddedContainsUnityMcp()
+        {
+            Assert.IsTrue(ServerBinaryUpdateWatcher.AffectsUnityMcpPackage(
+                added: new[] { "com.unity.collab-proxy", ServerBinaryUpdateWatcher.UnityMcpPackageName },
+                changedTo: null,
+                changedFrom: null));
+        }
+
+        [Test]
+        public void AffectsUnityMcpPackage_True_WhenChangedContainsUnityMcp_CaseInsensitive()
+        {
+            Assert.IsTrue(ServerBinaryUpdateWatcher.AffectsUnityMcpPackage(
+                added: null,
+                changedTo: new[] { "COM.IVANMURZAK.UNITY.MCP" },
+                changedFrom: new[] { "com.ivanmurzak.unity.mcp" }));
+        }
+
+        [Test]
+        public void AffectsUnityMcpPackage_False_ForUnrelatedPackagesOnly()
+        {
+            Assert.IsFalse(ServerBinaryUpdateWatcher.AffectsUnityMcpPackage(
+                added: new[] { "com.unity.textmeshpro" },
+                changedTo: new[] { "com.unity.test-framework" },
+                changedFrom: new string?[] { null }));
+        }
+
+        [Test]
+        public void AffectsUnityMcpPackage_False_ForAllNullCollections()
+        {
+            Assert.IsFalse(ServerBinaryUpdateWatcher.AffectsUnityMcpPackage(null, null, null));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerBinaryDownloadTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerBinaryDownloadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5bbeea48f27c7c4d8e0844d05db9b21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
Fixes issue #845 — on Linux after updating to plugin 0.82.1, `Library/mcp-server/<rid>/` was left empty (the `gamedev-mcp-server` binary was never downloaded), the AI Game Developer window hung on "Starting…" forever with no error/retry, and Start could not recover. Root cause was entirely client-side (server release v8.0.1 verified intact).

- **Atomic download** (`McpServerManager.DownloadAndUnpackBinary`): extract into a same-volume staging folder, fully prepare the payload (binary + sidecars + exec bit + `version` marker) there, then publish via a single `Directory.Move`. The per-RID cache folder is never pre-created empty, so an interrupted download can no longer leave a half-populated directory behind; the old working binary stays intact until the replacement is fully staged + verified.
- **Stuck "Starting…" fixed**: `HandleServerButton` now honors `StartServer()`'s `bool` return — a failed start re-enables the button and resets the label instead of dead-ending.
- **Start auto-recovers** a missing/outdated binary: downloads first (new `McpServerStatus.Downloading`, "Downloading server…") then launches.
- **Failures surfaced in-window** via `McpServerManager.LastDownloadError` + a visible **"Download / Retry server"** button, and the "Update Failed" popup now fires on every failure branch (not only post-extraction) for user-initiated downloads.
- **Re-check on plugin update** via `PackageManager.Events.registeredPackages` filtered to `com.ivanmurzak.unity.mcp` (new `ServerBinaryUpdateWatcher`).
- **Unattended path no longer blocks** behind a modal: the delete-folder dialog is skipped on the `[InitializeOnLoad]` / package-update download path.

## Test plan
- [x] Target-specific local tests passed: Unity **EditMode** suite **924/924** on `Unity-MCP-Plugin` (Unity 2022.3.62f3), 0 failures, 0 skipped. Includes 15 new tests in `McpServerBinaryDownloadTests` (atomic publish, layout-agnostic binary locator, Downloading-status UI mappings, package-change filter).
- Changes are Editor-only (no runtime / `cli/` code), so PlayMode and CLI suites do not apply.

Closes #845