### PR TITLE
fix: close first-install server-binary download Sharing-violation race

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -71,6 +71,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         static Process? _serverProcess;
 
+        // Single-flight guard for the server-binary download (0 = idle, 1 = a DownloadAndUnpackBinary is in
+        // flight). Claimed atomically via Interlocked.CompareExchange in TryBeginDownload BEFORE the first await,
+        // released in EndDownload from DownloadAndUnpackBinary's finally. This is the TOCTOU-safe replacement for
+        // the old "read _serverStatus, later SetDownloadingStatus" check-then-set that let two first-install
+        // triggers both start a colliding download → "IOException: Sharing violation" on the temp zip.
+        static int _downloadInProgress;
+
         public static ReadOnlyReactiveProperty<McpServerStatus> ServerStatus => _serverStatus;
 
         /// <summary>
@@ -372,13 +379,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 return Task.FromResult(false);
             }
 
-            // Deduplication guard (issue #845): UPM fires MULTIPLE registeredPackages events for a single
-            // package install/update, and ServerBinaryUpdateWatcher's _isRechecking flag resets synchronously
-            // (in its finally) before the fire-and-forget download Task completes. Without this guard, each
-            // event past the flag would start its own DownloadAndUnpackBinary, and the two would race at the
-            // shared archive path (corrupting the zip → checksum failure) and at PublishStagedBinary (one Move
-            // deleting the folder the other just installed). The Downloading status the lifecycle machine
-            // already tracks is the real idempotency guard: if a download is in flight, let it complete.
+            // Cheap best-effort early-out: if a download already advanced the lifecycle machine to Downloading,
+            // skip re-entering DownloadAndUnpackBinary at all. This is only an OPTIMIZATION — the authoritative
+            // single-flight guard is DownloadAndUnpackBinary's atomic TryBeginDownload, which also covers the
+            // manual menu path (MenuItems.DownloadServer calls DownloadAndUnpackBinary directly, bypassing this
+            // method) and the tiny window before SetDownloadingStatus runs. UPM fires MULTIPLE registeredPackages
+            // events per install and ServerBinaryUpdateWatcher's _isRechecking flag resets synchronously before
+            // the fire-and-forget download Task completes, so this caller can legitimately re-enter while a
+            // download is in flight; let the in-flight one complete.
             if (_serverStatus.CurrentValue == McpServerStatus.Downloading)
                 return Task.FromResult(true); // download already in progress; let it complete
 
@@ -414,19 +422,35 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         /// </param>
         public static async Task<bool> DownloadAndUnpackBinary(bool unattended = false)
         {
-            UnityEngine.Debug.Log($"Downloading GameDev-MCP-Server binary from: <color=yellow>{ExecutableZipUrl}</color>");
-
-            // Clear any prior failure + reflect the in-progress download in the status machine.
-            _lastDownloadError.Value = null;
-            SetDownloadingStatus();
+            // SINGLE-FLIGHT GUARD (first-install "IOException: Sharing violation" fix). Atomically claim the one
+            // download slot BEFORE the first await. On a fresh install two triggers race into the download — the
+            // [InitializeOnLoad] static ctor and ServerBinaryUpdateWatcher's registeredPackages handler (which UPM
+            // fires multiple times per install) — and the manual menu (MenuItems.DownloadServer) calls THIS method
+            // directly, bypassing DownloadServerBinaryIfNeeded's status check. The old dedup was a TOCTOU: it read
+            // _serverStatus, then set Downloading only later (SetDownloadingStatus below), so two callers both
+            // passed the check, both ran DownloadFileTaskAsync against the same fixed temp archive path, and the
+            // second WebClient opening the file the first still held threw the Sharing violation. CompareExchange
+            // makes claim-the-slot atomic, so a concurrent second caller no-ops (returns the in-flight result)
+            // instead of starting a second, colliding download. Released in the finally.
+            if (!TryBeginDownload())
+                return true; // a download is already in progress; let it complete
 
             string? stagingRoot = null;
             string? archiveFilePath = null;
             try
             {
+                UnityEngine.Debug.Log($"Downloading GameDev-MCP-Server binary from: <color=yellow>{ExecutableZipUrl}</color>");
+
+                // Clear any prior failure + reflect the in-progress download in the status machine.
+                _lastDownloadError.Value = null;
+                SetDownloadingStatus();
+
                 var previousKeepServerRunning = UnityMcpPluginEditor.KeepServerRunning;
 
-                archiveFilePath = Path.GetFullPath($"{Application.temporaryCachePath}/{ExecutableName.ToLowerInvariant()}-{PlatformName}-{ServerVersion}.zip");
+                // Per-attempt UNIQUE temp archive path (mirrors the staging folder's Guid below). Even if a future
+                // caller bypasses the single-flight guard, two downloads target DIFFERENT files and can never
+                // collide on the same zip — the defensive, belt-and-suspenders half of the fix.
+                archiveFilePath = BuildArchiveFilePath();
                 UnityEngine.Debug.Log($"Temporary archive file path: <color=yellow>{archiveFilePath}</color>");
 
                 // Download the zip file from the GitHub release notes
@@ -542,6 +566,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             }
             finally
             {
+                // Release the single-flight download slot claimed at entry so a later retry / real download can
+                // proceed. Only the caller that acquired the slot reaches this finally (the early return above
+                // never entered the try), so this always pairs 1:1 with the TryBeginDownload that returned true.
+                EndDownload();
+
                 if (stagingRoot != null)
                 {
                     try { if (Directory.Exists(stagingRoot)) Directory.Delete(stagingRoot, recursive: true); }
@@ -590,6 +619,35 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             if (_serverStatus.CurrentValue == McpServerStatus.Downloading)
                 _serverStatus.Value = McpServerStatus.Stopped;
         }
+
+        /// <summary>
+        /// Atomically claims the single server-binary download slot. Returns true when THIS caller acquired it
+        /// (and must eventually release it via <see cref="EndDownload"/>), or false when a download is already in
+        /// flight and the caller must no-op. The atomic claim-the-slot is the fix for the first-install
+        /// "IOException: Sharing violation" race: it replaces the non-atomic status check-then-set so two
+        /// concurrent triggers can never both start a download against the same temp archive path.
+        /// </summary>
+        internal static bool TryBeginDownload()
+            => Interlocked.CompareExchange(ref _downloadInProgress, 1, 0) == 0;
+
+        /// <summary>Releases the single download slot claimed by <see cref="TryBeginDownload"/>.</summary>
+        internal static void EndDownload()
+            => Interlocked.Exchange(ref _downloadInProgress, 0);
+
+        /// <summary>True while a server-binary download slot is currently held (diagnostic / test view).</summary>
+        internal static bool IsDownloadInProgress
+            => Volatile.Read(ref _downloadInProgress) != 0;
+
+        /// <summary>
+        /// Builds a PER-ATTEMPT-UNIQUE temp path for the downloaded server zip
+        /// (<c>{temporaryCachePath}/{executable}-{rid}-{version}-{guid}.zip</c>). The trailing Guid mirrors the
+        /// staging folder's Guid so two concurrent downloads never target the same file — the defensive half of
+        /// the first-install Sharing-violation fix. Internal so an EditMode test can assert per-call uniqueness
+        /// without performing a real download.
+        /// </summary>
+        internal static string BuildArchiveFilePath()
+            => Path.GetFullPath(
+                $"{Application.temporaryCachePath}/{ExecutableName.ToLowerInvariant()}-{PlatformName}-{ServerVersion}-{Guid.NewGuid():N}.zip");
 
         /// <summary>Shows the non-modal server-binary download result popup (success or failure).</summary>
         static void ShowUpdateResultPopup(bool success)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerDownloadRaceTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerDownloadRaceTests.cs
@@ -1,0 +1,131 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Regression tests for the first-install server-binary download RACE. On a fresh plugin install two triggers
+    /// funnel into <see cref="McpServerManager"/>.<c>DownloadAndUnpackBinary</c> — the <c>[InitializeOnLoad]</c>
+    /// static ctor and <c>ServerBinaryUpdateWatcher</c>'s <c>registeredPackages</c> handler (which UPM fires
+    /// multiple times per install) — plus the manual <c>Tools ▸ Server ▸ Download Binaries</c> menu, which calls
+    /// <c>DownloadAndUnpackBinary</c> DIRECTLY (bypassing <c>DownloadServerBinaryIfNeeded</c>'s status check). The
+    /// old dedup read the <see cref="McpServerStatus.Downloading"/> status then set it only later (a TOCTOU), so
+    /// two callers both entered, both downloaded to the SAME fixed temp zip path, and the second
+    /// <c>WebClient</c> opening the file the first still held threw <c>IOException: Sharing violation</c> — the
+    /// download then only succeeded on a manual retry (a single invocation → no race).
+    ///
+    /// <para>The fix has two deterministic, editor-free, network-free seams these tests pin:
+    ///   • <see cref="McpServerManager.TryBeginDownload"/> / <see cref="McpServerManager.EndDownload"/> — the
+    ///     atomic single-flight guard (<c>Interlocked.CompareExchange</c>). Exactly one concurrent caller may hold
+    ///     the slot; every other caller no-ops. Reverting it to a non-atomic check-then-set makes the contention
+    ///     test red.
+    ///   • <see cref="McpServerManager.BuildArchiveFilePath"/> — the per-attempt UNIQUE temp zip path (trailing
+    ///     Guid, mirroring the staging folder). Two calls yield different paths, so even a guard-bypassing caller
+    ///     cannot collide on the zip. Reverting it to the old fixed name makes the uniqueness test red.</para>
+    /// Nothing here touches a running Editor, the network, or the real project's Library folder.
+    /// </summary>
+    public class McpServerDownloadRaceTests
+    {
+        // The single-flight slot is shared static state; never let a test leak it (a leak would make every later
+        // download no-op forever). Release it before and after each test.
+        [SetUp]
+        public void ReleaseSlotBefore() => McpServerManager.EndDownload();
+
+        [TearDown]
+        public void ReleaseSlotAfter() => McpServerManager.EndDownload();
+
+        // --- Atomic single-flight guard (the core TOCTOU fix) ---
+
+        [Test]
+        public void TryBeginDownload_SecondCaller_IsRejectedUntilEndDownload()
+        {
+            Assert.IsFalse(McpServerManager.IsDownloadInProgress, "precondition: no download slot held");
+
+            Assert.IsTrue(McpServerManager.TryBeginDownload(), "the first caller must acquire the download slot");
+            Assert.IsTrue(McpServerManager.IsDownloadInProgress);
+
+            // The SECOND concurrent caller must be rejected — this is the whole fix: on the old check-then-set both
+            // callers passed the guard and raced on the same temp zip (Sharing violation).
+            Assert.IsFalse(McpServerManager.TryBeginDownload(),
+                "a second caller must NOT start a concurrent download while one is in flight");
+
+            McpServerManager.EndDownload();
+
+            // After release the slot is free again, so a later retry / real download can proceed.
+            Assert.IsFalse(McpServerManager.IsDownloadInProgress);
+            Assert.IsTrue(McpServerManager.TryBeginDownload(), "the slot must be re-acquirable after EndDownload");
+            McpServerManager.EndDownload();
+        }
+
+        [Test]
+        public void TryBeginDownload_UnderMaxContention_ExactlyOneWinner()
+        {
+            Assert.IsFalse(McpServerManager.IsDownloadInProgress, "precondition: no download slot held");
+
+            const int threadCount = 32;
+            var winners = 0;
+            using (var barrier = new Barrier(threadCount))
+            {
+                var tasks = new Task[threadCount];
+                for (var i = 0; i < threadCount; i++)
+                {
+                    tasks[i] = Task.Run(() =>
+                    {
+                        barrier.SignalAndWait(); // release all threads at once to maximize the race window
+                        if (McpServerManager.TryBeginDownload())
+                            Interlocked.Increment(ref winners);
+                    });
+                }
+                Assert.IsTrue(Task.WaitAll(tasks, 30_000), "all contending tasks should finish in time");
+            }
+
+            Assert.AreEqual(1, winners,
+                "exactly one caller may hold the single-flight download slot even under maximal contention " +
+                "(a non-atomic check-then-set would let more than one through — the original bug)");
+
+            McpServerManager.EndDownload();
+            Assert.IsFalse(McpServerManager.IsDownloadInProgress);
+        }
+
+        // --- Per-attempt UNIQUE temp archive path (defensive belt-and-suspenders) ---
+
+        [Test]
+        public void BuildArchiveFilePath_ProducesDistinctPathPerCall_NeverCollides()
+        {
+            const int calls = 64;
+            var seen = new HashSet<string>();
+            for (var i = 0; i < calls; i++)
+                Assert.IsTrue(seen.Add(McpServerManager.BuildArchiveFilePath()),
+                    "every download attempt must get a UNIQUE temp archive path (the old fixed name collided on " +
+                    "concurrent first-install downloads → Sharing violation)");
+
+            Assert.AreEqual(calls, seen.Count);
+        }
+
+        [Test]
+        public void BuildArchiveFilePath_KeepsExpectedShape()
+        {
+            var path = McpServerManager.BuildArchiveFilePath();
+
+            StringAssert.EndsWith(".zip", path);
+            var fileName = Path.GetFileName(path);
+            StringAssert.StartsWith(McpServerManager.ExecutableName.ToLowerInvariant() + "-", fileName);
+            StringAssert.Contains(McpServerManager.PlatformName, fileName);
+            StringAssert.Contains(McpServerManager.ServerVersion, fileName);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerDownloadRaceTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerDownloadRaceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1daa1c9c49bb7ef4ab8c7e77bb89272b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Fixes the first-install `IOException: Sharing violation` on the server-binary auto-download. Two triggers ([InitializeOnLoad] static ctor + `ServerBinaryUpdateWatcher`'s `registeredPackages` handler, fired multiple times per install) both funneled into `DownloadAndUnpackBinary`; the dedup guard read `McpServerStatus.Downloading` but that status was only set later inside the method (TOCTOU), so both callers downloaded to the same fixed temp zip path and collided. The download only worked on a manual retry.
- Adds an atomic single-flight guard (`Interlocked.CompareExchange` on `_downloadInProgress`, via `TryBeginDownload`/`EndDownload`) at the entry of `DownloadAndUnpackBinary`, before the first `await`, released in the existing `finally`. This protects both entry points — including the manual `Tools ▸ Server ▸ Download Binaries` menu, which calls `DownloadAndUnpackBinary` directly. A concurrent second caller no-ops.
- Defensive belt-and-suspenders: the temp archive now gets a per-attempt unique name (`BuildArchiveFilePath` adds a Guid, mirroring the staging folder), so two downloads can never collide on the same zip even if a future caller bypasses the guard.
- Unchanged: download URL, `ServerVersion` pin, checksum verify-before-execute gate, atomic staging/publish flow, and the unattended (no-modal) startup behavior. No version fields bumped.

## Test plan
- [x] Target-specific local tests passed — Unity EditMode suite green (928/928, 0 failures) on Unity 2022.3.62f3.
- [x] New EditMode regression tests (`McpServerDownloadRaceTests`): atomic single-flight contract (exactly one winner under 32-thread contention) + per-attempt unique temp path.

Closes #856