### PR TITLE
chore(cli): set npm homepage to ai-game.dev

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -57,6 +57,7 @@
     "url": "https://github.com/IvanMurzak/Unity-MCP.git",
     "directory": "cli"
   },
+  "homepage": "https://ai-game.dev",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },


### PR DESCRIPTION
## What
Sets the `unity-mcp-cli` package `homepage` to https://ai-game.dev — aligning all AI Game Dev CLI packages on the product landing page.

Metadata only — no code or README change (the unity-mcp-cli README is already the style reference for the family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015robv9F8U8vMFucatCqkXA