### PR TITLE
chore: bump consumed GameDev-MCP-Server pin 8.0.1 → 8.0.3

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -132,7 +132,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         /// <c>v&lt;ServerVersion&gt;</c> release with all 7 RID zips exists on GameDev-MCP-Server
         /// BEFORE cutting a plugin release that pins it — otherwise the download 404s).
         /// </summary>
-        public const string ServerVersion = "8.0.1";
+        public const string ServerVersion = "8.0.3";
 
         public const string ExecutableName = "gamedev-mcp-server";
 


### PR DESCRIPTION
## Summary

- Bump the pinned shared `GameDev-MCP-Server` version the Unity plugin downloads and runs from `8.0.1` to `8.0.3` — the single `ServerVersion` constant in `McpServerManager.cs`.
- `v8.0.3` (built on McpPlugin.Server 6.11.0) is already published on GameDev-MCP-Server with all RID zips + `SHA256SUMS`. Every other reference (checksum/download URL builders, Docker image tag, version-match check) reads the `McpServerManager.ServerVersion` constant, so they auto-update — nothing else is hardcoded. The coincidental `8.0.1` `Microsoft.Extensions.*` NuGet pins and the plugin `package.json` version were deliberately left untouched.

## Test plan

- [x] Target-specific local tests passed: Unity EditMode 928/928 green (0 failures) on 2022.3.62f3.
- [x] Editor compiled cleanly with the change (`IsCompiling: false`); the plugin downloaded and SHA256-verified the `v8.0.3` server release locally (cached version marker = `8.0.3`).

Closes #867