### PR TITLE
Prevent overlapping Unity test runs

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
@@ -101,6 +101,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             return await MainThread.Instance.RunAsync(async () =>
             {
+                if (IsTestRunActive(out var activeRequestId))
+                    return ResponseCallValueTool<TestRunResponse>
+                        .Error(Error.TestsAlreadyRunning(activeRequestId))
+                        .SetRequestID(requestId);
+
                 // Abort before any state mutation if any open scene has unsaved changes.
                 // Running tests against a dirty scene is unsafe: Unity may reload the scene on
                 // play-mode entry, silently discarding edits and producing non-reproducible
@@ -109,9 +114,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 // AssetDatabase.Refresh so nothing is side-effected on abort.
                 ThrowIfAnyOpenSceneIsDirty();
 
+                if (!TryBeginTestRun(requestId, out activeRequestId))
+                    return ResponseCallValueTool<TestRunResponse>
+                        .Error(Error.TestsAlreadyRunning(activeRequestId))
+                        .SetRequestID(requestId);
+
                 // Save display options to PlayerPrefs BEFORE AssetDatabase.Refresh —
                 // these must be persisted before a potential domain reload
-                TestResultCollector.TestCallRequestID.Value = requestId;
                 TestResultCollector.IncludePassingTests.Value = includePassingTests;
                 TestResultCollector.IncludeMessage.Value = includeMessages;
                 TestResultCollector.IncludeMessageStacktrace.Value = includeStacktrace;
@@ -148,7 +157,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 // Check for pre-existing compilation errors (no new compilation triggered)
                 if (UnityEditor.EditorUtility.scriptCompilationFailed)
                 {
-                    TestResultCollector.TestCallRequestID.Value = string.Empty;
+                    ClearActiveTestRun(requestId);
                     var errorDetails = ScriptUtils.GetCompilationErrorDetails();
                     return ResponseCallValueTool<TestRunResponse>
                         .Error($"Cannot run tests: Unity project has compilation errors.\n\n{errorDetails}")
@@ -168,7 +177,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
                     var validation = await ValidateTestFilters(TestRunnerApi, testMode, filterParams);
                     if (validation != null)
+                    {
+                        ClearActiveTestRun(requestId);
                         return ResponseCallValueTool<TestRunResponse>.Error(validation).SetRequestID(requestId);
+                    }
 
                     var filter = CreateTestFilter(testMode, filterParams);
 
@@ -184,6 +196,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         Debug.LogException(ex);
                         Debug.LogError($"[TestRunner] ------------------------------------- Exception {testMode} tests.");
                     }
+                    ClearActiveTestRun(requestId);
                     return ResponseCallValueTool<TestRunResponse>.Error(Error.TestExecutionFailed(ex.Message)).SetRequestID(requestId);
                 }
             }).Unwrap();

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
@@ -41,6 +41,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         const string PendingTestNamespaceKey = "MCP_PendingTestRun_TestNamespace";
         const string PendingTestClassKey = "MCP_PendingTestRun_TestClass";
         const string PendingTestMethodKey = "MCP_PendingTestRun_TestMethod";
+        const string ActiveTestRunStartedUtcTicksKey = "Unity_MCP_TestRunner_ActiveStartedUtcTicks";
+
+        static readonly TimeSpan ActiveTestRunTimeoutGrace = TimeSpan.FromMinutes(1);
+        static readonly TimeSpan MinimumActiveTestRunLease = TimeSpan.FromMinutes(10);
 
         static Tool_Tests()
         {
@@ -98,6 +102,70 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         static bool HasPendingTestRun()
             => !string.IsNullOrEmpty(SessionState.GetString(PendingTestRunKey, string.Empty));
 
+        internal static TimeSpan ActiveTestRunStaleAfter
+        {
+            get
+            {
+                var configuredTimeout = TimeSpan.FromMilliseconds(Math.Max(1000, UnityMcpPluginEditor.TimeoutMs));
+                var staleAfter = configuredTimeout + ActiveTestRunTimeoutGrace;
+                return staleAfter < MinimumActiveTestRunLease ? MinimumActiveTestRunLease : staleAfter;
+            }
+        }
+
+        internal static bool IsTestRunActive(out string activeRequestId)
+        {
+            activeRequestId = TestResultCollector.TestCallRequestID.Value;
+            if (HasPendingTestRun())
+                return true;
+
+            if (string.IsNullOrEmpty(activeRequestId))
+                return false;
+
+            if (!IsActiveTestRunStale(DateTime.UtcNow))
+                return true;
+
+            ClearActiveTestRun(activeRequestId);
+            activeRequestId = string.Empty;
+            return false;
+        }
+
+        internal static bool TryBeginTestRun(string requestId, out string activeRequestId)
+        {
+            if (IsTestRunActive(out activeRequestId))
+                return false;
+
+            TestResultCollector.TestCallRequestID.Value = requestId;
+            SetActiveTestRunStartedUtc(DateTime.UtcNow);
+            activeRequestId = requestId;
+            return true;
+        }
+
+        internal static void ClearActiveTestRun(string? requestId = null)
+        {
+            if (string.IsNullOrEmpty(requestId) || TestResultCollector.TestCallRequestID.Value == requestId)
+            {
+                TestResultCollector.TestCallRequestID.Value = string.Empty;
+                PlayerPrefs.DeleteKey(ActiveTestRunStartedUtcTicksKey);
+                PlayerPrefs.Save();
+            }
+        }
+
+        internal static void SetActiveTestRunStartedUtc(DateTime utcStarted)
+        {
+            PlayerPrefs.SetString(ActiveTestRunStartedUtcTicksKey, utcStarted.ToUniversalTime().Ticks.ToString());
+            PlayerPrefs.Save();
+        }
+
+        static bool IsActiveTestRunStale(DateTime utcNow)
+        {
+            var rawTicks = PlayerPrefs.GetString(ActiveTestRunStartedUtcTicksKey, string.Empty);
+            if (!long.TryParse(rawTicks, out var ticks))
+                return true;
+
+            var startedUtc = new DateTime(ticks, DateTimeKind.Utc);
+            return utcNow - startedUtc > ActiveTestRunStaleAfter;
+        }
+
         static void SavePendingTestRun(TestMode testMode, string? testAssembly, string? testNamespace, string? testClass, string? testMethod)
         {
             SessionState.SetString(PendingTestRunKey, "pending");
@@ -133,7 +201,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (EditorUtility.scriptCompilationFailed)
             {
                 ClearPendingTestRun();
-                TestResultCollector.TestCallRequestID.Value = string.Empty;
+                ClearActiveTestRun(requestId);
 
                 var errorDetails = ScriptUtils.GetCompilationErrorDetails();
                 var response = ResponseCallValueTool<TestRunResponse>
@@ -237,6 +305,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
 
             public static string TestTimeout(int timeoutMs)
                 => $"Test execution timed out after {timeoutMs} ms";
+
+            public static string TestsAlreadyRunning(string activeRequestId)
+            {
+                var suffix = string.IsNullOrEmpty(activeRequestId)
+                    ? string.Empty
+                    : $" Active request id: {activeRequestId}.";
+
+                return $"Cannot run tests: another test run is already in progress.{suffix} Wait for it to finish and try again.";
+            }
 
             public static string NoTestsFound(TestFilterParameters filterParams)
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/TestResultCollector.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/TestResultCollector.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using com.IvanMurzak.McpPlugin.Common.Model;
+using com.IvanMurzak.Unity.MCP.Editor.API;
 using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using Extensions.Unity.PlayerPrefsEx;
 using UnityEditor.TestTools.TestRunner.Api;
@@ -127,7 +128,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
                 UnityMcpPluginEditor.ConnectIfNeeded();
 
             var requestId = TestCallRequestID.Value;
-            TestCallRequestID.Value = string.Empty;
+            Tool_Tests.ClearActiveTestRun(requestId);
             if (string.IsNullOrEmpty(requestId) == false)
             {
                 var structuredResponse = CreateStructuredResponse(

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests/TestsRunDirtySceneTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Tests/TestsRunDirtySceneTests.cs
@@ -31,12 +31,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         [SetUp]
         public void EnsureCleanScene()
         {
+            Tool_Tests.ClearActiveTestRun();
             EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
         }
 
         [TearDown]
         public void RestoreCleanScene()
         {
+            Tool_Tests.ClearActiveTestRun();
             // Reset to a fresh empty scene so the next test (or the next session)
             // never sees the dirty marker we may have set.
             EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
@@ -98,6 +100,63 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 "Exactly one open scene should be reported as dirty.");
             Assert.IsTrue(dirty[0].isDirty,
                 "The returned scene must actually be dirty.");
+        }
+
+        [Test]
+        public void TryBeginTestRun_WhenNoRunIsActive_StoresRequestId()
+        {
+            var started = Tool_Tests.TryBeginTestRun("request-1", out var activeRequestId);
+
+            Assert.IsTrue(started);
+            Assert.AreEqual("request-1", activeRequestId);
+            Assert.IsTrue(Tool_Tests.IsTestRunActive(out activeRequestId));
+            Assert.AreEqual("request-1", activeRequestId);
+        }
+
+        [Test]
+        public void TryBeginTestRun_WhenRunIsAlreadyActive_DoesNotReplaceRequestId()
+        {
+            Assert.IsTrue(Tool_Tests.TryBeginTestRun("request-1", out _));
+
+            var started = Tool_Tests.TryBeginTestRun("request-2", out var activeRequestId);
+
+            Assert.IsFalse(started);
+            Assert.AreEqual("request-1", activeRequestId);
+            Assert.IsTrue(Tool_Tests.IsTestRunActive(out activeRequestId));
+            Assert.AreEqual("request-1", activeRequestId);
+        }
+
+        [Test]
+        public void ClearActiveTestRun_WhenRequestIdDoesNotMatch_KeepsActiveRun()
+        {
+            Assert.IsTrue(Tool_Tests.TryBeginTestRun("request-1", out _));
+
+            Tool_Tests.ClearActiveTestRun("request-2");
+
+            Assert.IsTrue(Tool_Tests.IsTestRunActive(out var activeRequestId));
+            Assert.AreEqual("request-1", activeRequestId);
+        }
+
+        [Test]
+        public void IsTestRunActive_WhenActiveRunIsFresh_KeepsActiveRun()
+        {
+            Assert.IsTrue(Tool_Tests.TryBeginTestRun("request-1", out _));
+            Tool_Tests.SetActiveTestRunStartedUtc(DateTime.UtcNow - TimeSpan.FromSeconds(30));
+
+            Assert.IsTrue(Tool_Tests.IsTestRunActive(out var activeRequestId));
+            Assert.AreEqual("request-1", activeRequestId);
+        }
+
+        [Test]
+        public void IsTestRunActive_WhenActiveRunIsStale_ClearsActiveRun()
+        {
+            Assert.IsTrue(Tool_Tests.TryBeginTestRun("request-1", out _));
+            Tool_Tests.SetActiveTestRunStartedUtc(DateTime.UtcNow - Tool_Tests.ActiveTestRunStaleAfter - TimeSpan.FromSeconds(1));
+
+            Assert.IsFalse(Tool_Tests.IsTestRunActive(out var activeRequestId));
+            Assert.AreEqual(string.Empty, activeRequestId);
+            Assert.IsTrue(Tool_Tests.TryBeginTestRun("request-2", out activeRequestId));
+            Assert.AreEqual("request-2", activeRequestId);
         }
 
         // --- helpers ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Prevents overlapping `tests-run` calls from overwriting the active MCP request id while a Unity test run is already in progress.

## Root cause

`tests-run` stored the active request id in a single static/PlayerPrefs-backed value. When two clients invoked the tool concurrently, the second call replaced the first request id. When Unity finished the test run, `RunFinished` completed only the latest request id, leaving the original caller waiting until its MCP-side timeout.

## Changes

- Adds single-flight tracking helpers for active Unity test runs.
- Returns an immediate tool error when another `tests-run` call is already active.
- Clears the active request id only when the finishing request matches it.
- Adds a stale-lock lease so a Unity crash or lost callback does not block future test runs forever.
- Adds editor tests for request-id preservation, guarded cleanup, and stale-lock recovery.

## Stale-lock behavior

The active test-run marker now stores a UTC start timestamp in PlayerPrefs. If Unity restarts after a crash, or no callback ever clears the marker, a future `tests-run` call treats the marker as stale after the configured MCP timeout plus one minute, with a 10-minute minimum lease. That keeps normal long-running tests from being preempted accidentally while avoiding a permanent PlayerPrefs lock.

## Validation

Ran Unity editmode tests locally:

```powershell
powershell -NoProfile -ExecutionPolicy Bypass -File commands\run-unity-tests.ps1 -UnityPath "C:\UnityEditor\2022.3.44f1\Editor\Unity.exe" -ProjectPath "Unity-Tests\2022.3.62f3" -TestMode editmode -OutputDir "commands\TestResults-singleflight-stale-lock"
```

Result: `EditMode PASSED, 939/939 tests`.
