### PR TITLE
feat(auth): RFC 8628 device flow + machine credential store + zero-button boot (mcp-authorize PR 2)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AccountCredentialService.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AccountCredentialService.cs
@@ -1,0 +1,132 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unity.MCP.Utils;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Services
+{
+    /// <summary>
+    /// Editor-side owner of the shared machine-credential account credential (mcp-authorize design 06 / D12).
+    /// It wraps McpPlugin 7.0's <see cref="PluginCredentialProvider"/> over the machine store
+    /// (<c>~/.ai-game-dev/credentials.json</c>) + a <see cref="UnityTokenRefresher"/>, and implements the
+    /// zero-button boot behaviour:
+    /// <list type="bullet">
+    ///   <item><b>Auto-adopt:</b> the provider reads the machine store at construction — a present credential
+    ///   means the plugin is <see cref="AuthState.SignedIn"/> with no UI interaction.</item>
+    ///   <item><b>Proactive refresh at connect:</b> <see cref="Initialize"/> points
+    ///   <see cref="UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider"/> at the provider's
+    ///   proactively-refreshed access-token callback, so a Cloud-mode SignalR connection presents the
+    ///   machine-store JWT automatically (falling back to the mode-routed token when signed out).</item>
+    ///   <item><b>On-401 refresh + reconnect:</b> <see cref="AttachTo"/> wires a
+    ///   <see cref="ConnectionCredentialCoordinator"/> so a 3-strike authorization rejection refreshes the
+    ///   token and reconnects without any UI.</item>
+    /// </list>
+    /// Credentials NEVER land in a project file / VCS — only in the protected machine store (0600 on POSIX /
+    /// DPAPI on Windows), which is shared by every engine plugin, CLI, and the local server on the machine.
+    /// </summary>
+    public static class AccountCredentialService
+    {
+        static readonly object _gate = new object();
+        static readonly ILogger _logger = UnityLoggerFactory.LoggerFactory.CreateLogger(nameof(AccountCredentialService));
+
+        static PluginCredentialProvider? _provider;
+        static ConnectionCredentialCoordinator? _coordinator;
+        static bool _wired;
+
+        /// <summary>
+        /// The machine-store-backed credential provider (lazily constructed). Reads
+        /// <c>~/.ai-game-dev/credentials.json</c> once per domain; a present credential auto-adopts as
+        /// <see cref="AuthState.SignedIn"/>.
+        /// </summary>
+        public static PluginCredentialProvider Provider
+        {
+            get
+            {
+                lock (_gate)
+                    return _provider ??= CreateDefaultProvider();
+            }
+        }
+
+        /// <summary>True when the machine store holds a usable credential (zero-button auto-adopt).</summary>
+        public static bool IsSignedIn => Provider.IsSignedIn;
+
+        static PluginCredentialProvider CreateDefaultProvider()
+        {
+            var store = new MachineCredentialStore();
+            var refresher = new UnityTokenRefresher(UnityMcpPlugin.UnityConnectionConfig.CloudServerBaseUrl);
+            return new PluginCredentialProvider(store, refresher, _logger);
+        }
+
+        /// <summary>
+        /// Point the connection config's Cloud credential provider at the machine-store-backed, proactively
+        /// refreshed access token. Idempotent — the callback always reflects the current provider state, so a
+        /// credential adopted later (via <see cref="Adopt"/>) is presented on the next (re)connect without
+        /// re-wiring. Safe to call on every editor boot / domain reload.
+        /// </summary>
+        public static void Initialize()
+        {
+            lock (_gate)
+            {
+                if (_wired)
+                    return;
+                var provider = _provider ??= CreateDefaultProvider();
+                UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = provider.AsAccessTokenProvider();
+                _wired = true;
+            }
+        }
+
+        /// <summary>
+        /// Attach the auth-rejection → refresh → reconnect coordinator to the freshly-built plugin (design 06,
+        /// on-401 recovery). No-op when no machine credential is present (nothing to refresh). Replaces any
+        /// previous coordinator so a rebuilt plugin never leaks a stale subscription.
+        /// </summary>
+        public static void AttachTo(IMcpPlugin? plugin)
+        {
+            if (plugin == null)
+                return;
+            Initialize();
+            lock (_gate)
+            {
+                _coordinator?.Dispose();
+                _coordinator = null;
+                if (_provider != null && _provider.IsSignedIn)
+                    _coordinator = new ConnectionCredentialCoordinator(plugin, _provider, _logger);
+            }
+        }
+
+        /// <summary>
+        /// Persist a freshly obtained device-flow credential into the machine store and adopt it
+        /// (<see cref="AuthState.SignedIn"/>). Shared once-per-machine across every engine plugin / CLI.
+        /// </summary>
+        public static void Adopt(MachineCredentials credentials)
+        {
+            if (credentials == null)
+                throw new ArgumentNullException(nameof(credentials));
+            Initialize();
+            Provider.Adopt(credentials);
+        }
+
+        /// <summary>Sign out: delete the stored credential and drop the on-401 coordinator.</summary>
+        public static void SignOut()
+        {
+            lock (_gate)
+            {
+                _provider?.SignOut();
+                _coordinator?.Dispose();
+                _coordinator = null;
+            }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AccountCredentialService.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AccountCredentialService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d878ae499628c9648b527f3250fcd9a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/DeviceAuthFlow.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/DeviceAuthFlow.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
 using Microsoft.Extensions.Logging;
 using UnityEngine;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -30,9 +31,24 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Services
         Cancelled
     }
 
+    /// <summary>
+    /// Drives the RFC 8628 device-authorization state machine (mcp-authorize design 03 Flow B): request a
+    /// device/user code, open the verification URL, poll <c>/oauth/token</c> until the user approves, then
+    /// hand the resulting <see cref="MachineCredentials"/> (access + refresh token + expiry) to
+    /// <paramref name="onAuthorized"/> — the editor wires that to <see cref="AccountCredentialService.Adopt"/>
+    /// so the credential lands in the shared machine store (D12). The device client, browser-open action,
+    /// and poll delay are all injectable so the state machine runs against a mocked authorization server with
+    /// no live network in CI.
+    /// </summary>
     public class DeviceAuthFlow
     {
         private static readonly ILogger _logger = MCP.Utils.UnityLoggerFactory.LoggerFactory.CreateLogger<DeviceAuthFlow>();
+
+        readonly IDeviceAuthClient _client;
+        readonly Action<MachineCredentials> _onAuthorized;
+        readonly Action<string> _openBrowser;
+        readonly Func<TimeSpan, CancellationToken, Task> _delay;
+        readonly string? _serverTarget;
 
         private CancellationTokenSource? _cts;
 
@@ -42,7 +58,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Services
 
         public event Action<DeviceAuthFlowState>? OnStateChanged;
 
-        public async Task StartAsync(string serverUrl, string? clientLabel = null)
+        /// <param name="client">Device-authorization transport (real <see cref="DeviceAuthService"/> or a mock).</param>
+        /// <param name="onAuthorized">Sink for the obtained credential (editor: persist to the machine store).</param>
+        /// <param name="serverTarget">The AS/hub target recorded on the credential (hosted vs local).</param>
+        /// <param name="openBrowser">Verification-URL opener; defaults to <see cref="Application.OpenURL"/>.</param>
+        /// <param name="delay">Poll delay; defaults to <see cref="Task.Delay(TimeSpan, CancellationToken)"/>.</param>
+        public DeviceAuthFlow(
+            IDeviceAuthClient client,
+            Action<MachineCredentials> onAuthorized,
+            string? serverTarget = null,
+            Action<string>? openBrowser = null,
+            Func<TimeSpan, CancellationToken, Task>? delay = null)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _onAuthorized = onAuthorized ?? throw new ArgumentNullException(nameof(onAuthorized));
+            _serverTarget = serverTarget;
+            _openBrowser = openBrowser ?? (url => Application.OpenURL(url));
+            _delay = delay ?? ((ts, ct) => Task.Delay(ts, ct));
+        }
+
+        public async Task StartAsync()
         {
             Cancel();
             _cts = new CancellationTokenSource();
@@ -52,50 +87,60 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Services
             {
                 SetState(DeviceAuthFlowState.Initiating);
 
-                var authResponse = await DeviceAuthService.InitiateDeviceAuthAsync(serverUrl, clientLabel, ct);
+                var authResponse = await _client.RequestDeviceCodeAsync(ct);
                 UserCode = authResponse.UserCode;
 
                 SetState(DeviceAuthFlowState.WaitingForUser);
 
-                Application.OpenURL(authResponse.VerificationUriComplete);
+                var verificationUrl = !string.IsNullOrEmpty(authResponse.VerificationUriComplete)
+                    ? authResponse.VerificationUriComplete
+                    : authResponse.VerificationUri;
+                if (!string.IsNullOrEmpty(verificationUrl))
+                    _openBrowser(verificationUrl);
 
                 SetState(DeviceAuthFlowState.Polling);
 
-                var interval = Math.Max(authResponse.Interval, 5) * 1000;
-                var deadline = DateTime.UtcNow.AddSeconds(authResponse.ExpiresIn);
+                // RFC 8628: honour the server's interval (floor 5s), and slow_down bumps it by 5s.
+                var interval = TimeSpan.FromSeconds(Math.Max(authResponse.Interval, 5));
+                var lifetimeSeconds = authResponse.ExpiresIn > 0 ? authResponse.ExpiresIn : 900;
+                var deadline = DateTime.UtcNow.AddSeconds(lifetimeSeconds);
 
                 while (DateTime.UtcNow < deadline)
                 {
                     ct.ThrowIfCancellationRequested();
-                    await Task.Delay(interval, ct);
+                    await _delay(interval, ct);
 
-                    var tokenResponse = await DeviceAuthService.PollDeviceTokenAsync(serverUrl, authResponse.DeviceCode, ct);
+                    var tokenResponse = await _client.PollTokenAsync(authResponse.DeviceCode, ct);
 
-                    if (tokenResponse.AccessToken != null)
+                    if (!string.IsNullOrEmpty(tokenResponse.AccessToken))
                     {
-                        UnityMcpPluginEditor.CloudToken = tokenResponse.AccessToken;
-                        UnityMcpPluginEditor.Instance.Save();
+                        var credentials = new MachineCredentials
+                        {
+                            AccessToken = tokenResponse.AccessToken,
+                            RefreshToken = tokenResponse.RefreshToken,
+                            ExpiresAt = tokenResponse.ExpiresIn > 0
+                                ? DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn)
+                                : (DateTimeOffset?)null,
+                            ServerTarget = _serverTarget,
+                        };
+                        _onAuthorized(credentials);
                         SetState(DeviceAuthFlowState.Authorized);
                         return;
                     }
 
-                    if (tokenResponse.Error == "access_denied")
+                    switch (tokenResponse.Error)
                     {
-                        ErrorMessage = "Authorization was denied.";
-                        SetState(DeviceAuthFlowState.Failed);
-                        return;
-                    }
-
-                    if (tokenResponse.Error == "expired_token")
-                    {
-                        SetState(DeviceAuthFlowState.Expired);
-                        return;
-                    }
-
-                    // authorization_pending or slow_down — keep polling
-                    if (tokenResponse.Error == "slow_down")
-                    {
-                        interval = Math.Min(interval + 5000, 30000);
+                        case "access_denied":
+                            ErrorMessage = "Authorization was denied.";
+                            SetState(DeviceAuthFlowState.Failed);
+                            return;
+                        case "expired_token":
+                            SetState(DeviceAuthFlowState.Expired);
+                            return;
+                        case "slow_down":
+                            interval += TimeSpan.FromSeconds(5);
+                            break;
+                        // "authorization_pending" (or no error) — keep polling.
                     }
                 }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/DeviceAuthService.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/DeviceAuthService.cs
@@ -10,8 +10,8 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -19,66 +19,135 @@ using System.Threading.Tasks;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Services
 {
-    public static class DeviceAuthService
+    /// <summary>
+    /// Device-authorization client contract (mcp-authorize design 03 Flow B / design 06). Split from the
+    /// concrete <see cref="DeviceAuthService"/> so the <see cref="DeviceAuthFlow"/> state machine can be
+    /// exercised against a mocked authorization server with no live network dependency.
+    /// </summary>
+    public interface IDeviceAuthClient
     {
-        private static readonly HttpClient _httpClient = new();
-        private static readonly JsonSerializerOptions _jsonOptions = new()
+        /// <summary>Begin the flow: <c>POST /oauth/device_authorization</c> → device/user code document.</summary>
+        Task<DeviceAuthorizeResponse> RequestDeviceCodeAsync(CancellationToken ct = default);
+
+        /// <summary>Poll for the token: <c>POST /oauth/token</c> (device-code grant). Pending is a soft error.</summary>
+        Task<DeviceTokenResponse> PollTokenAsync(string deviceCode, CancellationToken ct = default);
+    }
+
+    /// <summary>RFC 8628 <c>device_authorization</c> response document.</summary>
+    public class DeviceAuthorizeResponse
+    {
+        [JsonPropertyName("device_code")] public string DeviceCode { get; set; } = "";
+        [JsonPropertyName("user_code")] public string UserCode { get; set; } = "";
+        [JsonPropertyName("verification_uri")] public string VerificationUri { get; set; } = "";
+        [JsonPropertyName("verification_uri_complete")] public string VerificationUriComplete { get; set; } = "";
+        [JsonPropertyName("expires_in")] public int ExpiresIn { get; set; }
+        [JsonPropertyName("interval")] public int Interval { get; set; }
+    }
+
+    /// <summary>
+    /// OAuth 2.1 token response for the device-code grant (design 03 Flow B). On success it carries the
+    /// ES256 MCP JWT (<c>access_token</c>) + the rotating <c>refresh_token</c> + <c>expires_in</c>; while
+    /// authorization is pending it carries an RFC 6749 §5.2 <c>error</c> (<c>authorization_pending</c> /
+    /// <c>slow_down</c> / <c>access_denied</c> / <c>expired_token</c>) with HTTP 400.
+    /// </summary>
+    public class DeviceTokenResponse
+    {
+        [JsonPropertyName("access_token")] public string? AccessToken { get; set; }
+        [JsonPropertyName("refresh_token")] public string? RefreshToken { get; set; }
+        [JsonPropertyName("token_type")] public string? TokenType { get; set; }
+        [JsonPropertyName("expires_in")] public int ExpiresIn { get; set; }
+        [JsonPropertyName("scope")] public string? Scope { get; set; }
+        [JsonPropertyName("error")] public string? Error { get; set; }
+        [JsonPropertyName("error_description")] public string? ErrorDescription { get; set; }
+    }
+
+    /// <summary>
+    /// RFC 8628-conformant device-authorization client for the ai-game.dev authorization server
+    /// (mcp-authorize design 03 Flow B / design 05). It POSTs <c>client_id</c> + <c>scope=mcp:plugin</c>
+    /// (form-encoded) to <c>{base}/oauth/device_authorization</c>, then redeems the grant at
+    /// <c>{base}/oauth/token</c> with the device-code URN — yielding an ES256 hub JWT
+    /// (<c>aud=urn:agd:hub</c>) plus a rotating refresh token. This replaces the legacy
+    /// <c>/api/auth/device/*</c> JSON flow. It never persists anything itself — the caller
+    /// (<see cref="DeviceAuthFlow"/>) stores the credential in the shared machine credential store (D12).
+    /// </summary>
+    public sealed class DeviceAuthService : IDeviceAuthClient
+    {
+        /// <summary>Public device client id (audit only; the AS accepts any non-empty value for the device grant).</summary>
+        public const string DefaultClientId = "unity-mcp-plugin";
+
+        /// <summary>Scope selecting the ES256 MCP-plugin JWT + refresh-token response (design 08 §roles).</summary>
+        public const string PluginScope = "mcp:plugin";
+
+        /// <summary>RFC 8628 device-code grant type redeemed at <c>/oauth/token</c>.</summary>
+        public const string DeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code";
+
+        static readonly HttpClient _sharedHttpClient = new HttpClient();
+        static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
         {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
             PropertyNameCaseInsensitive = true
         };
 
-        public class DeviceAuthorizeResponse
+        readonly string _serverBaseUrl;
+        readonly string _clientId;
+        readonly string _scope;
+        readonly HttpClient _httpClient;
+
+        /// <param name="serverBaseUrl">The AS root (e.g. <c>https://ai-game.dev</c>) — NOT the <c>/mcp</c> hub URL.</param>
+        public DeviceAuthService(string serverBaseUrl, string? clientId = null, string? scope = null, HttpClient? httpClient = null)
         {
-            [JsonPropertyName("device_code")]
-            public string DeviceCode { get; set; } = "";
-            [JsonPropertyName("user_code")]
-            public string UserCode { get; set; } = "";
-            [JsonPropertyName("verification_uri")]
-            public string VerificationUri { get; set; } = "";
-            [JsonPropertyName("verification_uri_complete")]
-            public string VerificationUriComplete { get; set; } = "";
-            [JsonPropertyName("expires_in")]
-            public int ExpiresIn { get; set; }
-            [JsonPropertyName("interval")]
-            public int Interval { get; set; }
+            if (string.IsNullOrWhiteSpace(serverBaseUrl))
+                throw new ArgumentException("serverBaseUrl is required", nameof(serverBaseUrl));
+            _serverBaseUrl = serverBaseUrl.TrimEnd('/');
+            _clientId = string.IsNullOrWhiteSpace(clientId) ? DefaultClientId : clientId!;
+            _scope = string.IsNullOrWhiteSpace(scope) ? PluginScope : scope!;
+            _httpClient = httpClient ?? _sharedHttpClient;
         }
 
-        public class DeviceTokenResponse
+        public async Task<DeviceAuthorizeResponse> RequestDeviceCodeAsync(CancellationToken ct = default)
         {
-            [JsonPropertyName("access_token")]
-            public string? AccessToken { get; set; }
-            [JsonPropertyName("token_type")]
-            public string? TokenType { get; set; }
-            [JsonPropertyName("error")]
-            public string? Error { get; set; }
-            [JsonPropertyName("error_description")]
-            public string? ErrorDescription { get; set; }
-        }
-
-        public static async Task<DeviceAuthorizeResponse> InitiateDeviceAuthAsync(
-            string serverUrl, string? clientLabel, CancellationToken ct = default)
-        {
-            var body = clientLabel != null
-                ? JsonSerializer.Serialize(new { client_label = clientLabel }, _jsonOptions)
-                : "{}";
-            using var content = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await _httpClient.PostAsync($"{serverUrl.TrimEnd('/')}/api/auth/device/authorize", content, ct);
+            using var content = new FormUrlEncodedContent(BuildDeviceAuthorizeForm(_clientId, _scope));
+            using var response = await _httpClient.PostAsync(DeviceAuthorizeUrl(_serverBaseUrl), content, ct);
             response.EnsureSuccessStatusCode();
             var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<DeviceAuthorizeResponse>(json, _jsonOptions)
-                ?? throw new InvalidOperationException("Failed to deserialize device auth response");
+            return ParseDeviceAuthorizeResponse(json);
         }
 
-        public static async Task<DeviceTokenResponse> PollDeviceTokenAsync(
-            string serverUrl, string deviceCode, CancellationToken ct = default)
+        public async Task<DeviceTokenResponse> PollTokenAsync(string deviceCode, CancellationToken ct = default)
         {
-            var body = JsonSerializer.Serialize(new { device_code = deviceCode, grant_type = "urn:ietf:params:oauth:grant-type:device_code" }, _jsonOptions);
-            using var content = new StringContent(body, Encoding.UTF8, "application/json");
-            var response = await _httpClient.PostAsync($"{serverUrl.TrimEnd('/')}/api/auth/device/token", content, ct);
+            using var content = new FormUrlEncodedContent(BuildDeviceTokenForm(deviceCode, _clientId));
+            // Do NOT EnsureSuccessStatusCode: authorization_pending / slow_down come back as HTTP 400 with
+            // an RFC 6749 §5.2 JSON error body that DeviceAuthFlow inspects to decide whether to keep polling.
+            using var response = await _httpClient.PostAsync(TokenUrl(_serverBaseUrl), content, ct);
             var json = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<DeviceTokenResponse>(json, _jsonOptions)
-                ?? throw new InvalidOperationException("Failed to deserialize device token response");
+            return ParseDeviceTokenResponse(json);
         }
+
+        // ── Pure, unit-testable request/response helpers (mocked-AS coverage without an HttpMessageHandler) ──
+
+        internal static string DeviceAuthorizeUrl(string serverBaseUrl) => $"{serverBaseUrl.TrimEnd('/')}/oauth/device_authorization";
+        internal static string TokenUrl(string serverBaseUrl) => $"{serverBaseUrl.TrimEnd('/')}/oauth/token";
+
+        internal static IReadOnlyList<KeyValuePair<string, string>> BuildDeviceAuthorizeForm(string clientId, string scope)
+            => new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("client_id", clientId),
+                new KeyValuePair<string, string>("scope", scope),
+            };
+
+        internal static IReadOnlyList<KeyValuePair<string, string>> BuildDeviceTokenForm(string deviceCode, string clientId)
+            => new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("grant_type", DeviceCodeGrantType),
+                new KeyValuePair<string, string>("device_code", deviceCode),
+                new KeyValuePair<string, string>("client_id", clientId),
+            };
+
+        internal static DeviceAuthorizeResponse ParseDeviceAuthorizeResponse(string json)
+            => JsonSerializer.Deserialize<DeviceAuthorizeResponse>(json, _jsonOptions)
+               ?? throw new InvalidOperationException("Failed to deserialize device authorization response");
+
+        internal static DeviceTokenResponse ParseDeviceTokenResponse(string json)
+            => JsonSerializer.Deserialize<DeviceTokenResponse>(json, _jsonOptions)
+               ?? throw new InvalidOperationException("Failed to deserialize device token response");
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/UnityTokenRefresher.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/UnityTokenRefresher.cs
@@ -1,0 +1,111 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Services
+{
+    /// <summary>
+    /// Unity's concrete <see cref="ITokenRefresher"/> (mcp-authorize design 03 Flow B): exchanges a stored
+    /// refresh token for a fresh ES256 access token at <c>{serverTarget}/oauth/token</c>
+    /// (<c>grant_type=refresh_token</c>). The shared <see cref="PluginCredentialProvider"/> owns the
+    /// machine store and the refresh scheduling; this class is only the HTTP seam. It fails closed — any
+    /// non-success or exception returns <see cref="TokenRefreshResult.Failure"/> — and never logs token
+    /// material.
+    /// </summary>
+    public sealed class UnityTokenRefresher : ITokenRefresher
+    {
+        static readonly HttpClient _sharedHttpClient = new HttpClient();
+
+        readonly string _defaultServerBaseUrl;
+        readonly string _clientId;
+        readonly string _scope;
+        readonly HttpClient _httpClient;
+
+        public UnityTokenRefresher(string defaultServerBaseUrl, string? clientId = null, string? scope = null, HttpClient? httpClient = null)
+        {
+            _defaultServerBaseUrl = NormalizeBase(defaultServerBaseUrl) ?? "";
+            _clientId = string.IsNullOrWhiteSpace(clientId) ? DeviceAuthService.DefaultClientId : clientId!;
+            _scope = string.IsNullOrWhiteSpace(scope) ? DeviceAuthService.PluginScope : scope!;
+            _httpClient = httpClient ?? _sharedHttpClient;
+        }
+
+        public async Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(refreshToken))
+                return TokenRefreshResult.Failure("no refresh token");
+
+            var baseUrl = NormalizeBase(serverTarget) ?? _defaultServerBaseUrl;
+            if (string.IsNullOrEmpty(baseUrl))
+                return TokenRefreshResult.Failure("no server target");
+
+            try
+            {
+                using var content = new FormUrlEncodedContent(BuildRefreshForm(refreshToken, _clientId, _scope));
+                using var response = await _httpClient.PostAsync(DeviceAuthService.TokenUrl(baseUrl), content, cancellationToken);
+                var json = await response.Content.ReadAsStringAsync();
+                var parsed = DeviceAuthService.ParseDeviceTokenResponse(json);
+                return BuildResult(response.IsSuccessStatusCode, (int)response.StatusCode, parsed);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                return TokenRefreshResult.Failure(ex.Message);
+            }
+        }
+
+        // ── Pure, unit-testable helpers ──────────────────────────────────────────────────────────────
+
+        internal static IReadOnlyList<KeyValuePair<string, string>> BuildRefreshForm(string refreshToken, string clientId, string scope)
+            => new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("grant_type", "refresh_token"),
+                new KeyValuePair<string, string>("refresh_token", refreshToken),
+                new KeyValuePair<string, string>("client_id", clientId),
+                new KeyValuePair<string, string>("scope", scope),
+            };
+
+        internal static TokenRefreshResult BuildResult(bool isSuccessStatusCode, int statusCode, DeviceTokenResponse? parsed)
+        {
+            if (parsed == null)
+                return TokenRefreshResult.Failure("empty token response");
+            if (!isSuccessStatusCode || string.IsNullOrEmpty(parsed.AccessToken))
+                return TokenRefreshResult.Failure(parsed.Error ?? $"refresh failed (HTTP {statusCode})");
+
+            DateTimeOffset? expiresAt = parsed.ExpiresIn > 0
+                ? DateTimeOffset.UtcNow.AddSeconds(parsed.ExpiresIn)
+                : (DateTimeOffset?)null;
+            return TokenRefreshResult.Success(parsed.AccessToken!, parsed.RefreshToken, expiresAt);
+        }
+
+        /// <summary>
+        /// Normalize a stored server target to the AS root: trim a trailing slash and a trailing
+        /// <c>/mcp</c> hub segment so <c>/oauth/token</c> resolves on the authorization-server root.
+        /// </summary>
+        internal static string? NormalizeBase(string? serverTarget)
+        {
+            if (string.IsNullOrWhiteSpace(serverTarget))
+                return null;
+            var s = serverTarget!.Trim().TrimEnd('/');
+            if (s.EndsWith("/mcp", StringComparison.OrdinalIgnoreCase))
+                s = s.Substring(0, s.Length - "/mcp".Length);
+            return s;
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/UnityTokenRefresher.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/UnityTokenRefresher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2c97a7c0af81064891bfe8ab83d6c6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
@@ -89,6 +89,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             if (UnityMcpPluginEditor.ConnectionMode != ConnectionMode.Cloud)
                 return;
 
+            // When signed in via the shared machine credential store, the ConnectionCredentialCoordinator
+            // (wired in AccountCredentialService.AttachTo) already handles the 3-strike rejection by
+            // refreshing the token and reconnecting — do not clear the display token here (design 06).
+            if (AccountCredentialService.IsSignedIn)
+                return;
+
             Debug.LogWarning("[AI Game Developer] The server rejected the authorization token. " +
                 "The token has been cleared. Please click 'Authorize' to obtain a new token.");
 
@@ -350,7 +356,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 }
 
                 _deviceAuthFlow?.Cancel();
-                _deviceAuthFlow = new DeviceAuthFlow();
+                var cloudBaseUrl = UnityMcpPlugin.UnityConnectionConfig.CloudServerBaseUrl;
+                _deviceAuthFlow = new DeviceAuthFlow(
+                    new DeviceAuthService(cloudBaseUrl),
+                    onAuthorized: credentials =>
+                    {
+                        // Persist into the shared machine credential store (D12), and mirror the access token
+                        // into CloudToken so the existing cloud-auth UI + connection fallback keep working
+                        // until the token-field UI is retired in a later PR.
+                        AccountCredentialService.Adopt(credentials);
+                        UnityMcpPluginEditor.CloudToken = credentials.AccessToken;
+                        UnityMcpPluginEditor.Instance.Save();
+                    },
+                    serverTarget: cloudBaseUrl);
                 var capturedFlow = _deviceAuthFlow; // Capture to avoid stale field reference in async callbacks
 
                 capturedFlow.OnStateChanged += state =>
@@ -393,7 +411,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     });
                 };
 
-                await capturedFlow.StartAsync(UnityMcpPlugin.UnityConnectionConfig.CloudServerBaseUrl, "Unity Editor");
+                await capturedFlow.StartAsync();
             };
 
             btnAuthorize.RegisterCallback<ClickEvent>(_ => _startAuthorizeAction?.Invoke());

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
@@ -9,6 +9,7 @@
 */
 
 #nullable enable
+using com.IvanMurzak.Unity.MCP.Editor.Services;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using Microsoft.Extensions.Logging;
 
@@ -57,6 +58,12 @@ namespace com.IvanMurzak.Unity.MCP
                 stopwatch.ElapsedMilliseconds);
 
             SetCurrentPlugin(built);
+
+            // Zero-button auto-adopt (mcp-authorize design 06 / D12): point the Cloud credential provider at
+            // the shared machine store and attach the on-401 refresh→reconnect coordinator. Both are inert
+            // when the machine store holds no credential, so this does not change the anonymous/local path.
+            AccountCredentialService.AttachTo(built);
+
             ApplyConfigToMcpPlugin(built);
 
             return this;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.Config.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.Config.cs
@@ -121,19 +121,47 @@ namespace com.IvanMurzak.Unity.MCP
             }
 
             /// <summary>
+            /// Editor-populated machine-store credential provider (mcp-authorize design 06 / D12 zero-button
+            /// auto-adopt). When set — by <c>AccountCredentialService.Initialize()</c> — a <b>Cloud</b>-mode
+            /// connection presents the proactively-refreshed account JWT read from the shared machine store
+            /// (<c>~/.ai-game-dev/credentials.json</c>); a null/empty result falls back to the mode-routed
+            /// <see cref="Token"/>, and Local/Custom mode ignores it entirely. Static because the machine
+            /// store is per-machine, shared across every config instance and the runtime boot. Runtime-only;
+            /// never serialized.
+            /// </summary>
+            [JsonIgnore]
+            public static Func<Task<string?>>? CloudCredentialProvider { get; set; }
+
+            /// <summary>
             /// McpPlugin 7.0 credential provider (replaces the removed static <c>ConnectionConfig.Token</c>).
-            /// Behaviour-preserving: returns the current mode-routed <see cref="Token"/> on every (re)connect,
-            /// so the same token the pre-7.0 static <c>Token</c> presented is handed to SignalR's
-            /// <c>AccessTokenProvider</c> (the Authorization header). A null token yields an anonymous
-            /// connection — identical to the pre-7.0 empty-token behaviour. Runtime-only; never serialized
-            /// (<see cref="JsonIgnoreAttribute"/>). The setter is intentionally a no-op: Unity derives the
-            /// credential from <see cref="Token"/> rather than from a host-injected provider.
+            /// In <b>Cloud</b> mode it first consults <see cref="CloudCredentialProvider"/> (the shared
+            /// machine-store account credential, proactively refreshed — design 06 / D12); when that yields
+            /// a token it is presented on the (re)connect, giving zero-button sign-in without any UI. When it
+            /// is unset or returns null/empty — and always in Local/Custom mode — it falls back to the
+            /// mode-routed <see cref="Token"/>, so the on-the-wire behaviour is identical to the pre-b7
+            /// static-token connection. A null token yields an anonymous connection. Runtime-only; never
+            /// serialized (<see cref="JsonIgnoreAttribute"/>). The setter is intentionally a no-op: Unity
+            /// derives the credential from the machine store / <see cref="Token"/> rather than from a
+            /// host-injected provider.
             /// </summary>
             [JsonIgnore]
             public override Func<Task<string?>>? CredentialProvider
             {
-                get => () => Task.FromResult<string?>(Token);
-                set { /* Unity derives the credential from Token; a host-set provider is intentionally ignored. */ }
+                get => async () =>
+                {
+                    if (ConnectionMode == ConnectionMode.Cloud)
+                    {
+                        var provider = CloudCredentialProvider;
+                        if (provider != null)
+                        {
+                            var token = await provider().ConfigureAwait(false);
+                            if (!string.IsNullOrEmpty(token))
+                                return token;
+                        }
+                    }
+                    return Token;
+                };
+                set { /* Unity derives the credential from the machine store / Token; a host-set provider is intentionally ignored. */ }
             }
 
             public LogLevel LogLevel { get; set; } = LogLevel.Warning;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 098c54e7b3883a045853a285cc0135c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthFlowTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthFlowTests.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.AgentConfig;
 using com.IvanMurzak.Unity.MCP.Editor.Services;
 using NUnit.Framework;
+using UnityEngine.TestTools;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 {
@@ -199,6 +200,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             var client = new FakeDeviceAuthClient(Authorize(), Array.Empty<DeviceTokenResponse>(),
                 authorizeError: new HttpRequestException("network down"));
             var flow = NewFlow(client, _ => { });
+
+            // The transport-error path intentionally logs an error ("Device auth flow failed")
+            // before transitioning to Failed; tell the Unity test runner that error log is expected
+            // so it doesn't fail this negative-path test on the unhandled error message.
+            LogAssert.ignoreFailingMessages = true;
 
             Run(flow);
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthFlowTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthFlowTests.cs
@@ -1,0 +1,209 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Drives the <see cref="DeviceAuthFlow"/> state machine against a mocked authorization server
+    /// (<see cref="FakeDeviceAuthClient"/>) with a no-op browser + zero delay, so it runs fully in-process
+    /// with no live network. Verifies the terminal states and that a successful flow yields a
+    /// <see cref="MachineCredentials"/> carrying the access token, refresh token, expiry, and server target.
+    /// </summary>
+    public class DeviceAuthFlowTests
+    {
+        /// <summary>An <see cref="IDeviceAuthClient"/> stub returning canned responses (all completed tasks).</summary>
+        sealed class FakeDeviceAuthClient : IDeviceAuthClient
+        {
+            readonly DeviceAuthorizeResponse _authorize;
+            readonly Queue<DeviceTokenResponse> _tokens;
+            readonly Exception? _authorizeError;
+            readonly Exception? _pollError;
+
+            public int RequestCount { get; private set; }
+            public int PollCount { get; private set; }
+
+            public FakeDeviceAuthClient(DeviceAuthorizeResponse authorize, IEnumerable<DeviceTokenResponse> tokens,
+                Exception? authorizeError = null, Exception? pollError = null)
+            {
+                _authorize = authorize;
+                _tokens = new Queue<DeviceTokenResponse>(tokens);
+                _authorizeError = authorizeError;
+                _pollError = pollError;
+            }
+
+            public Task<DeviceAuthorizeResponse> RequestDeviceCodeAsync(CancellationToken ct = default)
+            {
+                RequestCount++;
+                if (_authorizeError != null)
+                    return Task.FromException<DeviceAuthorizeResponse>(_authorizeError);
+                return Task.FromResult(_authorize);
+            }
+
+            public Task<DeviceTokenResponse> PollTokenAsync(string deviceCode, CancellationToken ct = default)
+            {
+                PollCount++;
+                if (_pollError != null)
+                    return Task.FromException<DeviceTokenResponse>(_pollError);
+                return Task.FromResult(_tokens.Count > 0 ? _tokens.Dequeue() : Pending());
+            }
+        }
+
+        static DeviceAuthorizeResponse Authorize() => new DeviceAuthorizeResponse
+        {
+            DeviceCode = "DC-1",
+            UserCode = "WXYZ-1234",
+            VerificationUri = "https://ai-game.dev/device",
+            VerificationUriComplete = "https://ai-game.dev/device?code=WXYZ-1234",
+            ExpiresIn = 600,
+            Interval = 5,
+        };
+
+        static DeviceTokenResponse Pending() => new DeviceTokenResponse { Error = "authorization_pending" };
+        static DeviceTokenResponse SlowDown() => new DeviceTokenResponse { Error = "slow_down" };
+        static DeviceTokenResponse Denied() => new DeviceTokenResponse { Error = "access_denied" };
+        static DeviceTokenResponse Expired() => new DeviceTokenResponse { Error = "expired_token" };
+        static DeviceTokenResponse Success() => new DeviceTokenResponse
+        {
+            AccessToken = "es256.jwt",
+            RefreshToken = "rt-1",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            Scope = "mcp:plugin",
+        };
+
+        static DeviceAuthFlow NewFlow(IDeviceAuthClient client, Action<MachineCredentials> onAuthorized,
+            Func<TimeSpan, CancellationToken, Task>? delay = null, Action<string>? openBrowser = null)
+            => new DeviceAuthFlow(
+                client,
+                onAuthorized,
+                serverTarget: "https://ai-game.dev",
+                openBrowser: openBrowser ?? (_ => { }),
+                delay: delay ?? ((_, __) => Task.CompletedTask));
+
+        static void Run(DeviceAuthFlow flow) => flow.StartAsync().GetAwaiter().GetResult();
+
+        [Test]
+        public void HappyPath_Reaches_Authorized_And_Adopts_Credential()
+        {
+            MachineCredentials? adopted = null;
+            var states = new List<DeviceAuthFlowState>();
+            var client = new FakeDeviceAuthClient(Authorize(), new[] { Pending(), Success() });
+            var flow = NewFlow(client, c => adopted = c);
+            flow.OnStateChanged += states.Add;
+
+            Run(flow);
+
+            Assert.AreEqual(DeviceAuthFlowState.Authorized, flow.State);
+            Assert.AreEqual("WXYZ-1234", flow.UserCode);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    DeviceAuthFlowState.Initiating,
+                    DeviceAuthFlowState.WaitingForUser,
+                    DeviceAuthFlowState.Polling,
+                    DeviceAuthFlowState.Authorized,
+                },
+                states);
+
+            Assert.IsNotNull(adopted);
+            Assert.AreEqual("es256.jwt", adopted!.AccessToken);
+            Assert.AreEqual("rt-1", adopted.RefreshToken);
+            Assert.AreEqual("https://ai-game.dev", adopted.ServerTarget);
+            Assert.IsNotNull(adopted.ExpiresAt);
+            Assert.Greater(adopted.ExpiresAt!.Value, DateTimeOffset.UtcNow);
+        }
+
+        [Test]
+        public void OpensVerificationUrl_ForTheUser()
+        {
+            string? opened = null;
+            var client = new FakeDeviceAuthClient(Authorize(), new[] { Success() });
+            var flow = NewFlow(client, _ => { }, openBrowser: url => opened = url);
+
+            Run(flow);
+
+            Assert.AreEqual("https://ai-game.dev/device?code=WXYZ-1234", opened);
+        }
+
+        [Test]
+        public void SlowDown_KeepsPolling_UntilSuccess()
+        {
+            MachineCredentials? adopted = null;
+            var client = new FakeDeviceAuthClient(Authorize(), new[] { SlowDown(), Pending(), Success() });
+            var flow = NewFlow(client, c => adopted = c);
+
+            Run(flow);
+
+            Assert.AreEqual(DeviceAuthFlowState.Authorized, flow.State);
+            Assert.AreEqual(3, client.PollCount);
+            Assert.IsNotNull(adopted);
+        }
+
+        [Test]
+        public void AccessDenied_Reaches_Failed_WithMessage_AndNoCredential()
+        {
+            var adopted = false;
+            var client = new FakeDeviceAuthClient(Authorize(), new[] { Denied() });
+            var flow = NewFlow(client, _ => adopted = true);
+
+            Run(flow);
+
+            Assert.AreEqual(DeviceAuthFlowState.Failed, flow.State);
+            Assert.AreEqual("Authorization was denied.", flow.ErrorMessage);
+            Assert.IsFalse(adopted);
+        }
+
+        [Test]
+        public void ExpiredToken_Reaches_Expired()
+        {
+            var client = new FakeDeviceAuthClient(Authorize(), new[] { Expired() });
+            var flow = NewFlow(client, _ => { });
+
+            Run(flow);
+
+            Assert.AreEqual(DeviceAuthFlowState.Expired, flow.State);
+        }
+
+        [Test]
+        public void Cancellation_DuringPoll_Reaches_Cancelled()
+        {
+            var client = new FakeDeviceAuthClient(Authorize(), Array.Empty<DeviceTokenResponse>(),
+                pollError: new OperationCanceledException());
+            var flow = NewFlow(client, _ => { });
+
+            Run(flow);
+
+            Assert.AreEqual(DeviceAuthFlowState.Cancelled, flow.State);
+        }
+
+        [Test]
+        public void TransportError_Reaches_Failed_WithMessage()
+        {
+            var client = new FakeDeviceAuthClient(Authorize(), Array.Empty<DeviceTokenResponse>(),
+                authorizeError: new HttpRequestException("network down"));
+            var flow = NewFlow(client, _ => { });
+
+            Run(flow);
+
+            Assert.AreEqual(DeviceAuthFlowState.Failed, flow.State);
+            Assert.AreEqual("network down", flow.ErrorMessage);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthFlowTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthFlowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad6e53057f4952d4e9a4899df8e17602
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthServiceTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthServiceTests.cs
@@ -1,0 +1,114 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// RFC 8628 request-building + response-parsing coverage for <see cref="DeviceAuthService"/> against a
+    /// mocked authorization server (canned JSON), with no live network. Exercises the exact
+    /// <c>client_id</c> + <c>scope=mcp:plugin</c> form the ai-game.dev AS requires and the token/refresh
+    /// response shapes.
+    /// </summary>
+    public class DeviceAuthServiceTests
+    {
+        static string Value(IReadOnlyList<KeyValuePair<string, string>> form, string key)
+            => form.First(kv => kv.Key == key).Value;
+
+        [Test]
+        public void DeviceAuthorizeForm_Carries_ClientId_And_PluginScope()
+        {
+            var form = DeviceAuthService.BuildDeviceAuthorizeForm(DeviceAuthService.DefaultClientId, DeviceAuthService.PluginScope);
+            Assert.AreEqual(DeviceAuthService.DefaultClientId, Value(form, "client_id"));
+            Assert.AreEqual("mcp:plugin", Value(form, "scope"));
+        }
+
+        [Test]
+        public void DeviceTokenForm_Carries_DeviceCodeGrant_And_ClientId()
+        {
+            var form = DeviceAuthService.BuildDeviceTokenForm("dc-123", DeviceAuthService.DefaultClientId);
+            Assert.AreEqual("urn:ietf:params:oauth:grant-type:device_code", Value(form, "grant_type"));
+            Assert.AreEqual("dc-123", Value(form, "device_code"));
+            Assert.AreEqual(DeviceAuthService.DefaultClientId, Value(form, "client_id"));
+        }
+
+        [Test]
+        public void Endpoints_Resolve_On_The_AS_Root_Without_Double_Slash()
+        {
+            Assert.AreEqual("https://ai-game.dev/oauth/device_authorization", DeviceAuthService.DeviceAuthorizeUrl("https://ai-game.dev"));
+            Assert.AreEqual("https://ai-game.dev/oauth/device_authorization", DeviceAuthService.DeviceAuthorizeUrl("https://ai-game.dev/"));
+            Assert.AreEqual("https://ai-game.dev/oauth/token", DeviceAuthService.TokenUrl("https://ai-game.dev/"));
+        }
+
+        [Test]
+        public void ParseDeviceAuthorizeResponse_Reads_RFC8628_Document()
+        {
+            const string json = @"{
+                ""device_code"": ""DC-abc"",
+                ""user_code"": ""WXYZ-1234"",
+                ""verification_uri"": ""https://ai-game.dev/device"",
+                ""verification_uri_complete"": ""https://ai-game.dev/device?code=WXYZ-1234"",
+                ""expires_in"": 600,
+                ""interval"": 5
+            }";
+
+            var parsed = DeviceAuthService.ParseDeviceAuthorizeResponse(json);
+            Assert.AreEqual("DC-abc", parsed.DeviceCode);
+            Assert.AreEqual("WXYZ-1234", parsed.UserCode);
+            Assert.AreEqual("https://ai-game.dev/device", parsed.VerificationUri);
+            Assert.AreEqual("https://ai-game.dev/device?code=WXYZ-1234", parsed.VerificationUriComplete);
+            Assert.AreEqual(600, parsed.ExpiresIn);
+            Assert.AreEqual(5, parsed.Interval);
+        }
+
+        [Test]
+        public void ParseDeviceTokenResponse_Reads_AccessToken_RefreshToken_ExpiresIn()
+        {
+            const string json = @"{
+                ""access_token"": ""es256.jwt.here"",
+                ""token_type"": ""Bearer"",
+                ""expires_in"": 3600,
+                ""refresh_token"": ""rt-rotating"",
+                ""scope"": ""mcp:plugin""
+            }";
+
+            var parsed = DeviceAuthService.ParseDeviceTokenResponse(json);
+            Assert.AreEqual("es256.jwt.here", parsed.AccessToken);
+            Assert.AreEqual("rt-rotating", parsed.RefreshToken);
+            Assert.AreEqual(3600, parsed.ExpiresIn);
+            Assert.AreEqual("mcp:plugin", parsed.Scope);
+            Assert.IsNull(parsed.Error);
+        }
+
+        [Test]
+        public void ParseDeviceTokenResponse_Reads_Pending_Error_Body()
+        {
+            const string json = @"{ ""error"": ""authorization_pending"", ""error_description"": ""pending"" }";
+            var parsed = DeviceAuthService.ParseDeviceTokenResponse(json);
+            Assert.IsNull(parsed.AccessToken);
+            Assert.AreEqual("authorization_pending", parsed.Error);
+        }
+
+        [Test]
+        public void Defaults_Apply_When_ClientId_Or_Scope_Omitted()
+        {
+            // A blank client id / scope should fall back to the plugin defaults rather than sending empty values.
+            var service = new DeviceAuthService("https://ai-game.dev", clientId: " ", scope: "");
+            Assert.IsNotNull(service);
+            Assert.AreEqual("unity-mcp-plugin", DeviceAuthService.DefaultClientId);
+            Assert.AreEqual("mcp:plugin", DeviceAuthService.PluginScope);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthServiceTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/DeviceAuthServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45fa38d150a5632458393cebbca924aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/MachineCredentialTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/MachineCredentialTests.cs
@@ -1,0 +1,179 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Shared machine credential store round-trip + the zero-button auto-adopt behaviour (mcp-authorize
+    /// design 06 / D12), exercised over a temporary store directory so nothing touches the real
+    /// <c>~/.ai-game-dev/</c>. The refresh path (proactive + reactive) is driven by a mocked authorization
+    /// server (<see cref="FakeTokenRefresher"/>), so there is no live network.
+    /// </summary>
+    public class MachineCredentialTests
+    {
+        sealed class FakeTokenRefresher : ITokenRefresher
+        {
+            readonly TokenRefreshResult _result;
+            public int Calls { get; private set; }
+            public string? LastRefreshToken { get; private set; }
+
+            public FakeTokenRefresher(TokenRefreshResult result) => _result = result;
+
+            public Task<TokenRefreshResult> RefreshAsync(string refreshToken, string? serverTarget, CancellationToken cancellationToken = default)
+            {
+                Calls++;
+                LastRefreshToken = refreshToken;
+                return Task.FromResult(_result);
+            }
+        }
+
+        string _dir = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dir = Path.Combine(Path.GetTempPath(), "agd-cred-tests-" + Guid.NewGuid().ToString("N"));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+
+        MachineCredentialStore NewStore() => new MachineCredentialStore(_dir);
+
+        [Test]
+        public void Store_RoundTrips_Credentials()
+        {
+            var store = NewStore();
+            Assert.IsFalse(store.Exists);
+
+            var expiry = DateTimeOffset.UtcNow.AddHours(1);
+            store.Write(new MachineCredentials
+            {
+                AccessToken = "es256.jwt",
+                RefreshToken = "rt-1",
+                ExpiresAt = expiry,
+                ServerTarget = "https://ai-game.dev",
+                Subject = "acct-123",
+            });
+
+            Assert.IsTrue(store.Exists);
+            var read = store.Read();
+            Assert.IsNotNull(read);
+            Assert.AreEqual("es256.jwt", read!.AccessToken);
+            Assert.AreEqual("rt-1", read.RefreshToken);
+            Assert.AreEqual("https://ai-game.dev", read.ServerTarget);
+            Assert.AreEqual("acct-123", read.Subject);
+            Assert.AreEqual(expiry.ToUnixTimeSeconds(), read.ExpiresAt!.Value.ToUnixTimeSeconds());
+        }
+
+        [Test]
+        public void EmptyStore_AutoAdopt_IsSignedOut()
+        {
+            using var provider = new PluginCredentialProvider(NewStore());
+            Assert.IsFalse(provider.IsSignedIn);
+            Assert.IsNull(provider.AsAccessTokenProvider()().GetAwaiter().GetResult());
+        }
+
+        [Test]
+        public void PopulatedStore_AutoAdopts_SignedIn_ZeroButton()
+        {
+            var store = NewStore();
+            store.Write(new MachineCredentials
+            {
+                AccessToken = "es256.jwt",
+                RefreshToken = "rt-1",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+
+            // Construction reads the store — a present credential means SignedIn with no UI interaction.
+            using var provider = new PluginCredentialProvider(store);
+            Assert.IsTrue(provider.IsSignedIn);
+            Assert.AreEqual("es256.jwt", provider.AsAccessTokenProvider()().GetAwaiter().GetResult());
+            Assert.AreEqual("https://ai-game.dev", provider.ServerTarget);
+        }
+
+        [Test]
+        public void ProactiveRefresh_NearExpiry_MintsAndPersists_NewToken()
+        {
+            var store = NewStore();
+            store.Write(new MachineCredentials
+            {
+                AccessToken = "old.jwt",
+                RefreshToken = "rt-old",
+                ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(5), // within the 60s proactive-refresh skew
+                ServerTarget = "https://ai-game.dev",
+            });
+
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Success(
+                "new.jwt", "rt-new", DateTimeOffset.UtcNow.AddHours(1)));
+            using var provider = new PluginCredentialProvider(store, refresher);
+
+            var token = provider.AsAccessTokenProvider()().GetAwaiter().GetResult();
+
+            Assert.AreEqual("new.jwt", token);
+            Assert.AreEqual(1, refresher.Calls);
+            Assert.AreEqual("rt-old", refresher.LastRefreshToken);
+            // The rotated credential is persisted back to the store (survives a restart).
+            var persisted = store.Read();
+            Assert.AreEqual("new.jwt", persisted!.AccessToken);
+            Assert.AreEqual("rt-new", persisted.RefreshToken);
+        }
+
+        [Test]
+        public void ReactiveRefresh_Failure_SurfacesSignInRequired()
+        {
+            var store = NewStore();
+            store.Write(new MachineCredentials
+            {
+                AccessToken = "old.jwt",
+                RefreshToken = "rt-old",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+                ServerTarget = "https://ai-game.dev",
+            });
+
+            var refresher = new FakeTokenRefresher(TokenRefreshResult.Failure("refresh token expired"));
+            using var provider = new PluginCredentialProvider(store, refresher);
+
+            var refreshed = provider.RefreshAsync().GetAwaiter().GetResult();
+
+            Assert.IsFalse(refreshed);
+            Assert.AreEqual(AuthState.SignInRequired, provider.State.CurrentValue);
+        }
+
+        [Test]
+        public void SignOut_Deletes_StoredCredential()
+        {
+            var store = NewStore();
+            store.Write(new MachineCredentials { AccessToken = "es256.jwt", RefreshToken = "rt-1" });
+
+            using var provider = new PluginCredentialProvider(store);
+            Assert.IsTrue(provider.IsSignedIn);
+
+            provider.SignOut();
+
+            Assert.IsFalse(provider.IsSignedIn);
+            Assert.IsFalse(store.Exists);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/MachineCredentialTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/MachineCredentialTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcf6fb6924c87e74f8bfcfbe288d4b1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityConnectionConfigCredentialProviderTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityConnectionConfigCredentialProviderTests.cs
@@ -1,0 +1,85 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// The machine-store credential wins over the mode-routed token in Cloud mode, and is ignored in
+    /// Custom/Local mode (mcp-authorize design 06 / D12). This is the seam that makes zero-button boot
+    /// present the shared account JWT while preserving the anonymous/local behaviour when signed out.
+    /// </summary>
+    public class UnityConnectionConfigCredentialProviderTests
+    {
+        System.Func<Task<string?>>? _saved;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _saved = UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider;
+            UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = _saved;
+        }
+
+        static UnityMcpPlugin.UnityConnectionConfig NewConfig(ConnectionMode mode, string? cloudToken, string? localToken)
+        {
+            var config = new UnityMcpPlugin.UnityConnectionConfig
+            {
+                ConnectionMode = mode,
+                CloudToken = cloudToken,
+                LocalToken = localToken,
+            };
+            return config;
+        }
+
+        static string? Resolve(UnityMcpPlugin.UnityConnectionConfig config)
+            => config.CredentialProvider!().GetAwaiter().GetResult();
+
+        [Test]
+        public void Cloud_WithMachineCredential_PresentsMachineJwt()
+        {
+            UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = () => Task.FromResult<string?>("machine-jwt");
+            var config = NewConfig(ConnectionMode.Cloud, cloudToken: "cloud-tok", localToken: "local-tok");
+            Assert.AreEqual("machine-jwt", Resolve(config));
+        }
+
+        [Test]
+        public void Cloud_MachineCredentialEmpty_FallsBackToCloudToken()
+        {
+            UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = () => Task.FromResult<string?>(null);
+            var config = NewConfig(ConnectionMode.Cloud, cloudToken: "cloud-tok", localToken: "local-tok");
+            Assert.AreEqual("cloud-tok", Resolve(config));
+        }
+
+        [Test]
+        public void Cloud_NoMachineProvider_UsesCloudToken()
+        {
+            // CloudCredentialProvider is null (set in SetUp) — behaviour identical to the pre-b7 static token.
+            var config = NewConfig(ConnectionMode.Cloud, cloudToken: "cloud-tok", localToken: "local-tok");
+            Assert.AreEqual("cloud-tok", Resolve(config));
+        }
+
+        [Test]
+        public void Custom_IgnoresMachineCredential_UsesLocalToken()
+        {
+            UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = () => Task.FromResult<string?>("machine-jwt");
+            var config = NewConfig(ConnectionMode.Custom, cloudToken: "cloud-tok", localToken: "local-tok");
+            Assert.AreEqual("local-tok", Resolve(config));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityConnectionConfigCredentialProviderTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityConnectionConfigCredentialProviderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eee79251cd81bb3439ee9215629d1137
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityTokenRefresherTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityTokenRefresherTests.cs
@@ -1,0 +1,91 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Pure coverage of <see cref="UnityTokenRefresher"/>'s refresh-request form and its fail-closed
+    /// result mapping — the <c>ITokenRefresher</c> Unity wires into the shared credential provider.
+    /// </summary>
+    public class UnityTokenRefresherTests
+    {
+        static string Value(IReadOnlyList<KeyValuePair<string, string>> form, string key)
+            => form.First(kv => kv.Key == key).Value;
+
+        [Test]
+        public void RefreshForm_Is_RefreshTokenGrant()
+        {
+            var form = UnityTokenRefresher.BuildRefreshForm("rt-1", "unity-mcp-plugin", "mcp:plugin");
+            Assert.AreEqual("refresh_token", Value(form, "grant_type"));
+            Assert.AreEqual("rt-1", Value(form, "refresh_token"));
+            Assert.AreEqual("unity-mcp-plugin", Value(form, "client_id"));
+            Assert.AreEqual("mcp:plugin", Value(form, "scope"));
+        }
+
+        [Test]
+        public void BuildResult_Success_CarriesTokensAndExpiry()
+        {
+            var parsed = new DeviceTokenResponse { AccessToken = "new.jwt", RefreshToken = "rt-new", ExpiresIn = 3600 };
+            var result = UnityTokenRefresher.BuildResult(isSuccessStatusCode: true, statusCode: 200, parsed);
+            Assert.IsTrue(result.Succeeded);
+            Assert.AreEqual("new.jwt", result.AccessToken);
+            Assert.AreEqual("rt-new", result.RefreshToken);
+            Assert.IsNotNull(result.ExpiresAt);
+        }
+
+        [Test]
+        public void BuildResult_HttpError_FailsClosed_WithReason()
+        {
+            var parsed = new DeviceTokenResponse { Error = "invalid_grant" };
+            var result = UnityTokenRefresher.BuildResult(isSuccessStatusCode: false, statusCode: 400, parsed);
+            Assert.IsFalse(result.Succeeded);
+            Assert.AreEqual("invalid_grant", result.FailureReason);
+            Assert.IsNull(result.AccessToken);
+        }
+
+        [Test]
+        public void BuildResult_SuccessStatus_ButNoToken_FailsClosed()
+        {
+            var parsed = new DeviceTokenResponse { AccessToken = null };
+            var result = UnityTokenRefresher.BuildResult(isSuccessStatusCode: true, statusCode: 200, parsed);
+            Assert.IsFalse(result.Succeeded);
+        }
+
+        [Test]
+        public void BuildResult_NullBody_FailsClosed()
+        {
+            var result = UnityTokenRefresher.BuildResult(isSuccessStatusCode: true, statusCode: 200, parsed: null);
+            Assert.IsFalse(result.Succeeded);
+        }
+
+        [TestCase("https://ai-game.dev/mcp/", "https://ai-game.dev")]
+        [TestCase("https://ai-game.dev/mcp", "https://ai-game.dev")]
+        [TestCase("https://ai-game.dev/", "https://ai-game.dev")]
+        [TestCase("https://ai-game.dev", "https://ai-game.dev")]
+        public void NormalizeBase_TrimsSlash_And_McpHubSegment(string input, string expected)
+        {
+            Assert.AreEqual(expected, UnityTokenRefresher.NormalizeBase(input));
+        }
+
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase(null)]
+        public void NormalizeBase_BlankIsNull(string? input)
+        {
+            Assert.IsNull(UnityTokenRefresher.NormalizeBase(input));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityTokenRefresherTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityTokenRefresherTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 690e1bb63c29c0a429c2f522a681f2df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
mcp-authorize **d1-PR2** (Unity device flow) — PR 2 of the Unity engine wave, on top of the foundation (#875).

Delivers RFC 8628 device flow (`/oauth/device_authorization` + `/oauth/token` against the live ai-game.dev AS), credential persistence in the shared machine store (`~/.ai-game-dev/credentials.json`, via McpPlugin 7.0 `MachineCredentialStore`), zero-button boot auto-adopt (read store → connect, no UI), and a full EditMode test suite.

Scope: device flow only (instance-metadata handshake / port / UI are later PRs).

Note: the original implement-task run was cut off by the account token limit during local Unity verification with all code + tests already written; this PR carries that completed WIP through CI for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)