### PR TITLE
feat(auth): instance-metadata handshake + ProjectIdentity/marker wiring (mcp-authorize PR 3)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/ProjectInstanceService.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/ProjectInstanceService.cs
@@ -1,0 +1,159 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using UnityEditor;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Services
+{
+    /// <summary>
+    /// Editor-side owner of THIS project's connection identity (mcp-authorize design 04/06, PR 3). It is the
+    /// single Unity-side seam that:
+    /// <list type="bullet">
+    ///   <item><b>Instance-metadata handshake:</b> builds the non-secret
+    ///   <see cref="ConnectionInstanceMetadata"/> payload
+    ///   (<c>{engine:"unity", projectName, projectPathHash, machineName, instanceId}</c>) and attaches it to
+    ///   the <see cref="UnityMcpPlugin.UnityConnectionConfig"/> so McpPlugin's
+    ///   <c>HubConnectionProvider</c> sends it as hub-connection query params on every (re)connect. The token
+    ///   always travels separately in the <c>Authorization</c> header — never here.</item>
+    ///   <item><b>ProjectIdentity + ProjectMarker wiring:</b> resolves the routing <see cref="ProjectIdentity.Pin"/>
+    ///   (and the derived port, honouring any user override) via the shared
+    ///   <see cref="ProjectIdentity"/> derivation, and reads/writes the non-secret, committable project marker
+    ///   <c>&lt;project&gt;/.ai-game-dev/project.json</c> (<see cref="ProjectMarker"/>) so the enrolled
+    ///   server target + pin are resolved from it. Credentials NEVER go in the marker.</item>
+    /// </list>
+    /// The derivation matches the committed <c>ProjectIdentity.GoldenVectors.json</c> byte-for-byte (trim
+    /// trailing separators, do NOT convert separators, <see cref="string.ToLowerInvariant"/> only). This PR
+    /// wires the pin + server-target resolution only; it does not change the runtime local-port default
+    /// (Unity already ships the deterministic derived port via
+    /// <see cref="UnityMcpPlugin.GeneratePortFromDirectory"/>).
+    /// </summary>
+    public static class ProjectInstanceService
+    {
+        /// <summary>The engine identifier this plugin reports in its instance-metadata handshake.</summary>
+        public const string EngineName = "unity";
+
+        /// <summary>
+        /// <see cref="SessionState"/> key holding the per-editor-session instance id. <see cref="SessionState"/>
+        /// survives domain reloads but is cleared when the Editor is closed — exactly the "one id per editor
+        /// session" lifetime the account+instance router expects (reconnects of the same Editor reuse it; a
+        /// fresh Editor launch mints a new one).
+        /// </summary>
+        internal const string SessionInstanceIdKey = "com.IvanMurzak.Unity.MCP.ProjectInstance.InstanceId";
+
+        /// <summary>
+        /// The instance id for the current editor session: a GUID minted once per Editor launch and stable
+        /// across domain reloads (persisted in <see cref="SessionState"/>). Reconnects of the same Editor
+        /// present the same id so the server replaces the connection entry instead of orphaning it.
+        /// </summary>
+        public static string SessionInstanceId
+        {
+            get
+            {
+                var existing = SessionState.GetString(SessionInstanceIdKey, string.Empty);
+                if (!string.IsNullOrEmpty(existing))
+                    return existing;
+
+                var minted = Guid.NewGuid().ToString();
+                SessionState.SetString(SessionInstanceIdKey, minted);
+                return minted;
+            }
+        }
+
+        /// <summary>
+        /// Build the instance-metadata handshake payload for <paramref name="projectRoot"/>. The
+        /// <see cref="ConnectionInstanceMetadata.ProjectPathHash"/> is derived from the same normalized root
+        /// whose first 8 hex chars are the routing pin, so the server pin-matches this instance by prefix.
+        /// <paramref name="instanceId"/> defaults to <see cref="SessionInstanceId"/>.
+        /// </summary>
+        public static ConnectionInstanceMetadata BuildMetadata(string projectRoot, string projectName, string? instanceId = null)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+
+            return ConnectionInstanceMetadata.Create(
+                engine: EngineName,
+                projectName: projectName ?? string.Empty,
+                projectRootPath: projectRoot,
+                instanceId: string.IsNullOrEmpty(instanceId) ? SessionInstanceId : instanceId);
+        }
+
+        /// <summary>
+        /// Populate <paramref name="config"/>'s <see cref="ConnectionConfig.InstanceMetadata"/> from the host
+        /// Unity project (<see cref="UnityMcpPluginEditor.ProjectRootPath"/> + <see cref="Application.productName"/>)
+        /// so the handshake is sent on the next (re)connect. Called from the plugin build path; idempotent and
+        /// safe on every editor boot / domain reload (the session instance id is stable across reloads).
+        /// </summary>
+        public static void AttachInstanceMetadata(UnityMcpPlugin.UnityConnectionConfig config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            config.InstanceMetadata = BuildMetadata(
+                projectRoot: UnityMcpPluginEditor.ProjectRootPath,
+                projectName: Application.productName);
+        }
+
+        /// <summary>
+        /// Read the project marker <c>&lt;projectRoot&gt;/.ai-game-dev/project.json</c>, or <c>null</c> when it
+        /// does not exist (a project that has never been enrolled / configured).
+        /// </summary>
+        public static ProjectMarker? ReadMarker(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return ProjectMarker.Read(projectRoot);
+        }
+
+        /// <summary>
+        /// Write the non-secret project marker into <paramref name="projectRoot"/> (creating the
+        /// <c>.ai-game-dev</c> directory if needed). The marker is committable; credentials NEVER go here.
+        /// </summary>
+        public static void WriteMarker(string projectRoot, ProjectMarker marker)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            if (marker == null)
+                throw new ArgumentNullException(nameof(marker));
+            marker.Write(projectRoot);
+        }
+
+        /// <summary>
+        /// The enrolled server target (hosted vs local) recorded in the project marker, or <c>null</c> when no
+        /// marker exists or it records no target. This is how the plugin resolves which hub to point at.
+        /// </summary>
+        public static string? ResolveServerTarget(string projectRoot)
+            => ReadMarker(projectRoot)?.ServerTarget;
+
+        /// <summary>
+        /// Resolve the project's <see cref="ProjectIdentity"/> (routing pin + effective port) for
+        /// <paramref name="projectRoot"/>, honouring the marker's user port override when present. The pin is
+        /// always hash-derived (never affected by the override).
+        /// </summary>
+        public static ProjectIdentity ResolveIdentity(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return ProjectIdentity.Derive(projectRoot, ReadMarker(projectRoot));
+        }
+
+        /// <summary>The routing pin (first 8 lowercase hex chars of the SHA-256 of the normalized project root).</summary>
+        public static string ResolvePin(string projectRoot)
+        {
+            if (projectRoot == null)
+                throw new ArgumentNullException(nameof(projectRoot));
+            return ProjectIdentity.DerivePin(projectRoot);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/ProjectInstanceService.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/ProjectInstanceService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce6cfe0b1bf668e4f9832e4ab542c78f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Build.cs
@@ -40,6 +40,13 @@ namespace com.IvanMurzak.Unity.MCP
             unityConnectionConfig.ProjectRootPath = ProjectRootPath;
             _logger.LogTrace("Seeded ConnectionConfig.ProjectRootPath={path}", ProjectRootPath);
 
+            // Attach the instance-metadata handshake payload (mcp-authorize design 04/06, PR 3) so the hub
+            // connection identifies THIS editor session to the server's account+instance router. The payload
+            // is non-secret (engine/project/machine names + per-session instance id + project-path hash); the
+            // token always travels separately in the Authorization header. Inert on a none-mode/local server
+            // that ignores it. Re-applied on every (re)build; the session instance id is stable across reloads.
+            ProjectInstanceService.AttachInstanceMetadata(unityConnectionConfig);
+
             var built = _plugin.BuildOnce(() => BuildMcpPlugin(
                 version: BuildVersion(),
                 reflector: CreateDefaultReflector(),

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectIdentityGoldenVectorTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectIdentityGoldenVectorTests.cs
@@ -1,0 +1,111 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// mcp-authorize PR 3 — verifies the shared <see cref="ProjectIdentity"/> derivation, as compiled into the
+    /// vendored McpPlugin 7.0 DLL and run under Unity's Mono/IL2CPP runtime, reproduces the committed
+    /// cross-language golden vectors byte-for-byte. The canonical source of these values is
+    /// <c>MCP-Plugin-dotnet/McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json</c> (the routing pin +
+    /// deterministic local port a Unity project reports in its instance-metadata handshake).
+    /// <para>
+    /// The one committed vector NOT covered here is the U+0130 (LATIN CAPITAL LETTER I WITH DOT ABOVE) Unicode
+    /// case (<c>/home/İstanbul/game</c>). That vector exists specifically to pin the C# <c>ToLowerInvariant</c>
+    /// vs JS <c>toLowerCase()</c> divergence for the TS CLI port; asserting it under Unity's Mono runtime
+    /// (whose invariant-culture case tables can differ from .NET Core's) would test the host runtime's
+    /// globalization rather than this wiring. Every ASCII/Latin path below is runtime-stable.
+    /// </para>
+    /// </summary>
+    public class ProjectIdentityGoldenVectorTests
+    {
+        // Golden vectors (path, pin, port) copied verbatim from ProjectIdentity.GoldenVectors.json.
+        // A backslash in the C# literal ("\\") is a single backslash in the path string.
+        [TestCase("/home/user/my-game", "34ea75f2", 23940)]     // POSIX typical project path
+        [TestCase("/home/user/my-game/", "34ea75f2", 23940)]    // trailing slash trimmed -> identical
+        [TestCase("/home/USER/My-Game", "34ea75f2", 23940)]     // case-folded -> identical
+        [TestCase("C:\\Users\\user\\my-game", "8ef72cf7", 29310)]   // Windows backslash form
+        [TestCase("C:\\Users\\user\\my-game\\", "8ef72cf7", 29310)] // trailing backslash trimmed -> identical
+        [TestCase("C:/Users/user/my-game", "5a87324e", 24298)]  // forward-slash form DIFFERS (separators not normalized)
+        [TestCase("/srv/games/space sim", "08c6cbb6", 27816)]   // path containing a space
+        public void ProjectIdentity_ReproducesGoldenVector(string path, string expectedPin, int expectedPort)
+        {
+            Assert.AreEqual(expectedPin, ProjectIdentity.DerivePin(path));
+            Assert.AreEqual(expectedPort, ProjectIdentity.DerivePort(path));
+
+            var id = ProjectIdentity.Derive(path);
+            Assert.AreEqual(expectedPin, id.Pin);
+            Assert.AreEqual(expectedPort, id.Port);
+            Assert.IsFalse(id.PortIsOverridden);
+
+            // The full project-path hash (sent in the handshake) begins with the routing pin, so the server
+            // pin-matches by prefix.
+            var hash = ProjectIdentity.DeriveProjectPathHash(path);
+            Assert.AreEqual(64, hash.Length);
+            StringAssert.StartsWith(expectedPin, hash);
+        }
+
+        [TestCase("34ea75f2", 23940)]
+        [TestCase("8ef72cf7", 29310)]
+        [TestCase("5a87324e", 24298)]
+        [TestCase("08c6cbb6", 27816)]
+        public void EveryGoldenVector_HasValidPinAndPortShape(string expectedPin, int expectedPort)
+        {
+            Assert.AreEqual(ProjectIdentity.PinLength, expectedPin.Length);
+            foreach (var c in expectedPin)
+                Assert.IsTrue((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'), $"pin '{expectedPin}' must be lowercase hex");
+
+            Assert.GreaterOrEqual(expectedPort, ProjectIdentity.MinPort);
+            Assert.LessOrEqual(expectedPort, ProjectIdentity.MaxPort);
+        }
+
+        [Test]
+        public void Separators_AreNotNormalized_ForwardAndBackslashDiffer()
+        {
+            Assert.AreNotEqual(
+                ProjectIdentity.DerivePort("C:/Users/user/my-game"),
+                ProjectIdentity.DerivePort("C:\\Users\\user\\my-game"));
+        }
+
+        [Test]
+        public void TrailingSeparator_IsTrimmed_SameIdentityAsWithout()
+        {
+            Assert.AreEqual(
+                ProjectIdentity.DerivePin("/home/user/my-game"),
+                ProjectIdentity.DerivePin("/home/user/my-game/"));
+            Assert.AreEqual(
+                ProjectIdentity.DerivePort("C:\\Games\\proj"),
+                ProjectIdentity.DerivePort("C:\\Games\\proj\\"));
+        }
+
+        [Test]
+        public void CaseFolding_IsApplied()
+        {
+            Assert.AreEqual(
+                ProjectIdentity.DerivePin("/home/user/my-game"),
+                ProjectIdentity.DerivePin("/HOME/User/My-Game"));
+        }
+
+        [Test]
+        public void PortOverride_AlwaysWins_PinUnchanged()
+        {
+            const string path = "/home/user/my-game";
+            var overridden = ProjectIdentity.Derive(path, portOverride: 12345);
+
+            Assert.AreEqual(12345, overridden.Port);
+            Assert.IsTrue(overridden.PortIsOverridden);
+            Assert.AreEqual(ProjectIdentity.DerivePin(path), overridden.Pin);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectIdentityGoldenVectorTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectIdentityGoldenVectorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 136896959daec454492e82ea3db07737
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectInstanceServiceTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectInstanceServiceTests.cs
@@ -1,0 +1,184 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// mcp-authorize PR 3 — the Unity-side connection identity seam (<see cref="ProjectInstanceService"/>):
+    /// the instance-metadata handshake payload, the per-editor-session instance id, and the project-marker
+    /// read/write + server-target / pin resolution. Golden-vector parity for the shared
+    /// <see cref="ProjectIdentity"/> derivation lives in <c>ProjectIdentityGoldenVectorTests</c>.
+    /// </summary>
+    public class ProjectInstanceServiceTests
+    {
+        const string ProjectRoot = "/home/dev/MyGame";
+
+        string _markerRoot = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _markerRoot = Path.Combine(Path.GetTempPath(), "agd-marker-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_markerRoot);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try { if (Directory.Exists(_markerRoot)) Directory.Delete(_markerRoot, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+
+        // --- Instance-metadata handshake payload ---
+
+        [Test]
+        public void BuildMetadata_ProducesUnityHandshakePayload_WithPinAsHashPrefix()
+        {
+            var metadata = ProjectInstanceService.BuildMetadata(ProjectRoot, "MyGame", instanceId: "sess-1");
+
+            Assert.AreEqual("unity", metadata.Engine);
+            Assert.AreEqual("MyGame", metadata.ProjectName);
+            Assert.AreEqual("sess-1", metadata.InstanceId);
+            // ProjectPathHash is the full 64-hex SHA-256 of the normalized root; the routing pin is its prefix.
+            Assert.AreEqual(ProjectIdentity.DeriveProjectPathHash(ProjectRoot), metadata.ProjectPathHash);
+            Assert.AreEqual(64, metadata.ProjectPathHash.Length);
+            StringAssert.StartsWith(ProjectIdentity.DerivePin(ProjectRoot), metadata.ProjectPathHash);
+        }
+
+        [Test]
+        public void BuildMetadata_DefaultsInstanceId_ToSessionInstanceId()
+        {
+            var metadata = ProjectInstanceService.BuildMetadata(ProjectRoot, "MyGame");
+
+            Assert.AreEqual(ProjectInstanceService.SessionInstanceId, metadata.InstanceId);
+            Assert.IsNotEmpty(metadata.InstanceId);
+        }
+
+        [Test]
+        public void BuildMetadata_NullProjectName_YieldsEmptyName_NotThrow()
+        {
+            var metadata = ProjectInstanceService.BuildMetadata(ProjectRoot, null!);
+            Assert.AreEqual(string.Empty, metadata.ProjectName);
+        }
+
+        [Test]
+        public void BuildMetadata_NullProjectRoot_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => ProjectInstanceService.BuildMetadata(null!, "MyGame"));
+        }
+
+        // --- Per-editor-session instance id ---
+
+        [Test]
+        public void SessionInstanceId_IsStableAcrossCalls_AndIsAGuid()
+        {
+            var first = ProjectInstanceService.SessionInstanceId;
+            var second = ProjectInstanceService.SessionInstanceId;
+
+            Assert.AreEqual(first, second, "the session instance id must be stable across calls (survives domain reloads)");
+            Assert.IsTrue(Guid.TryParse(first, out _), "the session instance id must be a GUID");
+        }
+
+        // --- Wiring into the connection config ---
+
+        [Test]
+        public void AttachInstanceMetadata_PopulatesConfigWithUnitySessionPayload()
+        {
+            var config = new UnityMcpPlugin.UnityConnectionConfig();
+            Assert.IsNull(config.InstanceMetadata, "precondition: a fresh config carries no handshake payload");
+
+            ProjectInstanceService.AttachInstanceMetadata(config);
+
+            Assert.IsNotNull(config.InstanceMetadata);
+            Assert.AreEqual("unity", config.InstanceMetadata!.Engine);
+            Assert.AreEqual(ProjectInstanceService.SessionInstanceId, config.InstanceMetadata.InstanceId);
+            Assert.IsNotEmpty(config.InstanceMetadata.ProjectPathHash);
+        }
+
+        [Test]
+        public void AttachInstanceMetadata_NullConfig_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => ProjectInstanceService.AttachInstanceMetadata(null!));
+        }
+
+        // --- Project marker read/write + resolution ---
+
+        [Test]
+        public void Marker_RoundTrips_ServerTargetAndPortOverride()
+        {
+            ProjectInstanceService.WriteMarker(_markerRoot, new ProjectMarker
+            {
+                ServerTarget = "https://ai-game.dev",
+                PortOverride = 26123,
+            });
+
+            // The marker lands at the tool-neutral, committable location — and carries no credentials.
+            var markerPath = Path.Combine(_markerRoot, ProjectMarker.DirectoryName, ProjectMarker.FileName);
+            FileAssert.Exists(markerPath);
+            var json = File.ReadAllText(markerPath);
+            StringAssert.DoesNotContain("token", json.ToLowerInvariant());
+            StringAssert.DoesNotContain("credential", json.ToLowerInvariant());
+
+            var read = ProjectInstanceService.ReadMarker(_markerRoot);
+            Assert.IsNotNull(read);
+            Assert.AreEqual("https://ai-game.dev", read!.ServerTarget);
+            Assert.AreEqual(26123, read.PortOverride);
+        }
+
+        [Test]
+        public void ReadMarker_ReturnsNull_WhenNoMarkerExists()
+        {
+            Assert.IsNull(ProjectInstanceService.ReadMarker(_markerRoot));
+        }
+
+        [Test]
+        public void ResolveServerTarget_ReadsMarkerTarget_NullWhenAbsent()
+        {
+            Assert.IsNull(ProjectInstanceService.ResolveServerTarget(_markerRoot));
+
+            ProjectInstanceService.WriteMarker(_markerRoot, new ProjectMarker { ServerTarget = "http://localhost:23940" });
+
+            Assert.AreEqual("http://localhost:23940", ProjectInstanceService.ResolveServerTarget(_markerRoot));
+        }
+
+        [Test]
+        public void ResolveIdentity_UsesMarkerPortOverride_PinUnchanged()
+        {
+            var pin = ProjectIdentity.DerivePin(_markerRoot);
+
+            // No marker → the derived port; pin is hash-derived.
+            var derived = ProjectInstanceService.ResolveIdentity(_markerRoot);
+            Assert.AreEqual(ProjectIdentity.DerivePort(_markerRoot), derived.Port);
+            Assert.IsFalse(derived.PortIsOverridden);
+            Assert.AreEqual(pin, derived.Pin);
+
+            // With an override marker → the override wins for Port, pin is unchanged.
+            ProjectInstanceService.WriteMarker(_markerRoot, new ProjectMarker { PortOverride = 27777 });
+            var overridden = ProjectInstanceService.ResolveIdentity(_markerRoot);
+            Assert.AreEqual(27777, overridden.Port);
+            Assert.IsTrue(overridden.PortIsOverridden);
+            Assert.AreEqual(pin, overridden.Pin);
+        }
+
+        [Test]
+        public void ResolvePin_MatchesSharedDerivation()
+        {
+            Assert.AreEqual(ProjectIdentity.DerivePin(ProjectRoot), ProjectInstanceService.ResolvePin(ProjectRoot));
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectInstanceServiceTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/ProjectInstanceServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3be156e4a9b81bd4786e8365f0a29753
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Part of the **mcp-authorize** engine wave (d1, PR 3 of ~5 for Unity). Follows the landed device-flow PR #877 and 7.0-adopt #875.

## What
- **ProjectInstanceService** (new): builds the non-secret `ConnectionInstanceMetadata` handshake payload (engine=unity, project/machine names, per-editor-session instance id via SessionState, project-path hash) and attaches it to `UnityConnectionConfig` so McpPlugin's hub connection sends it as query params on every (re)connect. The access token stays in the `Authorization` header — never in the handshake.
- Resolves the routing `ProjectIdentity.Pin` (+ derived port, honouring a user override) via the shared McpPlugin 7.0 derivation, and reads/writes the committable, non-secret project marker `<project>/.ai-game-dev/project.json` (`{serverTarget, portOverride?}`). No credentials in the marker.
- Wired in `UnityMcpPluginEditor.Build.cs` (`AttachInstanceMetadata` on the connection config).

## Out of scope (later PRs)
- Runtime **port default** is unchanged — Unity already ships the deterministic derived port, so there is no separate Unity port-migration PR.
- Editor UI sign-in chip / token-field removal = PR 5. Live e2e = PR 6.

## Tests
- `ProjectIdentityGoldenVectorTests` — pin/port parity vs the committed golden vectors (inline, byte-for-byte).
- `ProjectInstanceServiceTests` — payload shape + marker read/write + session instance-id stability.

Recovered from run `1b2b99982637` (child hit the account session limit mid-run; the WIP was complete + brace-balanced + wired, verified before commit). CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)