### PR TITLE
feat(ui): configurator sign-in chip + remove token field from default view (mcp-authorize PR 5)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AgentConfiguratorSettingsFactory.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AgentConfiguratorSettingsFactory.cs
@@ -27,9 +27,27 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
     {
         /// <summary>
         /// Builds an <see cref="AgentConfig.AgentConfiguratorSettings"/> snapshot from the current
-        /// Unity editor connection state, auto-detecting the host OS.
+        /// Unity editor connection state, auto-detecting the host OS. This is the DEFAULT
+        /// (OAuth golden) path: the written config is credential-free, so
+        /// <see cref="AgentConfig.AgentConfiguratorSettings.Token"/> is no longer required input
+        /// (design 06 / mcp-authorize b6) — the value carried here is only consumed by the advanced
+        /// access-token path (<see cref="AgentConfig.HttpCredentialMode.AccessToken"/>).
         /// </summary>
         public static AgentConfig.AgentConfiguratorSettings Create()
+            => Build(UnityMcpPluginEditor.Token);
+
+        /// <summary>
+        /// Builds a settings snapshot for the ADVANCED "use access token" escape hatch (design 06
+        /// Flow C): the same host/port/mode snapshot as <see cref="Create"/> but with
+        /// <paramref name="accessToken"/> injected as the bearer token, so a subsequent
+        /// <c>GetHttpConfig(settings, credentialMode: HttpCredentialMode.AccessToken)</c> writes the
+        /// legacy <c>Authorization: Bearer</c> config for a client that cannot do MCP OAuth. This is
+        /// the only place a user-entered PAT enters the snapshot — the golden path never needs one.
+        /// </summary>
+        public static AgentConfig.AgentConfiguratorSettings CreateWithAccessToken(string? accessToken)
+            => Build(accessToken);
+
+        private static AgentConfig.AgentConfiguratorSettings Build(string? token)
         {
             return AgentConfig.AgentConfiguratorSettings.CreateForHost(
                 projectRootPath: UnityMcpPluginEditor.ProjectRootPath,
@@ -37,7 +55,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 port: UnityMcpPluginEditor.Port,
                 timeoutMs: UnityMcpPluginEditor.TimeoutMs,
                 host: UnityMcpPluginEditor.Host,
-                token: UnityMcpPluginEditor.Token,
+                token: token,
                 connectionMode: MapConnectionMode(UnityMcpPluginEditor.ConnectionMode),
                 authOption: UnityMcpPluginEditor.AuthOption,
                 // Pass Unity's authoritative server identity explicitly so the shared module's

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfiguratorView.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/AiAgentConfigurators/AiAgentConfiguratorView.cs
@@ -11,6 +11,7 @@
 #nullable enable
 using System;
 using System.IO;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -59,6 +60,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         public string AgentName => _configurator.AgentName;
         public bool SupportsSkills => _configurator.SupportsSkills;
         public string? SkillsPath => _configurator.SkillsPath;
+
+        /// <summary>
+        /// Whether this agent can complete native MCP OAuth (design 06 Flow A). When false, the
+        /// configure view exposes the "Advanced: use access token" escape hatch instead of the
+        /// credential-free default path (see <see cref="ShouldOfferAccessTokenAffordance"/>).
+        /// </summary>
+        public bool SupportsOAuth => _configurator.SupportsOAuth;
 
         /// <summary>
         /// Invalidates cached state. The shared configurator is stateless (settings are passed
@@ -162,6 +170,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             SetAgentName(_configurator.AgentName);
             SetAgentIcon();
             SetupHeaderLinks();
+            SetupSignInChip();
             BuildTransportSections();
             SetupSkillsUI();
             SetupAlertPanel();
@@ -284,6 +293,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             foreach (var section in description.Sections)
                 container.Add(BuildSection(section, transport));
+
+            // Advanced: use access token (design 06 Flow C). The default OAuth path writes a
+            // credential-free config and shows NO token field; only a client that cannot do MCP
+            // OAuth surfaces this collapsed escape hatch, and only on the HTTP transport (stdio
+            // spawns in `none` mode).
+            if (transport == TransportMethod.streamableHttp
+                && HasDetectableConfig
+                && ShouldOfferAccessTokenAffordance(_configurator.SupportsOAuth))
+                container.Add(BuildAccessTokenAdvancedSection());
         }
 
         /// <summary>
@@ -393,6 +411,95 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 label.RegisterCallback<ClickEvent>(_ => Application.OpenURL(url));
             }
             return label;
+        }
+
+        #endregion
+
+        #region Sign-in chip + advanced access-token (mcp-authorize design 06)
+
+        internal const string USS_ChipSignedIn = "signin-chip--in";
+        internal const string USS_ChipSignedOut = "signin-chip--out";
+
+        /// <summary>
+        /// Pure mapping of the machine-credential sign-in state (PR2's
+        /// <see cref="AccountCredentialService.IsSignedIn"/>) to the header chip's label + USS
+        /// modifier. Signed in → the OAuth golden path completes with a single in-browser click;
+        /// signed out → the user signs in (device flow) or uses the advanced access-token path.
+        /// </summary>
+        internal static (string Text, string UssClass) ComputeSignInChip(bool isSignedIn)
+            => isSignedIn
+                ? ("Signed in", USS_ChipSignedIn)
+                : ("Not signed in", USS_ChipSignedOut);
+
+        /// <summary>
+        /// Whether the configure view offers the "Advanced: use access token" (PAT) affordance. The
+        /// default OAuth-capable path is credential-free and shows NO token field; only a
+        /// configurator that cannot do MCP OAuth
+        /// (<see cref="AgentConfig.AiAgentConfigurator.SupportsOAuth"/> == <c>false</c>) surfaces the
+        /// legacy token field that writes the Bearer-header shape (design 06 Flow C).
+        /// </summary>
+        internal static bool ShouldOfferAccessTokenAffordance(bool supportsOAuth) => !supportsOAuth;
+
+        /// <summary>
+        /// Populates the header sign-in chip from the shared machine-credential store. The chip is
+        /// meaningful only for agents that write a real (OAuth-capable) config, so the Custom agent
+        /// (no writable config) shows none — mirroring the <see cref="HasDetectableConfig"/> gate.
+        /// </summary>
+        private void SetupSignInChip()
+        {
+            var chip = Root!.Q<Label>("signInChip");
+            if (chip == null)
+                return;
+
+            if (!HasDetectableConfig)
+            {
+                chip.style.display = DisplayStyle.None;
+                return;
+            }
+
+            var (text, ussClass) = ComputeSignInChip(AccountCredentialService.IsSignedIn);
+            chip.text = text;
+            chip.EnableInClassList(USS_ChipSignedIn, ussClass == USS_ChipSignedIn);
+            chip.EnableInClassList(USS_ChipSignedOut, ussClass == USS_ChipSignedOut);
+            chip.style.display = DisplayStyle.Flex;
+        }
+
+        /// <summary>
+        /// The collapsed "Advanced: use access token" escape hatch (design 06 Flow C), appended to
+        /// the HTTP transport container only for configurators that cannot do MCP OAuth. Reveals a
+        /// legacy access-token (PAT) field and writes the <c>Authorization: Bearer</c> config via
+        /// <see cref="AgentConfig.HttpCredentialMode.AccessToken"/>. Collapsed by default so the
+        /// golden path stays token-free.
+        /// </summary>
+        private VisualElement BuildAccessTokenAdvancedSection()
+        {
+            var foldout = TemplateFoldout("Advanced: use access token");
+            foldout.value = false;
+
+            foldout.Add(TemplateLabelDescription(
+                "This client cannot use OAuth sign-in. Paste an access token to write the legacy " +
+                "Authorization: Bearer config. Prefer a user-scope or environment-variable placement — " +
+                "a token written into a project file may be committed to version control."));
+
+            var tokenField = new TextField { isPasswordField = true };
+            tokenField.AddToClassList("token-input");
+            tokenField.style.flexGrow = 1;
+            tokenField.style.flexShrink = 1;
+            tokenField.style.minWidth = 0;
+            foldout.Add(tokenField);
+
+            var btnWrite = new Button { text = "Configure with access token" };
+            btnWrite.RegisterCallback<ClickEvent>(_ =>
+            {
+                var config = _configurator.GetHttpConfig(
+                    AgentConfiguratorSettingsFactory.CreateWithAccessToken(tokenField.value),
+                    credentialMode: AgentConfig.HttpCredentialMode.AccessToken);
+                config.Configure();
+                RefreshConfigurationUI();
+            });
+            foldout.Add(btnWrite);
+
+            return foldout;
         }
 
         #endregion

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/UI/uss/MainWindow.uss
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/UI/uss/MainWindow.uss
@@ -26,6 +26,37 @@
 }
 
 /* ==========================================================================
+   Sign-in state chip - Machine-credential (OAuth) sign-in badge in the
+   AI-agent configuration card header (mcp-authorize design 06 / PR2 store)
+   ========================================================================== */
+
+.signin-chip {
+    flex-shrink: 0;
+    -unity-text-align: middle-center;
+    font-size: 10px;
+    -unity-font-style: bold;
+    border-radius: 8px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    padding-left: 8px;
+    padding-right: 8px;
+    margin-left: 6px;
+    border-width: 1px;
+}
+
+.signin-chip--in {
+    background-color: rgba(70, 160, 90, 0.18);
+    border-color: rgba(90, 190, 110, 0.45);
+    color: rgb(120, 210, 140);
+}
+
+.signin-chip--out {
+    background-color: rgba(120, 120, 120, 0.15);
+    border-color: rgba(150, 150, 150, 0.4);
+    color: rgb(180, 180, 180);
+}
+
+/* ==========================================================================
    Connection Timeline - Vertical TODO-like list with connected points
    ========================================================================== */
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/UI/uxml/agents/AiAgentTemplateConfig.uxml
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/UI/uxml/agents/AiAgentTemplateConfig.uxml
@@ -11,6 +11,8 @@
                     <ui:Label name="tutorialLink" text="YouTube Tutorial" class="section-desc link-label" />
                 </ui:VisualElement>
             </ui:VisualElement>
+            <!-- Machine-credential sign-in state chip (populated by AiAgentConfiguratorView.SetupSignInChip) -->
+            <ui:Label name="signInChip" text="Not signed in" class="signin-chip" style="display: none;" />
         </ui:VisualElement>
 
         <!-- Under header container -->

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/AiAgentConfiguratorViewLogicTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/AiAgentConfiguratorViewLogicTests.cs
@@ -1,0 +1,108 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.Unity.MCP.Editor.UI;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Pure-logic tests for the mcp-authorize PR5 configurator-UI deltas (design 06):
+    /// the sign-in state chip, the default view omitting the token field, and the advanced
+    /// access-token path writing the legacy Bearer-header shape. No UIToolkit / Editor state is
+    /// exercised — the view's decision points are unit-tested through internal static helpers
+    /// (same pattern as <c>MainWindowEditorStatusLogicTests</c>).
+    /// </summary>
+    public class AiAgentConfiguratorViewLogicTests
+    {
+        #region Sign-in chip reflects credential state
+
+        [Test]
+        public void ComputeSignInChip_SignedIn()
+        {
+            var (text, uss) = AiAgentConfiguratorView.ComputeSignInChip(isSignedIn: true);
+            Assert.AreEqual("Signed in", text);
+            Assert.AreEqual(AiAgentConfiguratorView.USS_ChipSignedIn, uss);
+        }
+
+        [Test]
+        public void ComputeSignInChip_SignedOut()
+        {
+            var (text, uss) = AiAgentConfiguratorView.ComputeSignInChip(isSignedIn: false);
+            Assert.AreEqual("Not signed in", text);
+            Assert.AreEqual(AiAgentConfiguratorView.USS_ChipSignedOut, uss);
+        }
+
+        #endregion
+
+        #region Default view omits the token field (advanced-affordance gating)
+
+        [Test]
+        public void ShouldOfferAccessTokenAffordance_HiddenForOAuthClients()
+        {
+            // Default (SupportsOAuth == true) path is credential-free: no token field is offered.
+            Assert.IsFalse(AiAgentConfiguratorView.ShouldOfferAccessTokenAffordance(supportsOAuth: true));
+        }
+
+        [Test]
+        public void ShouldOfferAccessTokenAffordance_ShownForNonOAuthClients()
+        {
+            // Only a client that cannot do MCP OAuth surfaces the legacy token field.
+            Assert.IsTrue(AiAgentConfiguratorView.ShouldOfferAccessTokenAffordance(supportsOAuth: false));
+        }
+
+        #endregion
+
+        #region Advanced path writes the Bearer shape; default path omits it
+
+        private static AgentConfiguratorSettings MakeSettings(string? token)
+            => new AgentConfiguratorSettings(
+                operatingSystem: OperatingSystemKind.Windows,
+                projectRootPath: "C:/proj",
+                executableFullPath: "C:/proj/server.exe",
+                port: 12345,
+                timeoutMs: 60000,
+                host: "https://ai-game.dev/mcp",
+                token: token,
+                // Fully qualified: unqualified "ConnectionMode" binds to the Unity enum
+                // (com.IvanMurzak.Unity.MCP.ConnectionMode) via enclosing-namespace precedence,
+                // not the AgentConfig one this ctor expects.
+                connectionMode: com.IvanMurzak.McpPlugin.AgentConfig.ConnectionMode.Cloud);
+
+        [Test]
+        public void DefaultOAuthPath_OmitsAccessToken()
+        {
+            var configurator = AiAgentConfiguratorRegistry.GetByAgentId("claude-code");
+            Assert.IsNotNull(configurator);
+
+            // Default HttpCredentialMode is Oauth — credential-free even when settings carry a token.
+            var http = configurator!.GetHttpConfig(MakeSettings("SECRET-PAT-XYZ"));
+            StringAssert.DoesNotContain("SECRET-PAT-XYZ", http.ExpectedFileContent);
+            StringAssert.DoesNotContain("Bearer", http.ExpectedFileContent);
+        }
+
+        [Test]
+        public void AdvancedAccessTokenPath_WritesBearerShape()
+        {
+            var configurator = AiAgentConfiguratorRegistry.GetByAgentId("claude-code");
+            Assert.IsNotNull(configurator);
+
+            // The advanced escape hatch (HttpCredentialMode.AccessToken) writes the legacy Bearer header.
+            var http = configurator!.GetHttpConfig(
+                MakeSettings("SECRET-PAT-XYZ"),
+                credentialMode: HttpCredentialMode.AccessToken);
+            StringAssert.Contains("Bearer SECRET-PAT-XYZ", http.ExpectedFileContent);
+        }
+
+        #endregion
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/AiAgentConfiguratorViewLogicTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/AiAgentConfiguratorViewLogicTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30ac04e09d043f943849e6cfb1720436
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Part of the **mcp-authorize** engine wave (d1, PR 5 of ~6 for Unity). Follows 7.0-adopt #875, device-flow PR #877, and instance-metadata handshake PR #879. This is the **editor UI surface** for the new auth model (design 06 § "Engine UI deltas"). Live e2e = PR 6.

## Summary
- **Sign-in state chip** on each AI-agent configurator card header, reflecting the shared machine credential store (`AccountCredentialService.IsSignedIn`) — "Signed in" / "Not signed in".
- **Default configure view is token-free** (OAuth golden path): the shared configurators already write a credential-free config, and `AgentConfiguratorSettings.Token` is no longer required input there. `AgentConfiguratorSettingsFactory` documents this and adds a `CreateWithAccessToken(pat)` seam for the escape hatch only.
- **"Advanced: use access token"** collapsed escape hatch (Flow C), offered only for `SupportsOAuth == false` clients: reveals the legacy token field and writes the `Authorization: Bearer` config via `HttpCredentialMode.AccessToken`. The default path hides it.
- Scope fence honored: no change to the 16-configurator registry / dedup / path logic, the device-flow / machine-store / handshake core, runtime port default, or the McpPlugin/ReflectorNet pins / plugin version.

## Test plan
- [x] New EditMode tests `AiAgentConfiguratorViewLogicTests` (6): default view omits the token field, sign-in chip reflects credential state, advanced path writes `Bearer <token>`, default OAuth path omits it.
- [x] Local EditMode gate green — 992 tests, 0 failures (chunked per the profile's transport-ceiling fallback); all auth/credential fixtures + `MainWindowEditorStatusLogicTests` green.
- Full Unity CI matrix (2022.3 / 2023.2 / 6000.3, editmode + standalone) is the gate.

Closes #880