### PR TITLE
feat(cli): repoint login to machine credential store + port ProjectIdentity

### DIFF
--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -2,46 +2,58 @@
 // Licensed under the Apache License, Version 2.0.
 
 import { Command } from 'commander';
+import * as path from 'path';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
-import { resolveProjectPath } from '../utils/connection.js';
-import { getOrCreateConfig, CLOUD_SERVER_BASE_URL } from '../utils/config.js';
+import { CLOUD_SERVER_BASE_URL } from '../utils/config.js';
 import { runCloudLogin } from '../utils/cloud-login.js';
+import { MachineCredentialStore, MACHINE_STORE_DIR_NAME } from '../utils/machine-credentials.js';
 
 interface LoginOptions {
-  path?: string;
+  project?: string;
   force?: boolean;
 }
 
+/**
+ * Resolve the credential store: the shared machine store (`~/.ai-game-dev/`) by default, or a
+ * project-local store (`<path>/.ai-game-dev/`) when `--project` is given.
+ */
+function resolveStore(options: LoginOptions): MachineCredentialStore {
+  if (options.project) {
+    const base = path.join(path.resolve(options.project), MACHINE_STORE_DIR_NAME);
+    return new MachineCredentialStore(base);
+  }
+  return new MachineCredentialStore();
+}
+
 export const loginCommand = new Command('login')
-  .description('Authenticate with the Unity-MCP cloud server')
-  .argument('[path]', 'Unity project path (defaults to cwd)')
-  .option('--force', 'Re-authenticate even if already logged in')
-  .action(
-    async (
-      positionalPath: string | undefined,
-      options: LoginOptions,
-    ) => {
-      const projectPath = resolveProjectPath(positionalPath, options);
-      verbose(`Project path: ${projectPath}`);
+  .description(
+    'Sign in to ai-game.dev and store the credential in the shared machine credential store (~/.ai-game-dev/credentials.json)',
+  )
+  .option(
+    '--project <path>',
+    'Store the credential in a project-local store (<path>/.ai-game-dev/) instead of the shared machine store',
+  )
+  .option('--force', 'Re-authenticate even if already signed in')
+  .action(async (options: LoginOptions) => {
+    const store = resolveStore(options);
+    verbose(`Credential store: ${store.credentialsPath}`);
 
-      const config = getOrCreateConfig(projectPath);
+    if (store.exists && !options.force) {
+      ui.success('Already signed in.');
+      ui.info(`Credential: ${store.credentialsPath}`);
+      ui.info('Use --force to re-authenticate.');
+      return;
+    }
 
-      if (config.cloudToken && !options.force) {
-        ui.success('Already authenticated with cloud server.');
-        ui.info('Use --force to re-authenticate.');
-        return;
-      }
+    ui.heading('Sign in to ai-game.dev');
+    ui.label('Server', CLOUD_SERVER_BASE_URL);
+    ui.divider();
 
-      ui.heading('Cloud Authentication');
-      ui.label('Server', CLOUD_SERVER_BASE_URL);
-      ui.divider();
-
-      const token = await runCloudLogin(projectPath);
-      if (token) {
-        ui.success('Authentication complete. Cloud token saved to project config.');
-      } else {
-        process.exit(1);
-      }
-    },
-  );
+    const token = await runCloudLogin(store);
+    if (token) {
+      ui.success(`Signed in. Credential saved to ${store.credentialsPath}`);
+    } else {
+      process.exit(1);
+    }
+  });

--- a/cli/src/commands/setup-skills.ts
+++ b/cli/src/commands/setup-skills.ts
@@ -6,6 +6,7 @@ import { resolveAndValidateProjectPath, resolveConnection } from '../utils/conne
 import { getAgentById, getAgentIds, listAgentTable } from '../utils/agents.js';
 import { readConfig, isCloudMode } from '../utils/config.js';
 import { runCloudLogin } from '../utils/cloud-login.js';
+import { MachineCredentialStore } from '../utils/machine-credentials.js';
 
 interface SetupSkillsOptions {
   url?: string;
@@ -134,7 +135,7 @@ export const setupSkillsCommand = new Command('setup-skills')
           if (cloud && !options.token && !hadToken) {
             ui.info('Cloud authentication required. Starting login...');
             console.log();
-            const newToken = await runCloudLogin(projectPath);
+            const newToken = await runCloudLogin(new MachineCredentialStore());
             if (!newToken) {
               process.exit(1);
             }

--- a/cli/src/utils/cloud-login.ts
+++ b/cli/src/utils/cloud-login.ts
@@ -2,17 +2,18 @@
 // Licensed under the Apache License, Version 2.0.
 
 import * as ui from './ui.js';
-import { readConfig, writeConfig, CLOUD_SERVER_BASE_URL } from './config.js';
+import { CLOUD_SERVER_BASE_URL } from './config.js';
 import { deviceAuthFlow } from './auth.js';
 import { openBrowser } from './browser.js';
+import { MachineCredentialStore } from './machine-credentials.js';
 
 /**
  * Run the cloud device-auth flow: initiate, display code, open browser, poll,
- * and persist the token to the project config.
+ * and persist the token to the shared machine credential store.
  *
  * Returns the access token on success, or null on failure (errors are printed).
  */
-export async function runCloudLogin(projectPath: string): Promise<string | null> {
+export async function runCloudLogin(store: MachineCredentialStore): Promise<string | null> {
   let spinner: ReturnType<typeof ui.startSpinner> | undefined;
 
   try {
@@ -37,13 +38,10 @@ export async function runCloudLogin(projectPath: string): Promise<string | null>
     if (result.success) {
       spinner?.success('Authorized');
 
-      const config = readConfig(projectPath) ?? {};
-      const updatedConfig = {
-        ...config,
-        cloudToken: result.accessToken,
-        connectionMode: 'Cloud' as const,
-      };
-      writeConfig(projectPath, updatedConfig);
+      store.write({
+        accessToken: result.accessToken,
+        serverTarget: CLOUD_SERVER_BASE_URL,
+      });
 
       return result.accessToken;
     }

--- a/cli/src/utils/machine-credentials.ts
+++ b/cli/src/utils/machine-credentials.ts
@@ -1,0 +1,161 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+/**
+ * TypeScript client of the shared machine credential store — the same on-disk contract the
+ * plugin's C# `MachineCredentialStore` (MCP-Plugin-dotnet, com.IvanMurzak.McpPlugin.AgentConfig)
+ * reads and writes. A single ai-game.dev account credential lives once per machine at
+ * `~/.ai-game-dev/credentials.json`, so `login` writes it here and every engine plugin/CLI reads
+ * it — sign-in happens once per machine, never per project, and the credential is NEVER written
+ * into a project file / VCS.
+ *
+ * At-rest protection matches the C# store byte-for-byte so the plugin can read what the CLI wrote:
+ *   - POSIX  — plaintext JSON, file mode 0600, inside a 0700 directory.
+ *   - Windows — DPAPI-encrypted (CurrentUser scope, no entropy) via
+ *     System.Security.Cryptography.ProtectedData, invoked through PowerShell. This is
+ *     interoperable with the C# store's CryptProtectData/CryptUnprotectData (the description
+ *     string and CRYPTPROTECT_UI_FORBIDDEN flag do not affect decryptability).
+ */
+
+/** Directory name under the user home (or a project root) that holds the store. */
+export const MACHINE_STORE_DIR_NAME = '.ai-game-dev';
+
+/** File name of the secret credential document. */
+export const CREDENTIALS_FILE_NAME = 'credentials.json';
+
+/**
+ * The secret credential material persisted in the store. Mirrors the C# `MachineCredentials`
+ * schema (camelCase JSON keys). Unknown fields are preserved on read for forward-compatibility.
+ */
+export interface MachineCredentials {
+  /** Schema version of the persisted document (currently 1). */
+  version?: number;
+  /** The current short-lived JWT access token (MCP audience). */
+  accessToken?: string;
+  /** The rotating refresh token used to mint a new access token before `expiresAt`. */
+  refreshToken?: string;
+  /** ISO-8601 absolute expiry of `accessToken`; used to schedule proactive refresh. */
+  expiresAt?: string;
+  /** The server target the credential was issued for (hosted https://ai-game.dev or a local URL). */
+  serverTarget?: string;
+  /** The account id (`sub`) the credential resolves to. Audit/diagnostic only. */
+  subject?: string;
+  [key: string]: unknown;
+}
+
+const isWindows = process.platform === 'win32';
+
+/**
+ * The shared machine credential store. Defaults to `~/.ai-game-dev/`; pass an explicit
+ * `baseDirectory` for tests or for the `--project` per-project store
+ * (`<project>/.ai-game-dev/`).
+ */
+export class MachineCredentialStore {
+  private readonly _baseDirectory: string;
+
+  constructor(baseDirectory?: string) {
+    this._baseDirectory = baseDirectory ?? path.join(os.homedir(), MACHINE_STORE_DIR_NAME);
+  }
+
+  /** Absolute path of the store directory. */
+  get baseDirectory(): string {
+    return this._baseDirectory;
+  }
+
+  /** Absolute path of the secret credential file. */
+  get credentialsPath(): string {
+    return path.join(this._baseDirectory, CREDENTIALS_FILE_NAME);
+  }
+
+  /** True when a credential file exists in the store. */
+  get exists(): boolean {
+    return fs.existsSync(this.credentialsPath);
+  }
+
+  /**
+   * Encrypt (Windows) / restrict (POSIX) and write `credentials` to the store, creating the
+   * store directory with owner-only permissions if needed. `version` is always written as 1;
+   * undefined fields are omitted (matching the C# `WhenWritingNull` policy).
+   */
+  write(credentials: MachineCredentials): void {
+    this.ensureBaseDirectory();
+
+    const document: MachineCredentials = { ...credentials, version: 1 };
+    const json = JSON.stringify(document, null, 2);
+    const plaintext = Buffer.from(json, 'utf-8');
+    const bytes = isWindows ? dpapiTransform('Protect', plaintext) : plaintext;
+
+    fs.writeFileSync(this.credentialsPath, bytes);
+    if (!isWindows) {
+      fs.chmodSync(this.credentialsPath, 0o600);
+    }
+  }
+
+  /** Read and decrypt the stored credentials, or null when none are present. */
+  read(): MachineCredentials | null {
+    if (!fs.existsSync(this.credentialsPath)) {
+      return null;
+    }
+
+    const raw = fs.readFileSync(this.credentialsPath);
+    if (raw.length === 0) {
+      return null;
+    }
+
+    const plaintext = isWindows ? dpapiTransform('Unprotect', raw) : raw;
+    const json = plaintext.toString('utf-8');
+    if (json.trim().length === 0) {
+      return null;
+    }
+
+    return JSON.parse(json) as MachineCredentials;
+  }
+
+  /** Delete the stored credentials (sign-out). No-op when none exist. */
+  delete(): void {
+    if (fs.existsSync(this.credentialsPath)) {
+      fs.rmSync(this.credentialsPath);
+    }
+  }
+
+  private ensureBaseDirectory(): void {
+    fs.mkdirSync(this._baseDirectory, { recursive: true });
+    if (!isWindows) {
+      fs.chmodSync(this._baseDirectory, 0o700);
+    }
+  }
+}
+
+/**
+ * Run a Windows DPAPI Protect/Unprotect round trip through PowerShell's
+ * System.Security.Cryptography.ProtectedData (CurrentUser scope, no entropy) — interoperable
+ * with the C# store's CryptProtectData/CryptUnprotectData. Input and output are passed as
+ * base64 through an environment variable so the plaintext never lands in argv or the process
+ * table. Only ever invoked on Windows.
+ */
+function dpapiTransform(action: 'Protect' | 'Unprotect', input: Buffer): Buffer {
+  const script =
+    "$ErrorActionPreference='Stop';" +
+    'Add-Type -AssemblyName System.Security;' +
+    '$in=[Convert]::FromBase64String($env:AIGD_DPAPI_IN);' +
+    `$out=[System.Security.Cryptography.ProtectedData]::${action}($in,$null,[System.Security.Cryptography.DataProtectionScope]::CurrentUser);` +
+    '[Convert]::ToBase64String($out)';
+
+  const stdout = execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    {
+      encoding: 'utf-8',
+      env: { ...process.env, AIGD_DPAPI_IN: input.toString('base64') },
+      timeout: 20000,
+      windowsHide: true,
+    },
+  );
+
+  return Buffer.from(stdout.trim(), 'base64');
+}

--- a/cli/src/utils/port.ts
+++ b/cli/src/utils/port.ts
@@ -3,18 +3,79 @@ import { createHash } from 'crypto';
 const MIN_PORT = 20000;
 const MAX_PORT = 29999;
 const PORT_RANGE = MAX_PORT - MIN_PORT + 1;
+// Routing pin = first 4 bytes of the hash rendered as 8 lowercase hex chars.
+const PIN_BYTES = 4;
+
+// Characters where JS String.prototype.toLowerCase() diverges from .NET
+// string.ToLowerInvariant(). ToLowerInvariant is the canonical origin of the
+// ProjectIdentity derivation (see MCP-Plugin-dotnet ProjectIdentity.GoldenVectors.json),
+// so the TS port must reproduce it byte-for-byte. Each entry maps a code point to the
+// value ToLowerInvariant produces:
+//   U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE - ToLowerInvariant leaves it unchanged
+//   (no case fold), whereas toLowerCase() lowers it to U+0069 U+0307 (i + COMBINING DOT ABOVE).
+const INVARIANT_LOWER_OVERRIDES: Record<string, string> = {
+  'İ': 'İ',
+};
+
+/**
+ * Lowercase a string the way .NET string.ToLowerInvariant() does: a simple,
+ * culture-independent, per-code-point mapping (no context-sensitive rules such as the
+ * Greek final-sigma or the Turkish-i special cases). We lower each code point on its own
+ * and apply INVARIANT_LOWER_OVERRIDES for the few points where JS disagrees with .NET.
+ */
+function toLowerInvariant(value: string): string {
+  let out = '';
+  for (const ch of value) {
+    out += INVARIANT_LOWER_OVERRIDES[ch] ?? ch.toLowerCase();
+  }
+  return out;
+}
+
+/**
+ * Trim trailing directory separators ('/' and '\\') so '/a/b' and '/a/b/' are the same
+ * project. Never trims below length 1 (matches ProjectIdentity.TrimTrailingSeparators).
+ * Separators are NOT converted — 'C:\\a' and 'C:/a' remain distinct and hash differently.
+ */
+function trimTrailingSeparators(pathStr: string): string {
+  let end = pathStr.length;
+  while (end > 1 && (pathStr[end - 1] === '/' || pathStr[end - 1] === '\\')) {
+    end--;
+  }
+  return end === pathStr.length ? pathStr : pathStr.slice(0, end);
+}
+
+/**
+ * The exact string that is UTF-8/SHA-256 hashed: the project root with trailing directory
+ * separators trimmed, then lowercased with the ToLowerInvariant-matching rules above.
+ * Exposed so the golden-vector parity test can reproduce the pre-hash string.
+ */
+export function normalizeProjectRoot(projectRoot: string): string {
+  return toLowerInvariant(trimTrailingSeparators(projectRoot));
+}
+
+function hashOf(projectRoot: string): Buffer {
+  return createHash('sha256').update(normalizeProjectRoot(projectRoot), 'utf-8').digest();
+}
+
+/**
+ * The routing pin: the first 4 bytes of the SHA-256 of the normalized project root as 8
+ * lowercase hex characters. Byte-for-byte the C# ProjectIdentity.DerivePin.
+ */
+export function deriveProjectPin(dir: string): string {
+  return hashOf(dir).subarray(0, PIN_BYTES).toString('hex');
+}
 
 /**
  * Generate a deterministic port from a directory path.
- * Ports the C# UnityMcpPlugin.GeneratePortFromDirectory() logic.
- * SHA256 hash of lowercased directory → first 4 bytes as uint32 → modulo 10000 + 20000.
+ * Ports the canonical C# ProjectIdentity derivation (DerivePort), which is itself byte-for-byte
+ * the shipped Unity UnityMcpPlugin.GeneratePortFromDirectory() logic:
+ * SHA256 of the normalized (trailing-separator-trimmed, ToLowerInvariant) directory → first
+ * 4 bytes as a little-endian uint32 → modulo 10000 + 20000 (range 20000-29999).
  */
 export function generatePortFromDirectory(dir: string): number {
-  const hash = createHash('sha256')
-    .update(dir.toLowerCase())
-    .digest();
+  const hash = hashOf(dir);
 
-  // Read first 4 bytes as little-endian int32, then treat as unsigned
+  // Read first 4 bytes as little-endian int32, then treat as unsigned.
   const int32 = hash.readInt32LE(0);
   const uint32 = int32 >>> 0;
 

--- a/cli/tests/cloud-login.test.ts
+++ b/cli/tests/cloud-login.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Mock the device-auth flow so runCloudLogin never touches the network or opens a browser.
+// The mock resolves success WITHOUT invoking the onUserCode / onPolling callbacks, so
+// openBrowser and the spinner are never reached.
+vi.mock('../src/utils/auth.js', () => ({
+  deviceAuthFlow: vi.fn(async () => ({ success: true, accessToken: 'test-access-token' })),
+}));
+
+import { runCloudLogin } from '../src/utils/cloud-login.js';
+import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
+
+describe('runCloudLogin', () => {
+  it('persists the access token to the credential store (never a project config file)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'));
+
+      const token = await runCloudLogin(store);
+
+      expect(token).toBe('test-access-token');
+      expect(store.exists).toBe(true);
+
+      const creds = store.read();
+      expect(creds?.accessToken).toBe('test-access-token');
+      expect(creds?.serverTarget).toBe('https://ai-game.dev');
+      expect(creds?.version).toBe(1);
+
+      // The repoint must NOT write the legacy per-project cloudToken config.
+      expect(
+        fs.existsSync(path.join(tmp, 'UserSettings', 'AI-Game-Developer-Config.json')),
+      ).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -8,31 +8,61 @@ import * as os from 'os';
 import { runCliAsync } from './helpers/cli.js';
 
 // ---------------------------------------------------------------------------
-// Tests
+// login now signs in to the shared machine credential store (~/.ai-game-dev/credentials.json)
+// instead of writing a per-project cloudToken. --project routes the credential to a project-local
+// store (<path>/.ai-game-dev/). These CLI-subprocess tests only exercise the offline
+// "already signed in" short-circuit + --help; the write path (which needs the device flow) is
+// covered offline by tests/cloud-login.test.ts with a mocked deviceAuthFlow.
 // ---------------------------------------------------------------------------
 
 describe('login command', () => {
-  it('shows help with --help', async () => {
+  it('shows help with --help (documents --force and --project)', async () => {
     const { stdout, exitCode } = await runCliAsync(['login', '--help']);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('login');
     expect(stdout).toContain('--force');
+    expect(stdout).toContain('--project');
   });
 
-  it('shows already authenticated when cloudToken exists', async () => {
+  it('reports "Already signed in" when a --project store credential exists (offline short-circuit)', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-login-test-'));
     try {
-      fs.mkdirSync(path.join(tmpDir, 'Assets'), { recursive: true });
-      const configDir = path.join(tmpDir, 'UserSettings');
-      fs.mkdirSync(configDir, { recursive: true });
+      // Pre-create a project-local store credential. login only checks presence (never decrypts
+      // for the "already signed in" gate), so a plaintext stub is enough to drive the short-circuit
+      // without any network call.
+      const storeDir = path.join(tmpDir, '.ai-game-dev');
+      fs.mkdirSync(storeDir, { recursive: true });
       fs.writeFileSync(
-        path.join(configDir, 'AI-Game-Developer-Config.json'),
-        JSON.stringify({ connectionMode: 'Cloud', cloudToken: 'existing-token' }),
+        path.join(storeDir, 'credentials.json'),
+        JSON.stringify({ version: 1, accessToken: 'existing-token' }),
       );
 
-      const { stdout, exitCode } = await runCliAsync(['login', tmpDir]);
+      const { stdout, exitCode } = await runCliAsync(['login', '--project', tmpDir]);
       expect(exitCode).toBe(0);
-      expect(stdout).toContain('Already authenticated');
+      expect(stdout).toContain('Already signed in');
+      expect(stdout).toContain('Use --force to re-authenticate');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a legacy project cloudToken config alone does NOT count as signed-in', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-login-test-'));
+    try {
+      // Legacy per-project cloudToken config present, but NO project-store credential. login's
+      // sign-in gate consults ONLY the credential store (never the project config), so
+      // store.exists stays false — the legacy cloudToken is structurally ignored. Asserted
+      // offline (no CLI subprocess / device flow) to avoid firing the real cloud endpoint.
+      const cfgDir = path.join(tmpDir, 'UserSettings');
+      fs.mkdirSync(cfgDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(cfgDir, 'AI-Game-Developer-Config.json'),
+        JSON.stringify({ connectionMode: 'Cloud', cloudToken: 'legacy-token' }),
+      );
+
+      const { MachineCredentialStore } = await import('../src/utils/machine-credentials.js');
+      const store = new MachineCredentialStore(path.join(tmpDir, '.ai-game-dev'));
+      expect(store.exists).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/cli/tests/machine-credentials.test.ts
+++ b/cli/tests/machine-credentials.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  MachineCredentialStore,
+  CREDENTIALS_FILE_NAME,
+  MACHINE_STORE_DIR_NAME,
+} from '../src/utils/machine-credentials.js';
+
+function tmpStore(): { dir: string; store: MachineCredentialStore } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-store-'));
+  return { dir, store: new MachineCredentialStore(dir) };
+}
+
+describe('MachineCredentialStore', () => {
+  it('defaults to ~/.ai-game-dev/credentials.json', () => {
+    const store = new MachineCredentialStore();
+    expect(store.baseDirectory).toBe(path.join(os.homedir(), MACHINE_STORE_DIR_NAME));
+    expect(store.credentialsPath).toBe(
+      path.join(os.homedir(), MACHINE_STORE_DIR_NAME, CREDENTIALS_FILE_NAME),
+    );
+  });
+
+  it('reports the credential path inside the store directory and no credential initially', () => {
+    const { dir, store } = tmpStore();
+    try {
+      expect(store.credentialsPath).toBe(path.join(dir, CREDENTIALS_FILE_NAME));
+      expect(store.exists).toBe(false);
+      expect(store.read()).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('write then read round-trips the credential and stamps version 1', () => {
+    const { dir, store } = tmpStore();
+    try {
+      store.write({ accessToken: 'tok-123', serverTarget: 'https://ai-game.dev' });
+      expect(store.exists).toBe(true);
+      const creds = store.read();
+      expect(creds?.accessToken).toBe('tok-123');
+      expect(creds?.serverTarget).toBe('https://ai-game.dev');
+      expect(creds?.version).toBe(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits undefined fields on write (WhenWritingNull parity)', () => {
+    const { dir, store } = tmpStore();
+    try {
+      store.write({ accessToken: 'only-access' });
+      const creds = store.read();
+      expect(creds).not.toBeNull();
+      expect(Object.prototype.hasOwnProperty.call(creds, 'refreshToken')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(creds, 'subject')).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('delete removes the credential file (sign-out)', () => {
+    const { dir, store } = tmpStore();
+    try {
+      store.write({ accessToken: 'x' });
+      expect(store.exists).toBe(true);
+      store.delete();
+      expect(store.exists).toBe(false);
+      store.delete(); // idempotent no-op
+      expect(store.exists).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // POSIX: plaintext JSON, file mode 0600 inside a 0700 directory (matches the C# store).
+  it.runIf(process.platform !== 'win32')(
+    'writes plaintext JSON with 0600 file / 0700 dir perms on POSIX',
+    () => {
+      const { dir, store } = tmpStore();
+      try {
+        store.write({ accessToken: 'secret-token' });
+        const raw = fs.readFileSync(store.credentialsPath, 'utf-8');
+        expect(JSON.parse(raw).accessToken).toBe('secret-token');
+        expect(fs.statSync(store.credentialsPath).mode & 0o777).toBe(0o600);
+        expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  // Windows: on-disk bytes are DPAPI-encrypted (not plaintext) yet read() round-trips.
+  it.runIf(process.platform === 'win32')(
+    'DPAPI-encrypts the on-disk bytes on Windows but round-trips via read()',
+    () => {
+      const { dir, store } = tmpStore();
+      try {
+        store.write({ accessToken: 'secret-token' });
+        const raw = fs.readFileSync(store.credentialsPath, 'utf-8');
+        expect(raw.includes('secret-token')).toBe(false);
+        expect(store.read()?.accessToken).toBe('secret-token');
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/cli/tests/project-identity.test.ts
+++ b/cli/tests/project-identity.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import {
+  generatePortFromDirectory,
+  deriveProjectPin,
+  normalizeProjectRoot,
+} from '../src/utils/port.js';
+
+// ---------------------------------------------------------------------------
+// Golden-vector parity: C# ProjectIdentity <-> this TS port.
+//
+// Inlined verbatim from MCP-Plugin-dotnet
+//   McpPlugin/src/AgentConfig/ProjectIdentity.GoldenVectors.json
+// (intentionally copied inline — the test must NOT add a runtime dependency on that file).
+// The C# reference implementation is the canonical origin; this TS port MUST reproduce every
+// pin/port byte-for-byte, including the ToLowerInvariant-vs-toLowerCase() Unicode divergence.
+// ---------------------------------------------------------------------------
+
+interface GoldenVector {
+  path: string;
+  pin: string;
+  port: number;
+}
+
+const GOLDEN_VECTORS: GoldenVector[] = [
+  { path: '/home/user/my-game', pin: '34ea75f2', port: 23940 },
+  { path: '/home/user/my-game/', pin: '34ea75f2', port: 23940 }, // trailing slash trimmed
+  { path: '/home/USER/My-Game', pin: '34ea75f2', port: 23940 }, // case-folded
+  { path: 'C:\\Users\\user\\my-game', pin: '8ef72cf7', port: 29310 }, // Windows backslash form
+  { path: 'C:\\Users\\user\\my-game\\', pin: '8ef72cf7', port: 29310 }, // trailing backslash trimmed
+  { path: 'C:/Users/user/my-game', pin: '5a87324e', port: 24298 }, // forward-slash form differs
+  { path: '/home/İstanbul/game', pin: '672d80a7', port: 25303 }, // U+0130, ToLowerInvariant canonical
+  { path: '/srv/games/space sim', pin: '08c6cbb6', port: 27816 }, // path with a space
+];
+
+describe('ProjectIdentity golden-vector parity (C# reference <-> TS port)', () => {
+  for (const v of GOLDEN_VECTORS) {
+    it(`derives the canonical pin + port for ${JSON.stringify(v.path)}`, () => {
+      expect(deriveProjectPin(v.path)).toBe(v.pin);
+      expect(generatePortFromDirectory(v.path)).toBe(v.port);
+    });
+  }
+
+  it('uses ToLowerInvariant for U+0130 (NOT the naive JS toLowerCase value)', () => {
+    // A naive toLowerCase() port would derive pin 77300275 / port 27751 (U+0130 -> "i" + combining
+    // dot). The canonical C# ToLowerInvariant value is 672d80a7 / 25303 (U+0130 left unchanged).
+    expect(deriveProjectPin('/home/İstanbul/game')).toBe('672d80a7');
+    expect(deriveProjectPin('/home/İstanbul/game')).not.toBe('77300275');
+    expect(generatePortFromDirectory('/home/İstanbul/game')).not.toBe(27751);
+  });
+
+  it('does NOT convert separators — backslash and forward-slash forms differ', () => {
+    expect(generatePortFromDirectory('C:\\Users\\user\\my-game')).not.toBe(
+      generatePortFromDirectory('C:/Users/user/my-game'),
+    );
+    expect(deriveProjectPin('C:\\Users\\user\\my-game')).not.toBe(
+      deriveProjectPin('C:/Users/user/my-game'),
+    );
+  });
+
+  it('normalizes trailing separators and case before hashing', () => {
+    expect(normalizeProjectRoot('/home/user/my-game/')).toBe('/home/user/my-game');
+    expect(normalizeProjectRoot('/home/user/my-game\\')).toBe('/home/user/my-game');
+    expect(normalizeProjectRoot('/home/USER/My-Game')).toBe('/home/user/my-game');
+  });
+
+  it('never trims a lone separator below length 1', () => {
+    expect(normalizeProjectRoot('/')).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary

- `login` now persists the credential to the shared machine credential store `~/.ai-game-dev/credentials.json` (0600 POSIX / DPAPI Windows), matching the C# `MachineCredentialStore` contract the plugin auto-adopts — instead of the legacy per-project `cloudToken` config. Adds a `--project <path>` override that stores into a gitignored project-local `<path>/.ai-game-dev/` store. New TS `MachineCredentialStore` (`cli/src/utils/machine-credentials.ts`) mirrors the C# store byte-for-byte (Windows DPAPI via PowerShell `ProtectedData`, interoperable with `CryptProtectData`).
- `cli/src/utils/port.ts` ports the canonical `ProjectIdentity` derivation: trailing-separator trim + `ToLowerInvariant`-matching normalization (U+0130 divergence handled; separators are NOT converted).

## Test plan
- [x] Target-specific local tests passed (see profile test.md) — `cli/` vitest suite: 442 passed, 2 skipped (OS-guards), 0 failures.
- [x] Golden-vector parity test validates pin+port byte-for-byte against `MCP-Plugin-dotnet/.../ProjectIdentity.GoldenVectors.json` (vectors copied inline; no runtime dependency on that file), incl. the U+0130 `ToLowerInvariant` case.
- [x] Machine-store round-trip (Windows DPAPI verified locally; POSIX 0600/0700 asserted); `login --project` offline short-circuit; `runCloudLogin` writes to the store, not a project file.

Scope: mcp-authorize d2 CLI PR 1 of 2. No version bump / no publish. `install-plugin` / `configure` / `enroll` untouched (CLI PR 2).

Closes #882