### PR TITLE
chore: bump gamedev-mcp-server to 9.0.0

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -132,7 +132,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         /// <c>v&lt;ServerVersion&gt;</c> release with all 7 RID zips exists on GameDev-MCP-Server
         /// BEFORE cutting a plugin release that pins it — otherwise the download 404s).
         /// </summary>
-        public const string ServerVersion = "8.0.3";
+        public const string ServerVersion = "9.0.0";
 
         public const string ExecutableName = "gamedev-mcp-server";
 


### PR DESCRIPTION
Automated downstream bump of the pinned GameDev-MCP-Server version `8.0.3` -> `9.0.0` (adopts the just-released `v9.0.0` server: NuGet + Docker tag + all 7 RID zips are already live).