### PR TITLE
feat(cli): install-plugin --with-server/--enroll + configure --agent proxy (mcp-authorize CLI PR 2)

### DIFF
--- a/cli/src/commands/configure.ts
+++ b/cli/src/commands/configure.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
 import { configure } from '../lib/configure.js';
+import { proxyConfigure } from '../utils/managed-server.js';
 import type { FeatureAction } from '../lib/types.js';
 
 function parseCommaSeparated(value: string): string[] {
@@ -25,9 +26,11 @@ function buildAction(
 }
 
 export const configureCommand = new Command('configure')
-  .description('Configure MCP tools, prompts, and resources in AI-Game-Developer-Config.json')
+  .description('Configure MCP tools/prompts/resources, or (with --agent) write an AI agent config via the managed server')
   .argument('[path]', 'Path to the Unity project')
   .option('--path <path>', 'Path to the Unity project')
+  .option('--agent <id>', 'Write an AI agent MCP config by proxying to the managed GameDev-MCP-Server configurator')
+  .option('--url <url>', 'Explicit server URL forwarded to the managed configurator (with --agent)')
   .option('--enable-tools <names>', 'Enable specific tools (comma-separated)', parseCommaSeparated)
   .option('--disable-tools <names>', 'Disable specific tools (comma-separated)', parseCommaSeparated)
   .option('--enable-all-tools', 'Enable all tools')
@@ -43,6 +46,8 @@ export const configureCommand = new Command('configure')
   .option('--list', 'List current configuration')
   .action(async (positionalPath: string | undefined, options: {
     path?: string;
+    agent?: string;
+    url?: string;
     enableTools?: string[];
     disableTools?: string[];
     enableAllTools?: boolean;
@@ -64,6 +69,22 @@ export const configureCommand = new Command('configure')
     }
 
     const projectPath = path.resolve(resolvedPath);
+
+    // `--agent` mode: proxy to the managed GameDev-MCP-Server binary's `configure` subcommand
+    // (design 06/09 Phase 3) so the shared C# configurator writes the agent config with the
+    // derived project pin + port. This is a distinct mode from the tools/prompts/resources
+    // toggles below and short-circuits them.
+    if (options.agent) {
+      verbose(`Proxying configure --agent ${options.agent} to the managed server for: ${projectPath}`);
+      try {
+        proxyConfigure({ agentId: options.agent, projectPath, url: options.url });
+      } catch (err) {
+        ui.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      ui.success(`Configured agent "${options.agent}" via the managed server.`);
+      return;
+    }
 
     verbose(`Loading config for project: ${projectPath}`);
 

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -1,15 +1,35 @@
 import { Command } from 'commander';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
 import { installPlugin } from '../lib/install-plugin.js';
+import { downloadServerBinary } from '../utils/managed-server.js';
+import { DEFAULT_SERVER_VERSION } from '../utils/server-version.js';
+import { resolveEnrollCode, runEnroll, EnrollmentError } from '../utils/enroll.js';
+import { MachineCredentialStore } from '../utils/machine-credentials.js';
+
+interface InstallPluginOptions {
+  path?: string;
+  pluginVersion?: string;
+  withServer?: boolean;
+  serverVersion?: string;
+  serverSource?: string;
+  enroll?: string;
+  enrollStdin?: boolean;
+}
 
 export const installPluginCommand = new Command('install-plugin')
-  .description('Install Unity-MCP plugin into a Unity project')
+  .description('Install Unity-MCP plugin into a Unity project (optionally download the server + enroll)')
   .argument('[path]', 'Path to the Unity project')
   .option('--path <path>', 'Path to the Unity project')
   .option('--plugin-version <version>', 'Plugin version to install (default: latest)')
-  .action(async (positionalPath: string | undefined, options: { path?: string; pluginVersion?: string }) => {
+  .option('--with-server', 'Also download the RID-matched GameDev-MCP-Server binary into the CLI managed dir')
+  .option('--server-version <version>', `Server version to download with --with-server (default: ${DEFAULT_SERVER_VERSION})`)
+  .option('--server-source <path-or-url>', 'Offline/CI override: install the server from a local zip path or URL (skips SHA256SUMS verification)')
+  .option('--enroll <code>', 'Redeem an enrollment code for a plugin credential (planted in the shared machine store)')
+  .option('--enroll-stdin', 'Read the enrollment code from stdin (never argv/shell history)')
+  .action(async (positionalPath: string | undefined, options: InstallPluginOptions) => {
     const resolvedPath = positionalPath ?? options.path;
     if (!resolvedPath) {
       ui.error('Path is required. Usage: unity-mcp-cli install-plugin <path> or --path <path>');
@@ -18,6 +38,7 @@ export const installPluginCommand = new Command('install-plugin')
 
     const projectPath = path.resolve(resolvedPath);
 
+    // ── Phase 1: install the plugin into the Unity project's manifest ────────
     // Wire the library's progress events back into the CLI's chalk-
     // styled ui so the terminal experience stays identical.
     let spinner: ReturnType<typeof ui.startSpinner> | undefined;
@@ -64,6 +85,66 @@ export const installPluginCommand = new Command('install-plugin')
 
     for (const warning of result.warnings) {
       ui.warn(warning);
+    }
+
+    // ── Phase 2: download the RID-matched server binary (--with-server) ──────
+    if (options.withServer) {
+      const serverSpinner = ui.startSpinner('Downloading GameDev-MCP-Server binary...');
+      try {
+        const download = await downloadServerBinary({
+          version: options.serverVersion ?? DEFAULT_SERVER_VERSION,
+          source: options.serverSource,
+          onProgress: (msg) => {
+            serverSpinner.text = msg;
+            verbose(msg);
+          },
+        });
+        serverSpinner.success(
+          `Server ${download.rid} v${download.version} installed${download.verified ? ' (checksum verified)' : ''}`,
+        );
+        ui.label('Server binary', download.binaryPath);
+      } catch (err) {
+        serverSpinner.error('Server download failed');
+        ui.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    }
+
+    // ── Phase 3: redeem an enrollment code (--enroll / --enroll-stdin) ───────
+    if (options.enroll || options.enrollStdin) {
+      let code: string;
+      try {
+        code = resolveEnrollCode(
+          { enroll: options.enroll, enrollStdin: options.enrollStdin },
+          () => fs.readFileSync(0, 'utf-8'),
+        );
+      } catch (err) {
+        ui.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+
+      const enrollSpinner = ui.startSpinner('Redeeming enrollment code...');
+      try {
+        const enrolled = await runEnroll({
+          code,
+          projectPath,
+          store: new MachineCredentialStore(),
+        });
+        enrollSpinner.success('Enrollment complete');
+        ui.label('Credential', enrolled.credentialPath);
+        ui.label('Server target', enrolled.serverTarget);
+        ui.label('Project marker', enrolled.markerPath);
+        ui.label('Project pin', enrolled.pin);
+        if (enrolled.pinnedConfigs.length > 0) {
+          for (const cfg of enrolled.pinnedConfigs) {
+            ui.info(`Pinned project routing in ${cfg}`);
+          }
+        }
+      } catch (err) {
+        enrollSpinner.error('Enrollment failed');
+        ui.error(err instanceof EnrollmentError || err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
     }
 
     ui.success('Done! Open the project in Unity Editor to complete installation.');

--- a/cli/src/utils/enroll.ts
+++ b/cli/src/utils/enroll.ts
@@ -1,0 +1,327 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { CLOUD_SERVER_BASE_URL } from './config.js';
+import { deriveProjectPin } from './port.js';
+import { agentRegistry, MCP_SERVER_NAME } from './agents.js';
+import { writeProjectMarker } from './project-marker.js';
+import type { MachineCredentialStore } from './machine-credentials.js';
+
+/**
+ * Agent-driven enrollment (D13): redeem a one-time enrollment code — minted by the server's
+ * `enroll_engine_plugin` tool from an already-authorized agent session — for a plugin credential,
+ * with NO second browser hop. The redeemed credential is planted in the shared machine store, the
+ * server target it was minted for is recorded in the project marker, and the D14 project pin is
+ * upserted into any existing project-local agent config so the plugin boots pointed at the right
+ * hub. Codes are burned server-side on first redeem attempt; a spent/invalid code yields a uniform
+ * error surfaced here as an actionable message.
+ */
+
+/** Raised on any enrollment-redeem failure. Carries the HTTP status when one was received. */
+export class EnrollmentError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'EnrollmentError';
+    this.status = status;
+  }
+}
+
+/** Credential material returned by a successful `/api/auth/enroll/redeem`. */
+export interface RedeemedCredential {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: string;
+  serverTarget?: string;
+  subject?: string;
+}
+
+export interface RedeemOptions {
+  /** Authorization Server base; defaults to the hosted `CLOUD_SERVER_BASE_URL`. */
+  baseUrl?: string;
+  /** `fetch` injection (tests). */
+  fetchImpl?: typeof fetch;
+  /** Request timeout; defaults to 30s. */
+  timeoutMs?: number;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Normalize the redeem response. The Authorization Server's JSON key casing is not re-derivable
+ * from this repo (the AS lives in a separate service), so both snake_case and camelCase variants
+ * of every field are accepted defensively; `expires_in` seconds are converted to an absolute
+ * `expiresAt` ISO timestamp when no explicit `expires_at` is present.
+ */
+export function normalizeRedeemResponse(data: Record<string, unknown>): RedeemedCredential {
+  const accessToken = nonEmptyString(data.access_token) ?? nonEmptyString(data.accessToken);
+  const refreshToken = nonEmptyString(data.refresh_token) ?? nonEmptyString(data.refreshToken);
+  const serverTarget =
+    nonEmptyString(data.server_target) ??
+    nonEmptyString(data.serverTarget) ??
+    nonEmptyString(data.server_target_url) ??
+    nonEmptyString(data.serverTargetUrl);
+  const subject = nonEmptyString(data.subject) ?? nonEmptyString(data.sub);
+
+  let expiresAt = nonEmptyString(data.expires_at) ?? nonEmptyString(data.expiresAt);
+  const expiresIn = numberOrUndefined(data.expires_in) ?? numberOrUndefined(data.expiresIn);
+  if (!expiresAt && expiresIn !== undefined) {
+    expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+  }
+
+  return { accessToken, refreshToken, expiresAt, serverTarget, subject };
+}
+
+/**
+ * Redeem an enrollment code against `POST <baseUrl>/api/auth/enroll/redeem` with body
+ * `{enroll_code}`. The code travels only in the request BODY (never a query string). A non-2xx
+ * response is surfaced as an actionable `EnrollmentError` (invalid/expired/already-used codes all
+ * return a uniform server error; burn-on-first-attempt is server-side).
+ */
+export async function redeemEnrollmentCode(
+  code: string,
+  opts: RedeemOptions = {},
+): Promise<RedeemedCredential> {
+  const baseUrl = opts.baseUrl ?? CLOUD_SERVER_BASE_URL;
+  const doFetch = opts.fetchImpl ?? fetch;
+  const url = `${baseUrl}/api/auth/enroll/redeem`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 30000);
+
+  let response: Response;
+  try {
+    response = await doFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enroll_code: code }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    throw new EnrollmentError(
+      `Could not reach the enrollment server at ${url}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    throw new EnrollmentError(
+      `Enrollment failed (HTTP ${response.status}). The enrollment code may be invalid, expired, ` +
+        `or already used — ask the agent to issue a fresh code and try again.`,
+      response.status,
+    );
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    data = (await response.json()) as Record<string, unknown>;
+  } catch {
+    throw new EnrollmentError('Enrollment server returned a malformed (non-JSON) response.');
+  }
+
+  const credential = normalizeRedeemResponse(data);
+  if (!credential.accessToken) {
+    throw new EnrollmentError('Enrollment response did not contain an access token.');
+  }
+  return credential;
+}
+
+// ---------------------------------------------------------------------------
+// Enrollment code resolution (--enroll <code> vs --enroll-stdin)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the enrollment code from `--enroll <code>` (argv) or `--enroll-stdin` (stdin), enforcing
+ * mutual exclusion. `--enroll-stdin` reads via the injected `readStdin` so the code NEVER lands in
+ * argv / shell history. `readStdin` is only invoked in the stdin mode.
+ */
+export function resolveEnrollCode(
+  opts: { enroll?: string; enrollStdin?: boolean },
+  readStdin: () => string,
+): string {
+  if (opts.enroll && opts.enrollStdin) {
+    throw new Error('Use either --enroll <code> or --enroll-stdin, not both.');
+  }
+  if (opts.enrollStdin) {
+    const code = readStdin().trim();
+    if (!code) throw new Error('No enrollment code received on stdin.');
+    return code;
+  }
+  if (opts.enroll) {
+    const code = opts.enroll.trim();
+    if (!code) throw new Error('Enrollment code (--enroll) is empty.');
+    return code;
+  }
+  throw new Error('An enrollment code is required: pass --enroll <code> or --enroll-stdin.');
+}
+
+// ---------------------------------------------------------------------------
+// Project pin upsert (D14)
+// ---------------------------------------------------------------------------
+
+/**
+ * Add (or replace) the `/p/<pin>` routing segment on a config URL so an agent session launched in
+ * this project folder routes strictly to this project's engine (design 06 D14). Existing `/p/<pin>`
+ * segments are replaced; the port / host / scheme are preserved.
+ */
+export function pinUrl(rawUrl: string, pin: string): string {
+  const stripExistingPin = (segments: string[]): string[] => {
+    const idx = segments.findIndex((s) => s === 'p');
+    if (idx >= 0 && idx === segments.length - 2 && /^[0-9a-f]{8}$/i.test(segments[idx + 1])) {
+      return segments.slice(0, idx);
+    }
+    return segments;
+  };
+
+  try {
+    const url = new URL(rawUrl);
+    let segments = stripExistingPin(url.pathname.split('/').filter(Boolean));
+    segments = [...segments, 'p', pin];
+    url.pathname = '/' + segments.join('/');
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    const base = rawUrl.replace(/\/+$/, '').replace(/\/p\/[0-9a-f]{8}$/i, '');
+    return `${base}/p/${pin}`;
+  }
+}
+
+/**
+ * The exact project-root STRING to feed into ProjectIdentity so the CLI-derived pin matches the
+ * plugin's. The Unity plugin registers with `ProjectIdentity.DerivePin(UnityMcpPluginEditor
+ * .ProjectRootPath)`, where `ProjectRootPath => Path.GetDirectoryName(Application.dataPath)`.
+ * `Application.dataPath` is forward-slash on EVERY platform (incl. Windows: `C:/proj/Assets`), so
+ * the plugin hashes a forward-slash root like `C:/proj`. Node's `path.resolve` yields BACKSLASHES
+ * on Windows (`C:\proj`), which the ProjectIdentity golden vectors hash to a DIFFERENT pin — so we
+ * convert separators to `/` here (a no-op on POSIX) to route to the same engine instance.
+ */
+export function projectRootForIdentity(projectPath: string): string {
+  return path.resolve(projectPath).replace(/\\/g, '/');
+}
+
+export interface PinUpsertResult {
+  updatedFiles: string[];
+}
+
+/**
+ * Upsert the project pin into every EXISTING project-local (project-scoped) JSON agent config that
+ * carries an `ai-game-developer` server entry with a `url` / `serverUrl`. Global client config
+ * files (Claude Desktop, Antigravity, Cline, the Copilot CLI) are never touched — the golden path
+ * writes no user-global entry. TOML (Codex) configs are left to the server binary's own
+ * `configure`. Returns the list of files actually rewritten.
+ */
+export function upsertProjectPinIntoConfigs(projectPath: string, pin: string): PinUpsertResult {
+  const resolvedProject = path.resolve(projectPath);
+  const updatedFiles: string[] = [];
+
+  for (const agent of agentRegistry) {
+    if (agent.configFormat !== 'json') continue;
+
+    const configPath = agent.getConfigPath(resolvedProject);
+    // Project-scoped only: the config path must live inside the project directory.
+    const relative = path.relative(resolvedProject, configPath);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) continue;
+    if (!fs.existsSync(configPath)) continue;
+
+    let root: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
+      root = parsed as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const body = root[agent.bodyPath];
+    if (!body || typeof body !== 'object' || Array.isArray(body)) continue;
+    const entry = (body as Record<string, unknown>)[MCP_SERVER_NAME];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+
+    const entryRecord = entry as Record<string, unknown>;
+    let changed = false;
+    for (const key of ['url', 'serverUrl']) {
+      const current = entryRecord[key];
+      if (typeof current === 'string' && current.length > 0) {
+        const pinned = pinUrl(current, pin);
+        if (pinned !== current) {
+          entryRecord[key] = pinned;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      fs.writeFileSync(configPath, JSON.stringify(root, null, 2) + '\n');
+      updatedFiles.push(configPath);
+    }
+  }
+
+  return { updatedFiles };
+}
+
+// ---------------------------------------------------------------------------
+// Full enroll flow
+// ---------------------------------------------------------------------------
+
+export interface RunEnrollOptions {
+  code: string;
+  projectPath: string;
+  store: MachineCredentialStore;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface RunEnrollResult {
+  serverTarget: string;
+  pin: string;
+  credentialPath: string;
+  markerPath: string;
+  pinnedConfigs: string[];
+}
+
+/**
+ * Execute the full enrollment side effect: redeem → persist the plugin credential to the SHARED
+ * machine store → write the project marker with the server target → upsert the D14 pin into
+ * existing project-local configs. NEVER writes a project token file / `cloudToken` config.
+ */
+export async function runEnroll(opts: RunEnrollOptions): Promise<RunEnrollResult> {
+  const credential = await redeemEnrollmentCode(opts.code, {
+    baseUrl: opts.baseUrl,
+    fetchImpl: opts.fetchImpl,
+  });
+
+  const serverTarget = credential.serverTarget ?? opts.baseUrl ?? CLOUD_SERVER_BASE_URL;
+
+  // Persist to the shared machine credential store (0600 / DPAPI) — never a project file.
+  opts.store.write({
+    accessToken: credential.accessToken,
+    refreshToken: credential.refreshToken,
+    expiresAt: credential.expiresAt,
+    serverTarget,
+    subject: credential.subject,
+  });
+
+  // Record the enrolled server target in the committable project marker.
+  const markerPath = writeProjectMarker(opts.projectPath, { serverTarget });
+
+  // Upsert the D14 pin into existing project-local agent configs. The pin is derived from the
+  // forward-slash project root so it matches the plugin's pin (see projectRootForIdentity).
+  const pin = deriveProjectPin(projectRootForIdentity(opts.projectPath));
+  const { updatedFiles } = upsertProjectPinIntoConfigs(opts.projectPath, pin);
+
+  return {
+    serverTarget,
+    pin,
+    credentialPath: opts.store.credentialsPath,
+    markerPath,
+    pinnedConfigs: updatedFiles,
+  };
+}

--- a/cli/src/utils/managed-server.ts
+++ b/cli/src/utils/managed-server.ts
@@ -1,0 +1,351 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash, randomUUID } from 'crypto';
+import { execFileSync } from 'child_process';
+import { MACHINE_STORE_DIR_NAME } from './machine-credentials.js';
+import { resolveHostRid, type Rid } from './rid.js';
+import {
+  DEFAULT_SERVER_VERSION,
+  SERVER_EXECUTABLE_NAME,
+  SERVER_RELEASE_REPO,
+  serverReleaseTag,
+} from './server-version.js';
+
+/**
+ * The CLI's MANAGED server directory — the machine-shared home the `install-plugin --with-server`
+ * download lands in, and the directory `configure --agent` proxies to. Lives beside the shared
+ * machine credential store (`~/.ai-game-dev/`) so the server binary is fetched once per machine,
+ * not once per project, and is NEVER on PATH (design 06/09: the binary lives in the CLI's managed
+ * dir). Layout mirrors the plugin's `Library/mcp-server/<rid>/` — one folder per RID + a `version`
+ * marker.
+ */
+export function managedServerRootDir(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, MACHINE_STORE_DIR_NAME, 'server');
+}
+
+export function managedServerDir(rid: string, homeDir: string = os.homedir()): string {
+  return path.join(managedServerRootDir(homeDir), rid);
+}
+
+/** The server executable file name for a RID (`.exe` suffix on Windows RIDs). */
+export function managedServerBinaryName(rid: string): string {
+  return rid.startsWith('win-') ? `${SERVER_EXECUTABLE_NAME}.exe` : SERVER_EXECUTABLE_NAME;
+}
+
+export function managedServerBinaryPath(rid: string, homeDir: string = os.homedir()): string {
+  return path.join(managedServerDir(rid, homeDir), managedServerBinaryName(rid));
+}
+
+/** Absolute path of the `version` marker recording which server version is staged for a RID. */
+export function managedServerVersionPath(rid: string, homeDir: string = os.homedir()): string {
+  return path.join(managedServerDir(rid, homeDir), 'version');
+}
+
+/** The release-asset zip NAME for a RID (`gamedev-mcp-server-<rid>.zip`) — the SHA256SUMS key. */
+export function serverZipName(rid: string): string {
+  return `${SERVER_EXECUTABLE_NAME}-${rid}.zip`;
+}
+
+/** The GitHub release download URL of the per-RID server zip, pinned to `version`. */
+export function serverZipUrl(rid: string, version: string): string {
+  return `https://github.com/${SERVER_RELEASE_REPO}/releases/download/${serverReleaseTag(version)}/${serverZipName(rid)}`;
+}
+
+/** The GitHub release download URL of the `SHA256SUMS` integrity manifest, pinned to `version`. */
+export function serverShaSumsUrl(version: string): string {
+  return `https://github.com/${SERVER_RELEASE_REPO}/releases/download/${serverReleaseTag(version)}/SHA256SUMS`;
+}
+
+/**
+ * Look up the expected SHA-256 (lowercase hex) for `fileName` in a `SHA256SUMS` manifest.
+ * Accepts the canonical `<hex>  <name>` line shape and the `<hex> *<name>` binary-mode variant.
+ * Returns null when no line names `fileName` (exact match — mirrors the C# exact-key Ordinal
+ * lookup), so a missing entry fails closed at the call site.
+ */
+export function parseSha256Sums(manifest: string, fileName: string): string | null {
+  for (const rawLine of manifest.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const match = line.match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/);
+    if (!match) continue;
+    const [, hash, name] = match;
+    if (name.trim() === fileName) return hash.toLowerCase();
+  }
+  return null;
+}
+
+/** SHA-256 of a buffer as lowercase hex. */
+export function sha256Hex(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Archive extraction (runtime side; not exercised by the mocked unit gate)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a `.zip` into `destDir` using the best available platform archive tool. Node ships no
+ * zip reader, so this shells out: bsdtar (`tar -xf`, present on Windows 10+ and macOS) and `unzip`
+ * (POSIX) cover every supported host, with a PowerShell `Expand-Archive` fallback on Windows. The
+ * caller verifies the extracted binary exists afterwards, so a silent no-op tool is still caught.
+ */
+export function extractZip(zipPath: string, destDir: string): void {
+  fs.mkdirSync(destDir, { recursive: true });
+
+  const strategies: Array<{ cmd: string; args: string[] }> =
+    process.platform === 'win32'
+      ? [
+          { cmd: 'tar', args: ['-xf', zipPath, '-C', destDir] },
+          {
+            cmd: 'powershell.exe',
+            args: [
+              '-NoProfile',
+              '-NonInteractive',
+              '-Command',
+              `Expand-Archive -LiteralPath ${JSON.stringify(zipPath)} -DestinationPath ${JSON.stringify(destDir)} -Force`,
+            ],
+          },
+        ]
+      : [
+          { cmd: 'unzip', args: ['-o', zipPath, '-d', destDir] },
+          { cmd: 'tar', args: ['-xf', zipPath, '-C', destDir] },
+        ];
+
+  let lastError: unknown;
+  for (const strategy of strategies) {
+    try {
+      execFileSync(strategy.cmd, strategy.args, { stdio: 'ignore' });
+      return;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw new Error(
+    `Failed to extract ${zipPath} into ${destDir}: no working archive tool ` +
+      `(tried ${strategies.map((s) => s.cmd).join(', ')}). ` +
+      (lastError instanceof Error ? lastError.message : String(lastError)),
+  );
+}
+
+/** Shallow-search (root, then one level of subdirs) for `binaryName`; returns its directory. */
+function locateBinaryDir(rootDir: string, binaryName: string): string | null {
+  if (fs.existsSync(path.join(rootDir, binaryName))) return rootDir;
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(rootDir, entry.name, binaryName);
+    if (fs.existsSync(candidate)) return path.join(rootDir, entry.name);
+  }
+  return null;
+}
+
+function copyDirContents(srcDir: string, destDir: string): void {
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const src = path.join(srcDir, entry.name);
+    const dest = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirContents(src, dest);
+    } else {
+      fs.copyFileSync(src, dest);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Download + verify + publish
+// ---------------------------------------------------------------------------
+
+export interface DownloadServerOptions {
+  /** Host RID; defaults to `resolveHostRid()`. */
+  rid?: string;
+  /** Server version to fetch; defaults to `DEFAULT_SERVER_VERSION`. */
+  version?: string;
+  /**
+   * Offline/CI escape hatch: a local zip path OR a URL to fetch the zip from. When set, the
+   * download uses this source and the SHA256SUMS integrity gate is SKIPPED (explicit-trust
+   * override — mirrors the addon `--source` pattern). Otherwise the pinned release zip is fetched
+   * and verified fail-closed against the release's SHA256SUMS.
+   */
+  source?: string;
+  /** Home directory override (tests). */
+  homeDir?: string;
+  /** `fetch` injection (tests). */
+  fetchImpl?: typeof fetch;
+  /** Extraction injection (tests) — `(zipPath, destDir) => void`. */
+  extractImpl?: (zipPath: string, destDir: string) => void;
+  /** Optional progress reporter. */
+  onProgress?: (message: string) => void;
+}
+
+export interface DownloadServerResult {
+  rid: string;
+  version: string;
+  /** Absolute path of the published server binary. */
+  binaryPath: string;
+  /** True when the zip passed SHA256SUMS verification; false for a `--server-source` override. */
+  verified: boolean;
+}
+
+async function fetchBytes(url: string, doFetch: typeof fetch): Promise<Buffer> {
+  const response = await doFetch(url);
+  if (!response.ok) {
+    throw new Error(`Download failed (HTTP ${response.status}) for ${url}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function fetchText(url: string, doFetch: typeof fetch): Promise<string> {
+  const response = await doFetch(url);
+  if (!response.ok) {
+    throw new Error(`Download failed (HTTP ${response.status}) for ${url}`);
+  }
+  return response.text();
+}
+
+/**
+ * Download (or copy from `--server-source`), verify against the release SHA256SUMS (fail-closed),
+ * extract, and atomically publish the pinned GameDev-MCP-Server binary for the host RID into the
+ * CLI's managed directory. Never launches the binary. Returns the published path.
+ */
+export async function downloadServerBinary(
+  opts: DownloadServerOptions = {},
+): Promise<DownloadServerResult> {
+  const rid: Rid | string = opts.rid ?? resolveHostRid();
+  const version = opts.version ?? DEFAULT_SERVER_VERSION;
+  const homeDir = opts.homeDir ?? os.homedir();
+  const doFetch = opts.fetchImpl ?? fetch;
+  const extract = opts.extractImpl ?? extractZip;
+  const report = opts.onProgress ?? (() => {});
+  const zipName = serverZipName(rid);
+
+  // 1. Obtain the zip bytes.
+  let zipBytes: Buffer;
+  let verified: boolean;
+  if (opts.source) {
+    if (fs.existsSync(opts.source)) {
+      report(`Using local server source: ${opts.source}`);
+      zipBytes = fs.readFileSync(opts.source);
+    } else {
+      report(`Downloading server from source URL: ${opts.source}`);
+      zipBytes = await fetchBytes(opts.source, doFetch);
+    }
+    verified = false; // explicit-trust override — no release SHA256SUMS to verify against
+  } else {
+    const zipUrl = serverZipUrl(rid, version);
+    report(`Downloading ${zipName} (v${version})...`);
+    zipBytes = await fetchBytes(zipUrl, doFetch);
+
+    // FAIL-CLOSED INTEGRITY GATE (verify-before-extract). The zip is UNTRUSTED until its SHA-256
+    // matches the release's SHA256SUMS entry for THIS RID. A missing/mismatched/unfetchable
+    // manifest aborts WITHOUT extracting — an unverified binary must never be published.
+    const sumsUrl = serverShaSumsUrl(version);
+    report('Verifying checksum against release SHA256SUMS...');
+    const manifest = await fetchText(sumsUrl, doFetch);
+    const expected = parseSha256Sums(manifest, zipName);
+    if (!expected) {
+      throw new Error(
+        `Integrity check failed: no SHA256SUMS entry for ${zipName} in the v${version} release. ` +
+          `Refusing to install an unverified server binary.`,
+      );
+    }
+    const actual = sha256Hex(zipBytes);
+    if (actual !== expected) {
+      throw new Error(
+        `Integrity check FAILED for ${zipName}: expected ${expected}, got ${actual}. ` +
+          `Refusing to install a tampered or corrupt server binary.`,
+      );
+    }
+    verified = true;
+  }
+
+  // 2. Stage into a same-root temp dir, extract, locate the binary.
+  const rootDir = managedServerRootDir(homeDir);
+  fs.mkdirSync(rootDir, { recursive: true });
+  const stagingDir = path.join(rootDir, `.staging-${rid}-${randomUUID()}`);
+  const tempZip = path.join(rootDir, `.${SERVER_EXECUTABLE_NAME}-${rid}-${randomUUID()}.zip`);
+  try {
+    fs.writeFileSync(tempZip, zipBytes);
+    fs.mkdirSync(stagingDir, { recursive: true });
+    report('Extracting server archive...');
+    extract(tempZip, stagingDir);
+
+    const binaryName = managedServerBinaryName(rid);
+    const binaryDir = locateBinaryDir(stagingDir, binaryName);
+    if (!binaryDir) {
+      throw new Error(
+        `Extracted archive did not contain '${binaryName}'. The '${zipName}' asset layout may have changed.`,
+      );
+    }
+
+    // 3. Publish: replace the per-RID cache folder with the staged payload, write the version
+    //    marker, and set the exec bit on POSIX so the payload is launch-ready.
+    const destDir = managedServerDir(rid, homeDir);
+    fs.rmSync(destDir, { recursive: true, force: true });
+    copyDirContents(binaryDir, destDir);
+
+    const binaryPath = managedServerBinaryPath(rid, homeDir);
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(binaryPath, 0o755);
+      } catch {
+        /* best effort */
+      }
+    }
+    fs.writeFileSync(managedServerVersionPath(rid, homeDir), version);
+
+    report(`Server binary ready: ${binaryPath}`);
+    return { rid, version, binaryPath, verified };
+  } finally {
+    fs.rmSync(tempZip, { force: true });
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// configure --agent proxy
+// ---------------------------------------------------------------------------
+
+export interface ConfigureProxyOptions {
+  agentId: string;
+  projectPath: string;
+  /** Optional explicit server URL forwarded to the binary's `configure --url`. */
+  url?: string;
+  rid?: string;
+  homeDir?: string;
+  /** Runner injection (tests) — `(binaryPath, args, cwd) => void`. */
+  runImpl?: (binaryPath: string, args: string[], cwd: string) => void;
+}
+
+export interface ConfigureProxyResult {
+  binaryPath: string;
+  args: string[];
+  cwd: string;
+}
+
+/**
+ * Proxy `configure --agent <id>` to the managed GameDev-MCP-Server binary's `configure`
+ * subcommand (design 06/09 Phase 3) so the shared C# configurator registry — with the derived
+ * `port=` + `project=` pin — is reachable from the terminal. The binary derives the pin/port from
+ * its working directory, so we run it with `cwd` = the resolved project path. When no managed
+ * binary is installed, throws a clear, actionable error pointing at `install-plugin --with-server`.
+ */
+export function proxyConfigure(opts: ConfigureProxyOptions): ConfigureProxyResult {
+  const rid = opts.rid ?? resolveHostRid();
+  const binaryPath = managedServerBinaryPath(rid, opts.homeDir);
+  if (!fs.existsSync(binaryPath)) {
+    throw new Error(
+      `No managed GameDev-MCP-Server binary found at ${binaryPath}. ` +
+        `Run 'unity-mcp-cli install-plugin --with-server' first to download it.`,
+    );
+  }
+  const args = ['configure', '--agent', opts.agentId, ...(opts.url ? ['--url', opts.url] : [])];
+  const cwd = path.resolve(opts.projectPath);
+  const run =
+    opts.runImpl ?? ((bin, a, workDir) => execFileSync(bin, a, { cwd: workDir, stdio: 'inherit' }));
+  run(binaryPath, args, cwd);
+  return { binaryPath, args, cwd };
+}

--- a/cli/src/utils/project-marker.ts
+++ b/cli/src/utils/project-marker.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { MACHINE_STORE_DIR_NAME } from './machine-credentials.js';
+
+/**
+ * The tool-neutral, NON-SECRET, committable project marker at
+ * `<project>/.ai-game-dev/project.json` (design 06/09, D15). It records the enrolled server
+ * target (hosted vs local) and the optional user port override so ProjectIdentity resolution and
+ * every config writer (engine UI, CLIs, `configure`) agree on one source of truth. Credentials
+ * NEVER go here — those live only in the machine credential store (`credentials.json`).
+ */
+
+export const PROJECT_MARKER_FILE = 'project.json';
+
+export interface ProjectMarker {
+  /** The server the project is enrolled against (hosted `https://ai-game.dev` or a local URL). */
+  serverTarget?: string;
+  /** User's explicit local-port override (wins over the deterministic derived port). */
+  portOverride?: number;
+  /** Unknown fields are preserved on read/merge for forward-compatibility. */
+  [key: string]: unknown;
+}
+
+export function projectMarkerDir(projectPath: string): string {
+  return path.join(projectPath, MACHINE_STORE_DIR_NAME);
+}
+
+export function projectMarkerPath(projectPath: string): string {
+  return path.join(projectMarkerDir(projectPath), PROJECT_MARKER_FILE);
+}
+
+/** Read the marker, or null when absent/unparsable. */
+export function readProjectMarker(projectPath: string): ProjectMarker | null {
+  const markerPath = projectMarkerPath(projectPath);
+  if (!fs.existsSync(markerPath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(markerPath, 'utf-8')) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as ProjectMarker;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge `marker` into any existing marker and write it back (creating the `.ai-game-dev/`
+ * directory as needed). Idempotent for the same inputs; preserves pre-existing keys. Returns the
+ * absolute marker path.
+ */
+export function writeProjectMarker(projectPath: string, marker: ProjectMarker): string {
+  const dir = projectMarkerDir(projectPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const merged: ProjectMarker = { ...(readProjectMarker(projectPath) ?? {}), ...marker };
+  const markerPath = projectMarkerPath(projectPath);
+  fs.writeFileSync(markerPath, JSON.stringify(merged, null, 2) + '\n');
+  return markerPath;
+}

--- a/cli/src/utils/rid.ts
+++ b/cli/src/utils/rid.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+/**
+ * Runtime Identifier (RID) detection for the shared GameDev-MCP-Server binary.
+ *
+ * The RID string `<os>-<arch>` (e.g. `win-x64`, `osx-arm64`) selects which
+ * `gamedev-mcp-server-<rid>.zip` release asset to download. Ported from the plugin's C#
+ * `McpServerManager.PlatformName` (`OperationSystem` + `-` + `CpuArch`) so the CLI and plugin
+ * resolve the same asset for the same host.
+ */
+
+/** The exact set of RIDs published as `gamedev-mcp-server-<rid>.zip` on every server release. */
+export const KNOWN_RIDS = [
+  'linux-arm64',
+  'linux-x64',
+  'osx-arm64',
+  'osx-x64',
+  'win-arm64',
+  'win-x64',
+  'win-x86',
+] as const;
+
+export type Rid = (typeof KNOWN_RIDS)[number];
+
+/** Map a Node `process.platform` value to the server's `OperationSystem` token, or null. */
+function osToken(platform: NodeJS.Platform): string | null {
+  if (platform === 'win32') return 'win';
+  if (platform === 'darwin') return 'osx';
+  if (platform === 'linux') return 'linux';
+  return null;
+}
+
+/** Map a Node `process.arch` value to the server's `CpuArch` token, or null. */
+function archToken(arch: string): string | null {
+  if (arch === 'x64') return 'x64';
+  if (arch === 'arm64') return 'arm64';
+  if (arch === 'ia32') return 'x86';
+  return null;
+}
+
+/**
+ * Resolve the host RID (defaulting to the current process's platform/arch). Throws a clear,
+ * actionable error when the host has no published server build — a fail-closed guard so
+ * `install-plugin --with-server` never silently downloads the wrong asset (or a 404 page).
+ */
+export function resolveHostRid(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): Rid {
+  const os = osToken(platform);
+  const cpu = archToken(arch);
+  if (!os || !cpu) {
+    throw new Error(
+      `Unsupported host platform/architecture (${platform}/${arch}). ` +
+        `Supported GameDev-MCP-Server RIDs: ${KNOWN_RIDS.join(', ')}.`,
+    );
+  }
+  const rid = `${os}-${cpu}`;
+  if (!(KNOWN_RIDS as readonly string[]).includes(rid)) {
+    throw new Error(
+      `No GameDev-MCP-Server build exists for host RID '${rid}' (${platform}/${arch}). ` +
+        `Supported RIDs: ${KNOWN_RIDS.join(', ')}.`,
+    );
+  }
+  return rid as Rid;
+}

--- a/cli/src/utils/server-version.ts
+++ b/cli/src/utils/server-version.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+/**
+ * The pinned GameDev-MCP-Server version the CLI fetches by default with
+ * `install-plugin --with-server`.
+ *
+ * Kept in LOCKSTEP with the Unity plugin's `ServerVersion` constant in
+ *   Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+ * so the CLI-downloaded binary and the plugin-downloaded binary can never drift. A drift guard
+ * in `tests/server-version.test.ts` reads that C# constant and asserts the two are byte-equal.
+ * Override at runtime with `--server-version <v>`.
+ *
+ * The CLI mirrors the constant rather than reading the `.cs` at runtime because the published npm
+ * package ships no plugin sources — the plugin release cadence bumps both in the same PR, and the
+ * drift-guard test fails CI if a bump touches only one side.
+ */
+export const DEFAULT_SERVER_VERSION = '9.0.0';
+
+/** GitHub `owner/repo` that hosts the shared server's tagged releases + per-RID zips. */
+export const SERVER_RELEASE_REPO = 'IvanMurzak/GameDev-MCP-Server';
+
+/** Base executable name (no extension) of the shared server binary. */
+export const SERVER_EXECUTABLE_NAME = 'gamedev-mcp-server';
+
+/**
+ * The Git release TAG for a server version: the version with a leading `v` (e.g. `9.0.0` →
+ * `v9.0.0`). GameDev-MCP-Server tags every release `v<version>` and the per-RID zips + the
+ * `SHA256SUMS` manifest are attached to THAT tag — so the download path MUST use the v-prefixed
+ * tag (a bare-version path 404s). Already-v-prefixed input is passed through unchanged so a caller
+ * cannot accidentally double-prefix. Mirrors the C# `McpServerManager.ServerReleaseTag`.
+ */
+export function serverReleaseTag(version: string): string {
+  const v = (version ?? '').trim();
+  return v.startsWith('v') ? v : `v${v}`;
+}

--- a/cli/tests/enroll.test.ts
+++ b/cli/tests/enroll.test.ts
@@ -1,0 +1,288 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  redeemEnrollmentCode,
+  normalizeRedeemResponse,
+  resolveEnrollCode,
+  pinUrl,
+  upsertProjectPinIntoConfigs,
+  runEnroll,
+  projectRootForIdentity,
+  EnrollmentError,
+} from '../src/utils/enroll.js';
+import { deriveProjectPin } from '../src/utils/port.js';
+import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
+
+function tmpProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'enroll-'));
+}
+
+interface CapturedRequest {
+  url: string;
+  body: unknown;
+  method?: string;
+}
+
+/** A fetch double for the AS enroll/redeem endpoint that captures the request. */
+function makeRedeemFetch(
+  responseBody: Record<string, unknown>,
+  status: number,
+  captured: CapturedRequest[],
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured.push({
+      url: String(input),
+      method: init?.method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    if (status >= 400) return new Response('nope', { status });
+    return new Response(JSON.stringify(responseBody), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+}
+
+describe('normalizeRedeemResponse', () => {
+  it('accepts snake_case fields', () => {
+    const c = normalizeRedeemResponse({
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_at: '2030-01-01T00:00:00Z',
+      server_target: 'https://ai-game.dev',
+      subject: 'acct-1',
+    });
+    expect(c).toEqual({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      expiresAt: '2030-01-01T00:00:00Z',
+      serverTarget: 'https://ai-game.dev',
+      subject: 'acct-1',
+    });
+  });
+
+  it('accepts camelCase fields', () => {
+    const c = normalizeRedeemResponse({
+      accessToken: 'at',
+      refreshToken: 'rt',
+      serverTarget: 'http://localhost:24000',
+    });
+    expect(c.accessToken).toBe('at');
+    expect(c.refreshToken).toBe('rt');
+    expect(c.serverTarget).toBe('http://localhost:24000');
+  });
+
+  it('converts expires_in seconds to an absolute expiresAt', () => {
+    const before = Date.now();
+    const c = normalizeRedeemResponse({ access_token: 'at', expires_in: 3600 });
+    const at = new Date(c.expiresAt!).getTime();
+    expect(at).toBeGreaterThanOrEqual(before + 3600 * 1000 - 5000);
+    expect(at).toBeLessThanOrEqual(Date.now() + 3600 * 1000 + 5000);
+  });
+});
+
+describe('redeemEnrollmentCode', () => {
+  it('POSTs {enroll_code} in the body (never the URL) and returns the credential', async () => {
+    const captured: CapturedRequest[] = [];
+    const fetchImpl = makeRedeemFetch(
+      { access_token: 'plugin-jwt', refresh_token: 'rt', server_target: 'https://ai-game.dev' },
+      200,
+      captured,
+    );
+
+    const cred = await redeemEnrollmentCode('SECRET-CODE-123', {
+      baseUrl: 'https://ai-game.dev',
+      fetchImpl,
+    });
+
+    expect(cred.accessToken).toBe('plugin-jwt');
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toBe('https://ai-game.dev/api/auth/enroll/redeem');
+    expect(captured[0].method).toBe('POST');
+    expect(captured[0].body).toEqual({ enroll_code: 'SECRET-CODE-123' });
+    // The code must NOT appear in the URL / query string.
+    expect(captured[0].url).not.toContain('SECRET-CODE-123');
+  });
+
+  it('surfaces a spent/invalid code as an actionable EnrollmentError with the HTTP status', async () => {
+    const captured: CapturedRequest[] = [];
+    const fetchImpl = makeRedeemFetch({}, 400, captured);
+
+    await expect(
+      redeemEnrollmentCode('BURNED', { baseUrl: 'https://ai-game.dev', fetchImpl }),
+    ).rejects.toMatchObject({ name: 'EnrollmentError', status: 400 });
+  });
+
+  it('rejects a response with no access token', async () => {
+    const captured: CapturedRequest[] = [];
+    const fetchImpl = makeRedeemFetch({ server_target: 'https://ai-game.dev' }, 200, captured);
+    await expect(
+      redeemEnrollmentCode('X', { baseUrl: 'https://ai-game.dev', fetchImpl }),
+    ).rejects.toThrow(EnrollmentError);
+  });
+});
+
+describe('resolveEnrollCode (--enroll vs --enroll-stdin)', () => {
+  it('reads from stdin (not argv) in --enroll-stdin mode', () => {
+    let stdinRead = false;
+    const code = resolveEnrollCode({ enrollStdin: true }, () => {
+      stdinRead = true;
+      return '  code-from-stdin\n';
+    });
+    expect(code).toBe('code-from-stdin');
+    expect(stdinRead).toBe(true);
+  });
+
+  it('reads from argv in --enroll mode and never touches stdin', () => {
+    let stdinRead = false;
+    const code = resolveEnrollCode({ enroll: 'code-from-argv' }, () => {
+      stdinRead = true;
+      return 'unused';
+    });
+    expect(code).toBe('code-from-argv');
+    expect(stdinRead).toBe(false);
+  });
+
+  it('rejects supplying both', () => {
+    expect(() => resolveEnrollCode({ enroll: 'a', enrollStdin: true }, () => 'b')).toThrow(/not both/);
+  });
+
+  it('rejects supplying neither', () => {
+    expect(() => resolveEnrollCode({}, () => '')).toThrow(/required/);
+  });
+
+  it('rejects empty stdin', () => {
+    expect(() => resolveEnrollCode({ enrollStdin: true }, () => '   \n')).toThrow(/No enrollment code/);
+  });
+});
+
+describe('projectRootForIdentity', () => {
+  it('produces a forward-slash absolute root (matching the plugin ProjectRootPath)', () => {
+    const root = projectRootForIdentity(process.cwd());
+    expect(root).not.toContain('\\'); // never a backslash — plugin uses Application.dataPath form
+    expect(path.isAbsolute(root) || /^[A-Za-z]:\//.test(root)).toBe(true);
+  });
+
+  it('derives the same pin regardless of input separator style for the same path', () => {
+    // A path expressed with backslashes vs forward slashes must normalize to the same pin,
+    // because path.resolve + the /\\/->/ conversion canonicalizes the separators.
+    const a = projectRootForIdentity('C:/tmp/some-proj');
+    const b = projectRootForIdentity('C:/tmp/some-proj/');
+    expect(deriveProjectPin(a)).toBe(deriveProjectPin(b));
+  });
+});
+
+describe('pinUrl', () => {
+  it('appends /p/<pin> to a hosted URL', () => {
+    expect(pinUrl('https://ai-game.dev/mcp', '34ea75f2')).toBe('https://ai-game.dev/mcp/p/34ea75f2');
+  });
+  it('appends /p/<pin> to a localhost URL', () => {
+    expect(pinUrl('http://localhost:24000', '8ef72cf7')).toBe('http://localhost:24000/p/8ef72cf7');
+  });
+  it('replaces an existing pin rather than stacking', () => {
+    expect(pinUrl('https://ai-game.dev/mcp/p/00000000', '34ea75f2')).toBe(
+      'https://ai-game.dev/mcp/p/34ea75f2',
+    );
+  });
+});
+
+describe('upsertProjectPinIntoConfigs', () => {
+  it('pins the ai-game-developer URL in an existing project-local .mcp.json', () => {
+    const project = tmpProject();
+    try {
+      const mcpJson = path.join(project, '.mcp.json');
+      fs.writeFileSync(
+        mcpJson,
+        JSON.stringify({ mcpServers: { 'ai-game-developer': { type: 'http', url: 'https://ai-game.dev/mcp' } } }, null, 2),
+      );
+
+      const { updatedFiles } = upsertProjectPinIntoConfigs(project, '34ea75f2');
+      expect(updatedFiles).toContain(mcpJson);
+
+      const written = JSON.parse(fs.readFileSync(mcpJson, 'utf-8'));
+      expect(written.mcpServers['ai-game-developer'].url).toBe('https://ai-game.dev/mcp/p/34ea75f2');
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves configs without an ai-game-developer entry untouched', () => {
+    const project = tmpProject();
+    try {
+      const mcpJson = path.join(project, '.mcp.json');
+      const original = JSON.stringify({ mcpServers: { other: { url: 'https://example.com' } } }, null, 2);
+      fs.writeFileSync(mcpJson, original);
+
+      const { updatedFiles } = upsertProjectPinIntoConfigs(project, '34ea75f2');
+      expect(updatedFiles).toHaveLength(0);
+      expect(fs.readFileSync(mcpJson, 'utf-8')).toBe(original);
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op for a project with no agent configs', () => {
+    const project = tmpProject();
+    try {
+      const { updatedFiles } = upsertProjectPinIntoConfigs(project, '34ea75f2');
+      expect(updatedFiles).toHaveLength(0);
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runEnroll (full side effect)', () => {
+  it('writes the credential to the machine store + marker + pin, never a project token file', async () => {
+    const project = tmpProject();
+    const storeDir = path.join(project, '.ai-game-dev');
+    try {
+      // Pre-existing project-local agent config that should get pinned.
+      const mcpJson = path.join(project, '.mcp.json');
+      fs.writeFileSync(
+        mcpJson,
+        JSON.stringify({ mcpServers: { 'ai-game-developer': { type: 'http', url: 'https://ai-game.dev/mcp' } } }, null, 2),
+      );
+
+      const store = new MachineCredentialStore(storeDir);
+      const captured: CapturedRequest[] = [];
+      const fetchImpl = makeRedeemFetch(
+        {
+          access_token: 'plugin-jwt',
+          refresh_token: 'plugin-refresh',
+          server_target: 'https://ai-game.dev',
+          expires_in: 3600,
+        },
+        200,
+        captured,
+      );
+
+      const result = await runEnroll({ code: 'CODE', projectPath: project, store, fetchImpl });
+
+      // 1. Credential in the machine store (never a project cloudToken config).
+      const creds = store.read();
+      expect(creds?.accessToken).toBe('plugin-jwt');
+      expect(creds?.refreshToken).toBe('plugin-refresh');
+      expect(creds?.serverTarget).toBe('https://ai-game.dev');
+      expect(fs.existsSync(path.join(project, 'UserSettings', 'AI-Game-Developer-Config.json'))).toBe(false);
+
+      // 2. Project marker records the server target.
+      const marker = JSON.parse(fs.readFileSync(result.markerPath, 'utf-8'));
+      expect(marker.serverTarget).toBe('https://ai-game.dev');
+
+      // 3. Pin upserted into the existing config (forward-slash root, matching the plugin).
+      const expectedPin = deriveProjectPin(projectRootForIdentity(project));
+      expect(result.pin).toBe(expectedPin);
+      const written = JSON.parse(fs.readFileSync(mcpJson, 'utf-8'));
+      expect(written.mcpServers['ai-game-developer'].url).toBe(`https://ai-game.dev/mcp/p/${expectedPin}`);
+      expect(result.pinnedConfigs).toContain(mcpJson);
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/install-plugin-enroll-cli.test.ts
+++ b/cli/tests/install-plugin-enroll-cli.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import { runCliAsync } from './helpers/cli.js';
+
+// Wiring smoke: confirm the new install-plugin / configure options are registered and reachable
+// through the real CLI entry point (no network — --help only).
+
+describe('install-plugin new option wiring', () => {
+  it('exposes --with-server / --server-version / --server-source / --enroll / --enroll-stdin', async () => {
+    const { stdout, exitCode } = await runCliAsync(['install-plugin', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--with-server');
+    expect(stdout).toContain('--server-version');
+    expect(stdout).toContain('--server-source');
+    expect(stdout).toContain('--enroll');
+    expect(stdout).toContain('--enroll-stdin');
+  });
+});
+
+describe('configure new option wiring', () => {
+  it('exposes --agent', async () => {
+    const { stdout, exitCode } = await runCliAsync(['configure', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--agent');
+  });
+});

--- a/cli/tests/managed-server.test.ts
+++ b/cli/tests/managed-server.test.ts
@@ -1,0 +1,271 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+import {
+  parseSha256Sums,
+  sha256Hex,
+  serverZipName,
+  serverZipUrl,
+  serverShaSumsUrl,
+  managedServerBinaryPath,
+  managedServerDir,
+  managedServerVersionPath,
+  downloadServerBinary,
+  proxyConfigure,
+} from '../src/utils/managed-server.js';
+
+const RID = 'linux-x64'; // binary name has no `.exe` on any host — deterministic across CI + Windows
+
+function tmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/** A fetch double that serves `.zip` bytes and the `SHA256SUMS` manifest by URL suffix. */
+function makeFetch(zipBytes: Buffer, sumsText: string | null): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith('.zip')) {
+      return new Response(zipBytes, { status: 200 });
+    }
+    if (url.endsWith('/SHA256SUMS')) {
+      if (sumsText === null) return new Response('not found', { status: 404 });
+      return new Response(sumsText, { status: 200 });
+    }
+    return new Response('not found', { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+/** An extraction double that drops a fake server binary into the staging dir. */
+function fakeExtract(binaryName: string): (zipPath: string, destDir: string) => void {
+  return (_zipPath, destDir) => {
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(path.join(destDir, binaryName), 'fake-binary');
+    fs.writeFileSync(path.join(destDir, 'sidecar.dll'), 'fake-sidecar');
+  };
+}
+
+describe('parseSha256Sums', () => {
+  const sums =
+    'aaaa000000000000000000000000000000000000000000000000000000000000  gamedev-mcp-server-win-x64.zip\n' +
+    'bbbb111111111111111111111111111111111111111111111111111111111111  gamedev-mcp-server-linux-x64.zip\n';
+
+  it('finds the hash for an exact file name', () => {
+    expect(parseSha256Sums(sums, 'gamedev-mcp-server-linux-x64.zip')).toBe(
+      'bbbb111111111111111111111111111111111111111111111111111111111111',
+    );
+  });
+  it('returns null when the file name is absent', () => {
+    expect(parseSha256Sums(sums, 'gamedev-mcp-server-osx-arm64.zip')).toBeNull();
+  });
+  it('handles the binary-mode "hex *name" variant and lowercases the hash', () => {
+    const upper = 'CCCC222222222222222222222222222222222222222222222222222222222222 *file.zip';
+    expect(parseSha256Sums(upper, 'file.zip')).toBe(
+      'cccc222222222222222222222222222222222222222222222222222222222222',
+    );
+  });
+});
+
+describe('URL + name helpers', () => {
+  it('builds the zip name / url / SHA256SUMS url from RID + version', () => {
+    expect(serverZipName('win-x64')).toBe('gamedev-mcp-server-win-x64.zip');
+    expect(serverZipUrl('win-x64', '9.0.0')).toBe(
+      'https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v9.0.0/gamedev-mcp-server-win-x64.zip',
+    );
+    expect(serverShaSumsUrl('9.0.0')).toBe(
+      'https://github.com/IvanMurzak/GameDev-MCP-Server/releases/download/v9.0.0/SHA256SUMS',
+    );
+  });
+});
+
+describe('downloadServerBinary (verify-before-extract)', () => {
+  it('downloads, verifies the checksum, extracts, and publishes the binary', async () => {
+    const home = tmpDir('mgs-ok-');
+    try {
+      const zipBytes = Buffer.from('the-real-zip-bytes');
+      const hash = createHash('sha256').update(zipBytes).digest('hex');
+      const sums = `${hash}  ${serverZipName(RID)}\n`;
+
+      const result = await downloadServerBinary({
+        rid: RID,
+        version: '9.0.0',
+        homeDir: home,
+        fetchImpl: makeFetch(zipBytes, sums),
+        extractImpl: fakeExtract('gamedev-mcp-server'),
+      });
+
+      expect(result.verified).toBe(true);
+      expect(result.rid).toBe(RID);
+      expect(result.binaryPath).toBe(managedServerBinaryPath(RID, home));
+      expect(fs.existsSync(result.binaryPath)).toBe(true);
+      expect(fs.readFileSync(managedServerVersionPath(RID, home), 'utf-8')).toBe('9.0.0');
+      // Sidecars are published alongside the binary.
+      expect(fs.existsSync(path.join(managedServerDir(RID, home), 'sidecar.dll'))).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('FAILS CLOSED on a checksum mismatch — nothing is published', async () => {
+    const home = tmpDir('mgs-bad-');
+    try {
+      const zipBytes = Buffer.from('tampered-bytes');
+      // A hash for DIFFERENT content — the downloaded bytes will not match.
+      const wrongHash = createHash('sha256').update('other-content').digest('hex');
+      const sums = `${wrongHash}  ${serverZipName(RID)}\n`;
+
+      await expect(
+        downloadServerBinary({
+          rid: RID,
+          version: '9.0.0',
+          homeDir: home,
+          fetchImpl: makeFetch(zipBytes, sums),
+          extractImpl: fakeExtract('gamedev-mcp-server'),
+        }),
+      ).rejects.toThrow(/Integrity check FAILED/);
+
+      expect(fs.existsSync(managedServerBinaryPath(RID, home))).toBe(false);
+      expect(fs.existsSync(managedServerDir(RID, home))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('FAILS CLOSED when the SHA256SUMS manifest has no entry for the RID', async () => {
+    const home = tmpDir('mgs-noentry-');
+    try {
+      const zipBytes = Buffer.from('bytes');
+      const sums = 'deadbeef00000000000000000000000000000000000000000000000000000000  some-other-file.zip\n';
+
+      await expect(
+        downloadServerBinary({
+          rid: RID,
+          version: '9.0.0',
+          homeDir: home,
+          fetchImpl: makeFetch(zipBytes, sums),
+          extractImpl: fakeExtract('gamedev-mcp-server'),
+        }),
+      ).rejects.toThrow(/no SHA256SUMS entry/);
+
+      expect(fs.existsSync(managedServerDir(RID, home))).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('honours a local --server-source override (skips checksum verification)', async () => {
+    const home = tmpDir('mgs-src-');
+    const srcDir = tmpDir('mgs-srczip-');
+    try {
+      const localZip = path.join(srcDir, 'local-server.zip');
+      fs.writeFileSync(localZip, 'local-zip-bytes');
+
+      const result = await downloadServerBinary({
+        rid: RID,
+        version: '9.0.0',
+        homeDir: home,
+        source: localZip,
+        // fetch must never be called for a local source — make it throw if it is.
+        fetchImpl: (() => {
+          throw new Error('network should not be used for a local --server-source');
+        }) as unknown as typeof fetch,
+        extractImpl: fakeExtract('gamedev-mcp-server'),
+      });
+
+      expect(result.verified).toBe(false);
+      expect(fs.existsSync(result.binaryPath)).toBe(true);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(srcDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('sha256Hex', () => {
+  it('matches Node crypto', () => {
+    const buf = Buffer.from('hello');
+    expect(sha256Hex(buf)).toBe(createHash('sha256').update(buf).digest('hex'));
+  });
+});
+
+describe('proxyConfigure', () => {
+  it('runs the managed binary with the configure args and project cwd', () => {
+    const home = tmpDir('mgs-cfg-');
+    const project = tmpDir('mgs-proj-');
+    try {
+      // Plant a fake managed binary at the expected path.
+      const dir = managedServerDir(RID, home);
+      fs.mkdirSync(dir, { recursive: true });
+      const binPath = managedServerBinaryPath(RID, home);
+      fs.writeFileSync(binPath, 'fake');
+
+      const calls: Array<{ bin: string; args: string[]; cwd: string }> = [];
+      const result = proxyConfigure({
+        agentId: 'claude-code',
+        projectPath: project,
+        url: 'https://ai-game.dev/mcp',
+        rid: RID,
+        homeDir: home,
+        runImpl: (bin, args, cwd) => calls.push({ bin, args, cwd }),
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].bin).toBe(binPath);
+      expect(calls[0].args).toEqual(['configure', '--agent', 'claude-code', '--url', 'https://ai-game.dev/mcp']);
+      expect(calls[0].cwd).toBe(path.resolve(project));
+      expect(result.binaryPath).toBe(binPath);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('omits --url when none is supplied', () => {
+    const home = tmpDir('mgs-cfg2-');
+    const project = tmpDir('mgs-proj2-');
+    try {
+      fs.mkdirSync(managedServerDir(RID, home), { recursive: true });
+      fs.writeFileSync(managedServerBinaryPath(RID, home), 'fake');
+
+      const calls: string[][] = [];
+      proxyConfigure({
+        agentId: 'cursor',
+        projectPath: project,
+        rid: RID,
+        homeDir: home,
+        runImpl: (_bin, args) => calls.push(args),
+      });
+      expect(calls[0]).toEqual(['configure', '--agent', 'cursor']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('throws an actionable error when no managed binary is installed', () => {
+    const home = tmpDir('mgs-nobin-');
+    const project = tmpDir('mgs-proj3-');
+    try {
+      let ran = false;
+      expect(() =>
+        proxyConfigure({
+          agentId: 'claude-code',
+          projectPath: project,
+          rid: RID,
+          homeDir: home,
+          runImpl: () => {
+            ran = true;
+          },
+        }),
+      ).toThrow(/install-plugin --with-server/);
+      expect(ran).toBe(false);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/project-marker.test.ts
+++ b/cli/tests/project-marker.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  readProjectMarker,
+  writeProjectMarker,
+  projectMarkerPath,
+} from '../src/utils/project-marker.js';
+
+function tmpProject(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'marker-'));
+}
+
+describe('project marker', () => {
+  it('returns null when the marker is absent', () => {
+    const project = tmpProject();
+    try {
+      expect(readProjectMarker(project)).toBeNull();
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('writes the marker to <project>/.ai-game-dev/project.json and reads it back', () => {
+    const project = tmpProject();
+    try {
+      const written = writeProjectMarker(project, { serverTarget: 'https://ai-game.dev' });
+      expect(written).toBe(projectMarkerPath(project));
+      expect(written).toContain(path.join('.ai-game-dev', 'project.json'));
+
+      const marker = readProjectMarker(project);
+      expect(marker?.serverTarget).toBe('https://ai-game.dev');
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('merges into an existing marker, preserving unrelated keys', () => {
+    const project = tmpProject();
+    try {
+      writeProjectMarker(project, { serverTarget: 'http://localhost:24000', portOverride: 24000 });
+      writeProjectMarker(project, { serverTarget: 'https://ai-game.dev' });
+
+      const marker = readProjectMarker(project);
+      expect(marker?.serverTarget).toBe('https://ai-game.dev');
+      expect(marker?.portOverride).toBe(24000); // preserved
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('is idempotent for the same inputs', () => {
+    const project = tmpProject();
+    try {
+      writeProjectMarker(project, { serverTarget: 'https://ai-game.dev' });
+      const first = fs.readFileSync(projectMarkerPath(project), 'utf-8');
+      writeProjectMarker(project, { serverTarget: 'https://ai-game.dev' });
+      const second = fs.readFileSync(projectMarkerPath(project), 'utf-8');
+      expect(second).toBe(first);
+    } finally {
+      fs.rmSync(project, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/tests/rid.test.ts
+++ b/cli/tests/rid.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import { resolveHostRid, KNOWN_RIDS } from '../src/utils/rid.js';
+
+describe('resolveHostRid', () => {
+  const cases: Array<[NodeJS.Platform, string, string]> = [
+    ['win32', 'x64', 'win-x64'],
+    ['win32', 'arm64', 'win-arm64'],
+    ['win32', 'ia32', 'win-x86'],
+    ['darwin', 'x64', 'osx-x64'],
+    ['darwin', 'arm64', 'osx-arm64'],
+    ['linux', 'x64', 'linux-x64'],
+    ['linux', 'arm64', 'linux-arm64'],
+  ];
+
+  for (const [platform, arch, expected] of cases) {
+    it(`maps ${platform}/${arch} -> ${expected}`, () => {
+      expect(resolveHostRid(platform, arch)).toBe(expected);
+      expect(KNOWN_RIDS).toContain(expected as (typeof KNOWN_RIDS)[number]);
+    });
+  }
+
+  it('throws for an unknown platform', () => {
+    expect(() => resolveHostRid('sunos' as NodeJS.Platform, 'x64')).toThrow(/Unsupported host/);
+  });
+
+  it('throws for an unknown architecture', () => {
+    expect(() => resolveHostRid('linux', 'mips')).toThrow(/Unsupported host/);
+  });
+
+  it('throws for a platform/arch combo with no published build (osx-x86)', () => {
+    // ia32 -> x86 is a valid token, but osx-x86 is not a published RID.
+    expect(() => resolveHostRid('darwin', 'ia32')).toThrow(/No GameDev-MCP-Server build/);
+  });
+
+  it('defaults to the current process platform/arch', () => {
+    expect(KNOWN_RIDS).toContain(resolveHostRid());
+  });
+});

--- a/cli/tests/server-version.test.ts
+++ b/cli/tests/server-version.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { DEFAULT_SERVER_VERSION, serverReleaseTag } from '../src/utils/server-version.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The plugin's pinned ServerVersion constant. The CLI default MUST match it byte-for-byte so a
+// CLI-downloaded server can never drift from what the plugin downloads.
+const MCP_SERVER_MANAGER_CS = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'Unity-MCP-Plugin',
+  'Packages',
+  'com.ivanmurzak.unity.mcp',
+  'Editor',
+  'Scripts',
+  'McpServerManager.cs',
+);
+
+describe('DEFAULT_SERVER_VERSION drift guard', () => {
+  it('is a valid semver-ish version string', () => {
+    expect(DEFAULT_SERVER_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('matches the plugin ServerVersion constant in McpServerManager.cs', () => {
+    // Only asserted in-repo (the published npm package ships no plugin sources).
+    if (!fs.existsSync(MCP_SERVER_MANAGER_CS)) {
+      expect(DEFAULT_SERVER_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+      return;
+    }
+    const source = fs.readFileSync(MCP_SERVER_MANAGER_CS, 'utf-8');
+    const match = source.match(/public const string ServerVersion\s*=\s*"([^"]+)"/);
+    expect(match, 'ServerVersion constant not found in McpServerManager.cs').not.toBeNull();
+    expect(DEFAULT_SERVER_VERSION).toBe(match![1]);
+  });
+});
+
+describe('serverReleaseTag', () => {
+  it('adds a leading v to a bare version', () => {
+    expect(serverReleaseTag('9.0.0')).toBe('v9.0.0');
+  });
+  it('passes a v-prefixed version through unchanged (no double prefix)', () => {
+    expect(serverReleaseTag('v9.0.0')).toBe('v9.0.0');
+  });
+  it('trims surrounding whitespace', () => {
+    expect(serverReleaseTag('  9.0.0 ')).toBe('v9.0.0');
+  });
+});


### PR DESCRIPTION
## Summary

- **`install-plugin --with-server`** — detect the host RID, download the RID-matched `gamedev-mcp-server-<rid>.zip` into the CLI's machine-shared managed dir, **verify against the release `SHA256SUMS` fail-closed before extract**, extract, and record the managed binary path. Default version = the plugin's pinned `ServerVersion` (`9.0.0`, drift-guarded by a test that reads `McpServerManager.cs`), with `--server-version` and `--server-source <path-or-url>` (offline/CI) escape hatches.
- **`install-plugin --enroll <code>` / `--enroll-stdin`** — redeem the enrollment code against the cloud AS (`POST /api/auth/enroll/redeem`), persist the plugin credential to the **shared machine store** (CLI-PR1's store), write the committable project marker (`.ai-game-dev/project.json`) with the server target, and upsert the D14 project pin into existing project-local agent configs. `--enroll-stdin` reads the code from stdin (never argv). Burn-on-first-redeem is server-side; spent/invalid codes surface a clean, actionable error.
- **`configure --agent <id>`** — proxy to the managed server binary's `configure` surface; actionable error when no managed binary is installed.

Second (final) `unity-mcp-cli` PR for the mcp-authorize terminal-onboarding surface (design d2, refs 06 + 09), building on CLI-PR1 (#883). Onboarding workflows 1A (agent-first hosted) + 1B (offline, zero auth).

The pin is derived from the forward-slash project root so it matches the plugin's `ProjectIdentity.DerivePin(ProjectRootPath)` (`Path.GetDirectoryName(Application.dataPath)`, forward-slash on Windows) rather than Node's backslash `path.resolve`.

## Test plan

- [x] Target-specific local tests passed (CLI Suite 3: `npm test` — 496 passed, 2 skipped, 0 failures)
- [x] New unit coverage: RID detection, fail-closed SHA256 verification (mocked download), `--server-source` override, stdin-not-argv code handling, enroll store+marker+pin (no project token file), configure proxy — all with mocked fetch + a fake AS (no live network)
- [x] Golden-vector parity (CLI-PR1) kept green

No CLI version bump / npm publish — the CLI rides the Unity plugin release.

Closes #885