### PR TITLE
fix(cli): setup-mcp writes credential-free URL-only config for OAuth clients

### DIFF
--- a/cli/src/lib/setup-mcp.ts
+++ b/cli/src/lib/setup-mcp.ts
@@ -36,6 +36,20 @@ function portFromHost(host: string | undefined, projectPath: string): number {
 }
 
 /**
+ * True when `configPath` resolves to a location at or under `projectRoot`
+ * (separator- and case-insensitive) — i.e. a VCS-visible project-scoped file.
+ * Mirrors the b6 configurator's `IsProjectScopedPath`, used to decide whether a
+ * written access token would land in a committable file (design 03 Flow C).
+ */
+function isProjectScoped(configPath: string, projectRoot: string): boolean {
+  const norm = (p: string): string =>
+    path.resolve(p).replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  const root = norm(projectRoot);
+  const target = norm(configPath);
+  return target === root || target.startsWith(root + '/');
+}
+
+/**
  * Write MCP configuration for the given AI agent, so it can talk to
  * Unity-MCP. Library-safe: no stdout noise, no process.exit, no throws
  * past the public boundary.
@@ -112,8 +126,24 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
 
     const timeout = (config?.timeoutMs as number) ?? 10000;
     const auth = (config?.authOption as string) ?? 'none';
+
+    // Explicit PAT opt-in (design 03 Flow C): a token the caller passed on the
+    // command line (`--token`). Only an explicit opt-in — never a token merely
+    // resolved from the project config — places a static credential in the file.
+    const patOptIn = typeof opts.token === 'string' && opts.token.length > 0;
     const token = opts.token ?? fromConfig.token ?? '';
-    const authRequired = auth === 'required';
+
+    // b6 credential policy (design decision D11): the DEFAULT http config is
+    // credential-free. OAuth-capable clients perform native RFC 9728 OAuth
+    // against the URL (Flow A), so a static `Authorization: Bearer` header both
+    // FAILS (the hosted ai-game.dev/mcp endpoint 401s the token) AND suppresses
+    // the client's own OAuth handshake ("OAuth fallback is disabled when
+    // headers.Authorization is set"). A static header is written ONLY for an
+    // explicit PAT opt-in (Flow C) or a client that cannot do MCP OAuth
+    // (`supportsOAuth === false`) — never automatically for an OAuth-capable
+    // client, regardless of the server's `authRequired` setting.
+    const supportsOAuth = agent.supportsOAuth !== false;
+    const emitAuthHeader = token.length > 0 && (patOptIn || !supportsOAuth);
 
     const serverPath = resolveServerBinaryPath(projectPath).replace(/\\/g, '/');
 
@@ -130,7 +160,7 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
       props = agent.getStdioProps(serverPath, port, timeout, auth, token);
       removeKeys = agent.stdioRemoveKeys;
     } else {
-      props = agent.getHttpProps(serverUrl, token, authRequired);
+      props = agent.getHttpProps(serverUrl, token, emitAuthHeader);
       removeKeys = agent.httpRemoveKeys;
     }
 
@@ -145,6 +175,15 @@ export async function setupMcp(opts: SetupMcpOptions): Promise<SetupMcpResult> {
       message: `Wrote ${configPath}`,
       manifestPath: configPath,
     });
+
+    // Flow C credential-placement rule (design 03): a static access token
+    // written into a project-scoped config file is VCS-visible. Warn so the
+    // user prefers an env-var / user-scope placement for the credential.
+    if (transport === 'http' && emitAuthHeader && isProjectScoped(configPath, projectPath)) {
+      warnings.push(
+        `Wrote an access token into project-scoped config file "${configPath}" — it is under the project root and may be committed to version control. Prefer an env-var or user-scope placement for the access token (design 03 Flow C).`,
+      );
+    }
 
     if (transport === 'stdio' && !fs.existsSync(serverPath.replace(/\//g, path.sep))) {
       warnings.push(

--- a/cli/src/utils/agents.ts
+++ b/cli/src/utils/agents.ts
@@ -14,6 +14,17 @@ export interface AgentDefinition {
   configPathDisplay: string;
   configFormat: 'json' | 'toml';
   bodyPath: string;
+  /**
+   * Whether this agent can complete native MCP OAuth (RFC 9728) against the
+   * server URL on the default http path (design 03 Flow A / decision D11).
+   * `undefined`/`true` — the default across the registry, mirroring the shared
+   * b6 configurators — means the default config is credential-free: the client
+   * runs its own authorize flow, so injecting a static `Authorization` header
+   * would both fail (the hosted endpoint 401s the token) and suppress that
+   * flow. Set `false` only for a client that cannot do MCP OAuth; such a client
+   * still receives a header only via the explicit PAT fallback (Flow C).
+   */
+  supportsOAuth?: boolean;
   getConfigPath(projectPath: string): string;
   getStdioProps(
     serverPath: string,
@@ -25,7 +36,7 @@ export interface AgentDefinition {
   getHttpProps(
     url: string,
     token: string,
-    authRequired: boolean,
+    emitAuthHeader: boolean,
   ): Record<string, unknown>;
   stdioRemoveKeys: string[];
   httpRemoveKeys: string[];
@@ -70,11 +81,19 @@ function stdioArgs(
   ];
 }
 
+/**
+ * The static `Authorization: Bearer <token>` header, or `undefined` when none
+ * should be written. Whether to emit it is decided by the CALLER (`setupMcp`)
+ * per the b6 credential policy (design decision D11) and passed in as
+ * `emitAuthHeader`; the default http path is credential-free (OAuth-capable
+ * clients authorize natively — Flow A), so a header is emitted only for an
+ * explicit PAT opt-in or a non-OAuth client (Flow C).
+ */
 function authHeaders(
   token: string,
-  authRequired: boolean,
+  emitAuthHeader: boolean,
 ): Record<string, string> | undefined {
-  if (authRequired && token) {
+  if (emitAuthHeader && token) {
     return { Authorization: `Bearer ${token}` };
   }
   return undefined;
@@ -100,11 +119,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['type', 'url'],
@@ -134,11 +153,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -159,11 +178,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -184,11 +203,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -209,11 +228,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -235,12 +254,12 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       enabled: true,
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['disabled', 'url'],
@@ -261,12 +280,12 @@ export const agentRegistry: readonly AgentDefinition[] = [
       args: stdioArgs(port, timeout, auth, token),
       tools: ['*'],
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
       tools: ['*'],
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url', 'type'],
@@ -287,11 +306,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -313,7 +332,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, _token, _authRequired) => ({
+    getHttpProps: (url, _token, _emitAuthHeader) => ({
       disabled: false,
       serverUrl: url,
     }),
@@ -363,11 +382,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'streamableHttp',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -391,12 +410,12 @@ export const agentRegistry: readonly AgentDefinition[] = [
         ...stdioArgs(port, timeout, auth, token),
       ],
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'remote',
       enabled: true,
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url', 'args'],
@@ -423,7 +442,7 @@ export const agentRegistry: readonly AgentDefinition[] = [
       ],
       tool_timeout_sec: 300,
     }),
-    getHttpProps: (url, _token, _authRequired) => ({
+    getHttpProps: (url, _token, _emitAuthHeader) => ({
       enabled: true,
       url,
       tool_timeout_sec: 300,
@@ -448,12 +467,12 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'streamable-http',
       disabled: false,
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -474,11 +493,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],
@@ -505,11 +524,11 @@ export const agentRegistry: readonly AgentDefinition[] = [
       command: serverPath,
       args: stdioArgs(port, timeout, auth, token),
     }),
-    getHttpProps: (url, token, authRequired) => ({
+    getHttpProps: (url, token, emitAuthHeader) => ({
       type: 'http',
       url,
-      ...(authHeaders(token, authRequired)
-        ? { headers: authHeaders(token, authRequired) }
+      ...(authHeaders(token, emitAuthHeader)
+        ? { headers: authHeaders(token, emitAuthHeader) }
         : {}),
     }),
     stdioRemoveKeys: ['url'],

--- a/cli/tests/setup-mcp.test.ts
+++ b/cli/tests/setup-mcp.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { setupMcp } from '../src/lib/setup-mcp.js';
+import { getAgentById, MCP_SERVER_NAME } from '../src/utils/agents.js';
+import type { UnityConnectionConfig } from '../src/utils/config.js';
+
+// ---------------------------------------------------------------------------
+// mcp-authorize g2 — setup-mcp writes a credential-free, URL-only http config
+// for OAuth-capable clients (design decision D11 / Flow A), and a static
+// Authorization header ONLY on an explicit PAT opt-in (Flow C). Regression
+// guard for the g1 flagship bug (setup-mcp injected a static Bearer token that
+// the hosted OAuth endpoint 401s AND that suppresses the client's own OAuth).
+// ---------------------------------------------------------------------------
+
+/** Seed a project's UserSettings/AI-Game-Developer-Config.json. */
+function seedConfig(projectDir: string, config: UnityConnectionConfig): void {
+  const dir = path.join(projectDir, 'UserSettings');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'AI-Game-Developer-Config.json'),
+    JSON.stringify(config, null, 2) + '\n',
+  );
+}
+
+/** The hosted-Cloud config that reproduces the g1 flagship scenario: a
+ *  cloud token pinned on disk + `authOption: required` + the hosted endpoint. */
+const CONFIG_TOKEN = 'agd_cloud_token_from_config_SHOULD_NOT_LEAK';
+function seedHostedConfig(projectDir: string): void {
+  seedConfig(projectDir, {
+    connectionMode: 'Cloud',
+    cloudToken: CONFIG_TOKEN,
+    authOption: 'required',
+    timeoutMs: 10000,
+  });
+}
+
+describe('setup-mcp — credential-free OAuth config (mcp-authorize g2 / D11)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-setup-mcp-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // DoD 1: URL-only (no Authorization header) for every OAuth-capable client,
+  // even against the hosted endpoint with a config token + required auth.
+  it.each(['claude-code', 'cursor', 'vscode-copilot', 'codex'])(
+    'writes a URL-only config (no Authorization header) for %s',
+    async (agentId) => {
+      seedHostedConfig(tmpDir);
+
+      const result = await setupMcp({
+        agentId,
+        unityProjectPath: tmpDir,
+        transport: 'http',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind !== 'success') return;
+
+      const raw = fs.readFileSync(result.configPath, 'utf-8');
+      // The hosted OAuth URL is present…
+      expect(raw).toContain('https://ai-game.dev/mcp');
+      // …but NO credential and NO Authorization header leaked into the file.
+      expect(raw).not.toContain('Authorization');
+      expect(raw).not.toContain(CONFIG_TOKEN);
+      // No project-file-PAT warning on the credential-free default path.
+      expect(result.warnings).toHaveLength(0);
+    },
+  );
+
+  it('claude-code entry is exactly {type,url} with no headers key', async () => {
+    seedHostedConfig(tmpDir);
+
+    const result = await setupMcp({
+      agentId: 'claude-code',
+      unityProjectPath: tmpDir,
+      transport: 'http',
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    const root = JSON.parse(fs.readFileSync(result.configPath, 'utf-8')) as {
+      mcpServers: Record<string, Record<string, unknown>>;
+    };
+    const entry = root.mcpServers[MCP_SERVER_NAME];
+    expect(entry).toEqual({ type: 'http', url: 'https://ai-game.dev/mcp' });
+    expect(entry).not.toHaveProperty('headers');
+  });
+
+  // DoD 2: the PAT fallback still writes a header — but ONLY on an explicit
+  // opt-in (a `--token` the caller passed), not from a config-resolved token.
+  it('writes the Authorization header for an explicit PAT opt-in (--token)', async () => {
+    seedHostedConfig(tmpDir);
+    const pat = 'agd_pat_explicit_optin';
+
+    const result = await setupMcp({
+      agentId: 'claude-code',
+      unityProjectPath: tmpDir,
+      transport: 'http',
+      token: pat,
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    const root = JSON.parse(fs.readFileSync(result.configPath, 'utf-8')) as {
+      mcpServers: Record<string, { url: string; headers?: Record<string, string> }>;
+    };
+    const entry = root.mcpServers[MCP_SERVER_NAME];
+    expect(entry.url).toBe('https://ai-game.dev/mcp');
+    expect(entry.headers).toEqual({ Authorization: `Bearer ${pat}` });
+
+    // Flow C credential-placement rule: warn on a project-scoped PAT.
+    expect(result.warnings.some((w) => w.includes('project-scoped'))).toBe(true);
+  });
+
+  it('does NOT write a header when the token is only resolved from config (no opt-in)', async () => {
+    // Custom/localhost config carrying a token but no explicit --token opt-in.
+    seedConfig(tmpDir, {
+      connectionMode: 'Custom',
+      host: 'http://localhost:12345',
+      token: CONFIG_TOKEN,
+      authOption: 'required',
+    });
+
+    const result = await setupMcp({
+      agentId: 'claude-code',
+      unityProjectPath: tmpDir,
+      transport: 'http',
+    });
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    const raw = fs.readFileSync(result.configPath, 'utf-8');
+    expect(raw).toContain('http://localhost:12345');
+    expect(raw).not.toContain('Authorization');
+    expect(raw).not.toContain(CONFIG_TOKEN);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('OAuth-capable clients default to supportsOAuth !== false in the registry', () => {
+    for (const id of ['claude-code', 'cursor', 'vscode-copilot', 'codex']) {
+      expect(getAgentById(id)?.supportsOAuth).not.toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `setup-mcp` no longer injects a static `Authorization: Bearer <token>` for OAuth-capable interactive clients. The default HTTP config is now credential-free (`{type, url}` only), so Claude Code / Cursor / Codex / Copilot perform native RFC 9728 OAuth against the URL (design 03 Flow A / decision D11) instead of being 401'd and having their own OAuth handshake suppressed.
- A static Bearer header is written ONLY on an explicit PAT opt-in (`--token`, Flow C) or a `supportsOAuth === false` client — mirroring the shipped b6 C# configurator policy. A project-scoped PAT emits a VCS-leak warning.
- Added `supportsOAuth` capability to the agent registry (default `true`); the header-emission decision is computed by `setupMcp` and passed to `getHttpProps` as `emitAuthHeader`.

## Test plan
- [x] Target-specific local tests passed (see profile test.md): `cli` build (tsc) + full `npm test` suite green (504 passed / 2 skipped / 0 failures), including new `cli/tests/setup-mcp.test.ts` (URL-only for claude-code/cursor/codex/copilot; header only on explicit `--token`).

Scope: setup-mcp config generation only — no plugin/editor code, no version bumps.

Closes #890