### PR TITLE
fix: stabilize LocalToken so client configs never go stale (401)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.Config.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.Config.cs
@@ -206,7 +206,15 @@ namespace com.IvanMurzak.Unity.MCP
                 Tools = DefaultTools;
                 Prompts = DefaultPrompts;
                 Resources = DefaultResources;
-                Token = GenerateToken();
+                // Seed the LOCAL server token directly, NOT through the mode-routed `Token` setter.
+                // `ConnectionMode` was set to `Cloud` above, so `Token = GenerateToken()` would route
+                // the freshly-generated local secret into `CloudToken` and leave `LocalToken` null —
+                // the local server token would then never be seeded here, forcing the generate-if-empty
+                // fallback in `GetOrCreateConfig` to mint (and re-mint) it, which is exactly how a
+                // persisted local token could drift and orphan an already-written client `.mcp.json`
+                // (stale Bearer -> 401; Unity-MCP #897 / mcp-authorize i2). `GenerateToken()` produces a
+                // local server secret; `CloudToken` is populated by Cloud sign-in, so it stays null here.
+                LocalToken = GenerateToken();
                 return this;
             }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Config/LocalTokenStabilityTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Config/LocalTokenStabilityTests.cs
@@ -1,0 +1,124 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NUnit.Framework;
+using AuthOption = com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server.AuthOption;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Guards the mcp-authorize i2 local-token lifecycle fix (Unity-MCP #897 / BUG-B): the local server
+    /// token (<see cref="UnityMcpPlugin.UnityConnectionConfig.LocalToken"/>) must be seeded by
+    /// <c>SetDefault()</c> and must survive a mode re-apply and a serialize/deserialize (domain reload +
+    /// save/load) round-trip UNCHANGED. A silently regenerated local token orphans the already-written
+    /// client <c>.mcp.json</c> (stale <c>Bearer</c>) and produces a Claude Code 401.
+    /// </summary>
+    public class LocalTokenStabilityTests
+    {
+        const string PersistedLocalToken = "PERSISTED_LOCAL_TOKEN";
+
+        // Mirror the production serializer options so this round-trip exercises the SAME JSON shape the
+        // plugin persists and reloads across a domain reload:
+        //  - Save()            -> WriteIndented + CamelCase + JsonStringEnumConverter
+        //  - GetOrCreateConfig -> PropertyNameCaseInsensitive + JsonStringEnumConverter
+        // (both in Editor/Scripts/UnityMcpPluginEditor.Config.cs).
+        static JsonSerializerOptions SaveOptions() => new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter() }
+        };
+
+        static JsonSerializerOptions LoadOptions() => new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+
+        static UnityMcpPlugin.UnityConnectionConfig RoundTrip(UnityMcpPlugin.UnityConnectionConfig config)
+        {
+            var json = JsonSerializer.Serialize(config, SaveOptions());
+            return JsonSerializer.Deserialize<UnityMcpPlugin.UnityConnectionConfig>(json, LoadOptions())!;
+        }
+
+        static UnityMcpPlugin.UnityConnectionConfig CustomTokenConfig() => new UnityMcpPlugin.UnityConnectionConfig
+        {
+            ConnectionMode = ConnectionMode.Custom,
+            AuthOption = AuthOption.token,
+            LocalToken = PersistedLocalToken,
+        };
+
+        [Test]
+        public void SetDefault_SeedsLocalToken_NotCloudToken()
+        {
+            // A freshly-constructed config (the ctor calls SetDefault) must carry a non-empty LOCAL token
+            // and a null cloud token. The prior bug routed GenerateToken() into CloudToken because
+            // SetDefault sets ConnectionMode=Cloud BEFORE assigning the token via the mode-routed setter,
+            // leaving LocalToken unseeded (and re-mintable by the generate-if-empty fallback).
+            var config = new UnityMcpPlugin.UnityConnectionConfig();
+
+            Assert.IsFalse(string.IsNullOrEmpty(config.LocalToken),
+                "SetDefault must seed a non-empty LocalToken so the generate-if-empty fallback never has to mint it.");
+            Assert.IsNull(config.CloudToken,
+                "SetDefault must leave CloudToken null — the cloud token comes from Cloud sign-in, not GenerateToken().");
+        }
+
+        [Test]
+        public void LocalToken_StableAcrossModeReapply()
+        {
+            var config = CustomTokenConfig();
+
+            // Re-apply / toggle the connection mode; the local token must never move.
+            config.ConnectionMode = ConnectionMode.Cloud;
+            config.ConnectionMode = ConnectionMode.Custom;
+
+            Assert.AreEqual(PersistedLocalToken, config.LocalToken,
+                "Re-applying the connection mode must not regenerate the local token.");
+            Assert.AreEqual(PersistedLocalToken, config.Token,
+                "In Custom mode the effective Token must resolve to the (unchanged) LocalToken.");
+        }
+
+        [Test]
+        public void LocalToken_SurvivesSaveLoadRoundTrip()
+        {
+            var reloaded = RoundTrip(CustomTokenConfig());
+
+            Assert.AreEqual(PersistedLocalToken, reloaded.LocalToken,
+                "The persisted local token must survive a serialize/deserialize (domain reload / save-load) round-trip.");
+            Assert.AreEqual(ConnectionMode.Custom, reloaded.ConnectionMode);
+            Assert.AreEqual(AuthOption.token, reloaded.AuthOption);
+        }
+
+        [Test]
+        public void RoundTrip_LeavesLocalTokenNonEmpty_SoGenerateIfEmptyNeverRegenerates()
+        {
+            // GetOrCreateConfig re-mints LocalToken only when it is null/empty after load. A persisted
+            // token must therefore round-trip NON-EMPTY so that guard stays a no-op and never re-mints it.
+            var reloaded = RoundTrip(CustomTokenConfig());
+
+            Assert.IsFalse(string.IsNullOrEmpty(reloaded.LocalToken),
+                "A reloaded config must carry a non-empty LocalToken so the generate-if-empty fallback stays a no-op.");
+        }
+
+        [Test]
+        public void LocalToken_SerializesUnderTokenJsonField()
+        {
+            var json = JsonSerializer.Serialize(CustomTokenConfig(), SaveOptions());
+            using var doc = JsonDocument.Parse(json);
+
+            Assert.IsTrue(doc.RootElement.TryGetProperty("token", out var tokenProp),
+                "LocalToken must serialize under the \"token\" JSON field the loader reads back.");
+            Assert.AreEqual(PersistedLocalToken, tokenProp.GetString());
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Config/LocalTokenStabilityTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Config/LocalTokenStabilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45cfd42f66ef4f8ba1f9f03c3829f7bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- **BUG-B (mcp-authorize i2, #897):** in Custom + `token` mode the client `.mcp.json` ended up with a DIFFERENT token than the running local server → Claude Code **401**.
- **Root cause / regen trigger identified:** `UnityConnectionConfig.SetDefault()` assigns the freshly-generated local server token through the **mode-routed `Token` setter** *after* setting `ConnectionMode = Cloud`. So `Token = GenerateToken()` routed the local secret into **`CloudToken`** and left **`LocalToken` unseeded**. `LocalToken` initialization then fell entirely to the generate-if-empty fallback in `GetOrCreateConfig`, which let the persisted local token drift / regenerate and orphan the already-written client `.mcp.json` (stale `Bearer` → 401).
- **Fix:** seed `LocalToken` directly in `SetDefault()` (`GenerateToken()` produces a *local* server secret; `CloudToken` is populated by Cloud sign-in, so it now correctly stays `null`). A persisted `LocalToken` is stable across construction, mode re-apply, and a serialize/deserialize (domain reload / save-load) round-trip, so the server launch token (`McpServerManager` → `UnityMcpPluginEditor.Token`) and the client-config `Bearer` (`AgentConfiguratorSettingsFactory` → `UnityMcpPluginEditor.Token`) stay in lockstep.
- **Token change (New button) → reconfigure:** left unchanged. That path already restarts the server and calls `InvalidateAndReloadAgentUI()` → re-evaluates `_configurator.GetStatus(...) == ReconfigureNeeded` and shows the "Reconfiguration Required" alert (driven by sibling task **i1**'s token-aware validator). No new plumbing needed here.
- No version bump / no McpPlugin re-pin (client-side-only fix; coordinated bump + release is task i6).

## Test plan
- [x] New `LocalTokenStabilityTests` (EditMode) — 5 tests, all pass: `SetDefault` seeds `LocalToken` not `CloudToken`; `LocalToken` stable across mode re-apply; survives save/load round-trip; round-trip leaves it non-empty (generate-if-empty stays a no-op); serializes under the `token` JSON field.
- [x] Full Unity EditMode suite (2022.3.62f3) — **0 failures** across all runnable fixtures (chunked). One fixture, `TestsRunDirtySceneTests`, cannot run through the MCP `tests-run` tool (it mutates `Tool_Tests`' active-run bookkeeping, self-interfering with the tool's completion detection) and is validated by CI's direct Unity Test Runner instead — unrelated to this diff.
- [x] Unity PlayMode suite — 0 failures.

Closes #897