### PR TITLE
refactor: remove legacy cloudToken UserSettings mirror

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
@@ -91,15 +91,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
             // When signed in via the shared machine credential store, the ConnectionCredentialCoordinator
             // (wired in AccountCredentialService.AttachTo) already handles the 3-strike rejection by
-            // refreshing the token and reconnecting — do not clear the display token here (design 06).
+            // refreshing the token and reconnecting — do not disturb the session here (design 06).
             if (AccountCredentialService.IsSignedIn)
                 return;
 
-            Debug.LogWarning("[AI Game Developer] The server rejected the authorization token. " +
-                "The token has been cleared. Please click 'Authorize' to obtain a new token.");
-
-            UnityMcpPluginEditor.CloudToken = null;
-            UnityMcpPluginEditor.Instance.Save();
+            // Not signed in: the machine store is the only Cloud credential source (T9 — the cloudToken
+            // UserSettings mirror was removed), so there is no persisted token to clear. Prompt a fresh sign-in.
+            Debug.LogWarning("[AI Game Developer] The server rejected the authorization. " +
+                "Please click 'Authorize' to sign in again.");
 
             UpdateCloudAuthState();
             RefreshConnectionUI();
@@ -259,8 +258,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     if (McpServerManager.IsRunning || McpServerManager.IsStarting)
                         McpServerManager.StopServer();
 
-                    // Reconnect to cloud server (only if authorized)
-                    if (!string.IsNullOrEmpty(UnityMcpPluginEditor.CloudToken))
+                    // Reconnect to cloud server (only if authorized via the machine store)
+                    if (AccountCredentialService.IsSignedIn)
                         ReconnectAfterModeSwitch();
                     ScheduleConnectionUIRefresh();
                 }
@@ -305,30 +304,33 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             });
 
             const string tokenPlaceholder = "Token — press Authorize";
-            void SetTokenValue(string? token)
+            const string signedInDisplay = "Signed in via account";
+            // The raw cloud JWT is no longer mirrored into the config (T9); it lives only in the shared
+            // machine store. This read-only field therefore reflects sign-in state, not the token value.
+            void UpdateTokenDisplay()
             {
-                var isEmpty = string.IsNullOrEmpty(token);
-                inputCloudToken.value = isEmpty ? tokenPlaceholder : token!;
-                inputCloudToken.EnableInClassList("token-placeholder", isEmpty);
+                var signedIn = AccountCredentialService.IsSignedIn;
+                inputCloudToken.value = signedIn ? signedInDisplay : tokenPlaceholder;
+                inputCloudToken.EnableInClassList("token-placeholder", !signedIn);
             }
 
-            SetTokenValue(UnityMcpPluginEditor.CloudToken);
+            UpdateTokenDisplay();
             UpdateCloudAuthState();
 
             void UpdateRevokeButtonVisibility()
             {
                 if (btnRevoke != null)
-                    btnRevoke.style.display = string.IsNullOrEmpty(UnityMcpPluginEditor.CloudToken)
-                        ? DisplayStyle.None
-                        : DisplayStyle.Flex;
+                    btnRevoke.style.display = AccountCredentialService.IsSignedIn
+                        ? DisplayStyle.Flex
+                        : DisplayStyle.None;
             }
             UpdateRevokeButtonVisibility();
 
             btnRevoke?.RegisterCallback<ClickEvent>(evt =>
             {
-                UnityMcpPluginEditor.CloudToken = null;
-                UnityMcpPluginEditor.Instance.Save();
-                SetTokenValue(null);
+                // Sign out of the shared machine store (T9 — the credential lives only there now).
+                AccountCredentialService.SignOut();
+                UpdateTokenDisplay();
                 UpdateRevokeButtonVisibility();
 
                 if (statusLabel != null)
@@ -363,12 +365,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                     new DeviceAuthService(cloudBaseUrl),
                     onAuthorized: credentials =>
                     {
-                        // Persist into the shared machine credential store (D12), and mirror the access token
-                        // into CloudToken so the existing cloud-auth UI + connection fallback keep working
-                        // until the token-field UI is retired in a later PR.
+                        // Persist into the shared machine credential store (D12 / T9). The machine store
+                        // (~/.ai-game-dev/credentials.json) is the single Cloud credential source — there is
+                        // no UserSettings cloudToken mirror.
                         AccountCredentialService.Adopt(credentials);
-                        UnityMcpPluginEditor.CloudToken = credentials.AccessToken;
-                        UnityMcpPluginEditor.Instance.Save();
                     },
                     serverTarget: cloudBaseUrl);
                 var capturedFlow = _deviceAuthFlow; // Capture to avoid stale field reference in async callbacks
@@ -392,7 +392,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                         }
                         if (state == DeviceAuthFlowState.Authorized && inputCloudToken != null)
                         {
-                            SetTokenValue(UnityMcpPluginEditor.CloudToken);
+                            UpdateTokenDisplay();
                             UpdateRevokeButtonVisibility();
                             UpdateCloudAuthState();
                         }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 using System;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
 using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using Microsoft.AspNetCore.SignalR.Client;
 using R3;
@@ -74,17 +75,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
             _authRejectedSubscription.Dispose();
         }
 
-        internal static (bool needsAuth, bool hasToken, bool isCloud) ComputeCloudAuthState(ConnectionMode mode, string? token)
+        internal static (bool needsAuth, bool hasToken, bool isCloud) ComputeCloudAuthState(ConnectionMode mode, bool hasCredential)
         {
             var isCloud = mode == ConnectionMode.Cloud;
-            var hasToken = !string.IsNullOrEmpty(token);
-            var needsAuth = isCloud && !hasToken;
-            return (needsAuth, hasToken, isCloud);
+            var needsAuth = isCloud && !hasCredential;
+            return (needsAuth, hasCredential, isCloud);
         }
 
         private void UpdateCloudAuthState()
         {
-            var (needsAuth, hasToken, isCloud) = ComputeCloudAuthState(UnityMcpPluginEditor.ConnectionMode, UnityMcpPluginEditor.CloudToken);
+            // Cloud sign-in state comes from the shared machine store (T9 — the cloudToken UserSettings
+            // mirror was removed); the machine store is the single Cloud-mode credential source.
+            var (needsAuth, hasToken, isCloud) = ComputeCloudAuthState(
+                UnityMcpPluginEditor.ConnectionMode, AccountCredentialService.IsSignedIn);
 
             if (_timelinePointUnity != null)
             {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UnityMcpPluginEditor.Static.cs
@@ -185,15 +185,6 @@ namespace com.IvanMurzak.Unity.MCP
             }
         }
         public static string CloudServerUrl => UnityMcpPlugin.UnityConnectionConfig.CloudServerUrl;
-        public static string? CloudToken
-        {
-            get => Instance.unityConnectionConfig.CloudToken;
-            set
-            {
-                Instance.unityConnectionConfig.CloudToken = value;
-                NotifyChanged(Instance.unityConnectionConfig);
-            }
-        }
 
         public static bool IsAutoGenerateSkills(string agentId)
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.Config.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.Config.cs
@@ -93,39 +93,32 @@ namespace com.IvanMurzak.Unity.MCP
             }
 
             /// <summary>
-            /// Gets/sets the active auth token based on <see cref="ConnectionMode"/>.
-            /// In Cloud mode, routes to <see cref="CloudToken"/>.
-            /// In Local mode, routes to <see cref="LocalToken"/>.
-            /// Setter mirrors the getter so env-var / CLI overrides (which write via
-            /// the generic Token property) land on the right field regardless of mode.
+            /// Gets/sets the local server auth token (<see cref="LocalToken"/>). Cloud-mode credentials no
+            /// longer live in this config — they come exclusively from the shared machine store via
+            /// <see cref="CloudCredentialProvider"/> (T9: the legacy <c>cloudToken</c> UserSettings mirror was
+            /// removed), so this property is the single source of truth for the LOCAL/Custom-mode token only.
             /// </summary>
             /// <remarks>
             /// McpPlugin 7.0 removed the static <c>ConnectionConfig.Token</c> string in favour of the
             /// <see cref="ConnectionConfig.CredentialProvider"/> callback. This Unity-side property is kept as
-            /// the single source of truth for the effective token (routed by <see cref="ConnectionMode"/>);
-            /// the overridden <see cref="CredentialProvider"/> below presents it on every (re)connect, so the
-            /// on-the-wire behaviour is identical to the pre-7.0 static-token connection. It is no longer an
+            /// the effective local token; the overridden <see cref="CredentialProvider"/> below presents it in
+            /// Local/Custom mode, while Cloud mode is served solely by the machine store. It is no longer an
             /// <c>override</c> because the base no longer declares <c>Token</c>.
             /// </remarks>
             [JsonIgnore]
             public string? Token
             {
-                get => ConnectionMode == ConnectionMode.Cloud ? CloudToken : LocalToken;
-                set
-                {
-                    if (ConnectionMode == ConnectionMode.Cloud)
-                        CloudToken = value;
-                    else
-                        LocalToken = value;
-                }
+                get => LocalToken;
+                set => LocalToken = value;
             }
 
             /// <summary>
             /// Editor-populated machine-store credential provider (mcp-authorize design 06 / D12 zero-button
             /// auto-adopt). When set — by <c>AccountCredentialService.Initialize()</c> — a <b>Cloud</b>-mode
             /// connection presents the proactively-refreshed account JWT read from the shared machine store
-            /// (<c>~/.ai-game-dev/credentials.json</c>); a null/empty result falls back to the mode-routed
-            /// <see cref="Token"/>, and Local/Custom mode ignores it entirely. Static because the machine
+            /// (<c>~/.ai-game-dev/credentials.json</c>), which is the ONLY Cloud-mode credential source
+            /// (T9: the legacy <c>cloudToken</c> UserSettings mirror was removed). A null/empty result yields
+            /// an anonymous Cloud connection; Local/Custom mode ignores it entirely. Static because the machine
             /// store is per-machine, shared across every config instance and the runtime boot. Runtime-only;
             /// never serialized.
             /// </summary>
@@ -134,15 +127,13 @@ namespace com.IvanMurzak.Unity.MCP
 
             /// <summary>
             /// McpPlugin 7.0 credential provider (replaces the removed static <c>ConnectionConfig.Token</c>).
-            /// In <b>Cloud</b> mode it first consults <see cref="CloudCredentialProvider"/> (the shared
-            /// machine-store account credential, proactively refreshed — design 06 / D12); when that yields
-            /// a token it is presented on the (re)connect, giving zero-button sign-in without any UI. When it
-            /// is unset or returns null/empty — and always in Local/Custom mode — it falls back to the
-            /// mode-routed <see cref="Token"/>, so the on-the-wire behaviour is identical to the pre-b7
-            /// static-token connection. A null token yields an anonymous connection. Runtime-only; never
-            /// serialized (<see cref="JsonIgnoreAttribute"/>). The setter is intentionally a no-op: Unity
-            /// derives the credential from the machine store / <see cref="Token"/> rather than from a
-            /// host-injected provider.
+            /// In <b>Cloud</b> mode it presents the shared machine-store account credential from
+            /// <see cref="CloudCredentialProvider"/> (proactively refreshed — design 06 / D12), which is the
+            /// ONLY Cloud-mode credential source (T9 — the legacy <c>cloudToken</c> mirror was removed); a
+            /// null/empty result yields an anonymous connection. In Local/Custom mode it returns the local
+            /// <see cref="Token"/>. Runtime-only; never serialized (<see cref="JsonIgnoreAttribute"/>). The
+            /// setter is intentionally a no-op: Unity derives the credential from the machine store /
+            /// <see cref="Token"/> rather than from a host-injected provider.
             /// </summary>
             [JsonIgnore]
             public override Func<Task<string?>>? CredentialProvider
@@ -151,13 +142,16 @@ namespace com.IvanMurzak.Unity.MCP
                 {
                     if (ConnectionMode == ConnectionMode.Cloud)
                     {
+                        // Cloud mode: the shared machine store is the ONLY credential source (T9 — the
+                        // legacy cloudToken UserSettings mirror was removed). A null/empty result yields an
+                        // anonymous connection; there is no persisted cloud-token fallback.
                         var provider = CloudCredentialProvider;
                         if (provider != null)
                         {
                             var token = await provider().ConfigureAwait(false);
-                            if (!string.IsNullOrEmpty(token))
-                                return token;
+                            return string.IsNullOrEmpty(token) ? null : token;
                         }
+                        return null;
                     }
                     return Token;
                 };
@@ -169,7 +163,6 @@ namespace com.IvanMurzak.Unity.MCP
             public TransportMethod TransportMethod { get; set; } = TransportMethod.streamableHttp;
             public AuthOption AuthOption { get; set; } = AuthOption.none;
             public ConnectionMode ConnectionMode { get; set; } = ConnectionMode.Cloud;
-            public string? CloudToken { get; set; }
             public List<McpFeature> Tools { get; set; } = new();
             public List<McpFeature> Prompts { get; set; } = new();
             public List<McpFeature> Resources { get; set; } = new();
@@ -200,20 +193,16 @@ namespace com.IvanMurzak.Unity.MCP
                 TransportMethod = TransportMethod.streamableHttp;
                 AuthOption = AuthOption.none;
                 ConnectionMode = ConnectionMode.Cloud;
-                CloudToken = null;
                 LogLevel = LogLevel.Warning;
                 TimeoutMs = Consts.Hub.DefaultTimeoutMs;
                 Tools = DefaultTools;
                 Prompts = DefaultPrompts;
                 Resources = DefaultResources;
-                // Seed the LOCAL server token directly, NOT through the mode-routed `Token` setter.
-                // `ConnectionMode` was set to `Cloud` above, so `Token = GenerateToken()` would route
-                // the freshly-generated local secret into `CloudToken` and leave `LocalToken` null —
-                // the local server token would then never be seeded here, forcing the generate-if-empty
-                // fallback in `GetOrCreateConfig` to mint (and re-mint) it, which is exactly how a
-                // persisted local token could drift and orphan an already-written client `.mcp.json`
-                // (stale Bearer -> 401; Unity-MCP #897 / mcp-authorize i2). `GenerateToken()` produces a
-                // local server secret; `CloudToken` is populated by Cloud sign-in, so it stays null here.
+                // Seed the LOCAL server token directly. `GenerateToken()` produces the local server secret;
+                // Cloud-mode credentials come from the shared machine store (T9), never from this config, so
+                // nothing cloud-related is seeded here. Seeding LocalToken up front keeps the generate-if-empty
+                // fallback in `GetOrCreateConfig` a no-op, so a persisted local token can't drift and orphan an
+                // already-written client `.mcp.json` (stale Bearer -> 401; Unity-MCP #897 / mcp-authorize i2).
                 LocalToken = GenerateToken();
                 return this;
             }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
@@ -64,7 +64,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
         public const string FieldKeepConnected = nameof(UnityMcpPlugin.UnityConnectionConfig.KeepConnected);
         public const string FieldAuthOption = nameof(UnityMcpPlugin.UnityConnectionConfig.AuthOption);
         public const string FieldLocalToken = nameof(UnityMcpPlugin.UnityConnectionConfig.LocalToken);
-        public const string FieldCloudToken = nameof(UnityMcpPlugin.UnityConnectionConfig.CloudToken);
         public const string FieldTools = nameof(UnityMcpPlugin.UnityConnectionConfig.EnabledToolsOverride);
         public const string FieldStartServer = nameof(UnityMcpPlugin.UnityConnectionConfig.KeepServerRunning);
         public const string FieldTransport = nameof(UnityMcpPlugin.UnityConnectionConfig.TransportMethod);
@@ -216,32 +215,21 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                 _logger.LogInformation("[MCP] Override: {Key}={Value}", EnvAuthOption, ao);
             }
 
-            // Resolved AFTER ConnectionMode so we route to the correct underlying field
-            // (LocalToken in Custom mode, CloudToken in Cloud mode). We track the specific
-            // backing field rather than the abstract Token property because only the backing
-            // fields are serialised — restoring the baseline must target the same field that
-            // was clobbered.
+            // The env/flag token override targets the LOCAL server token only. Cloud-mode credentials come
+            // exclusively from the shared machine store (T9 — the cloudToken UserSettings mirror was
+            // removed), so UNITY_MCP_TOKEN / --token no longer seeds a persisted cloud token; in Cloud mode
+            // the machine store is authoritative and this local override is inert for the connection. We
+            // track the backing field (not the abstract Token property) because only the backing field is
+            // serialised — restoring the baseline must target the same field that was clobbered.
             var rawToken = Resolve(EnvToken, FlagToken);
             if (rawToken != null)
             {
                 var token = Sanitize(rawToken);
-                if (config.ConnectionMode == ConnectionMode.Cloud)
+                if (!string.Equals(token, config.LocalToken, StringComparison.Ordinal))
                 {
-                    if (!string.Equals(token, config.CloudToken, StringComparison.Ordinal))
-                    {
-                        record.Track(FieldCloudToken, config.CloudToken, token);
-                        config.CloudToken = token;
-                        _logger.LogInformation("[MCP] Override: {Key}=*** (CloudToken)", EnvToken);
-                    }
-                }
-                else
-                {
-                    if (!string.Equals(token, config.LocalToken, StringComparison.Ordinal))
-                    {
-                        record.Track(FieldLocalToken, config.LocalToken, token);
-                        config.LocalToken = token;
-                        _logger.LogInformation("[MCP] Override: {Key}=*** (LocalToken)", EnvToken);
-                    }
+                    record.Track(FieldLocalToken, config.LocalToken, token);
+                    config.LocalToken = token;
+                    _logger.LogInformation("[MCP] Override: {Key}=*** (LocalToken)", EnvToken);
                 }
             }
 
@@ -325,9 +313,6 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
                         break;
                     case FieldLocalToken:
                         config.LocalToken = (string?)kvp.Value;
-                        break;
-                    case FieldCloudToken:
-                        config.CloudToken = (string?)kvp.Value;
                         break;
                     case FieldTools:
                         config.EnabledToolsOverride = (List<string>?)kvp.Value;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityConnectionConfigCredentialProviderTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/UnityConnectionConfigCredentialProviderTests.cs
@@ -15,9 +15,10 @@ using NUnit.Framework;
 namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 {
     /// <summary>
-    /// The machine-store credential wins over the mode-routed token in Cloud mode, and is ignored in
-    /// Custom/Local mode (mcp-authorize design 06 / D12). This is the seam that makes zero-button boot
-    /// present the shared account JWT while preserving the anonymous/local behaviour when signed out.
+    /// The machine store is the ONLY Cloud-mode credential source (mcp-authorize design 06 / D12; T9 —
+    /// the legacy cloudToken UserSettings mirror was removed): Cloud mode presents the shared account JWT
+    /// when signed in and an anonymous (null) credential otherwise, while Custom/Local mode ignores the
+    /// machine store and uses the local token.
     /// </summary>
     public class UnityConnectionConfigCredentialProviderTests
     {
@@ -36,12 +37,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = _saved;
         }
 
-        static UnityMcpPlugin.UnityConnectionConfig NewConfig(ConnectionMode mode, string? cloudToken, string? localToken)
+        static UnityMcpPlugin.UnityConnectionConfig NewConfig(ConnectionMode mode, string? localToken)
         {
             var config = new UnityMcpPlugin.UnityConnectionConfig
             {
                 ConnectionMode = mode,
-                CloudToken = cloudToken,
                 LocalToken = localToken,
             };
             return config;
@@ -54,31 +54,34 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         public void Cloud_WithMachineCredential_PresentsMachineJwt()
         {
             UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = () => Task.FromResult<string?>("machine-jwt");
-            var config = NewConfig(ConnectionMode.Cloud, cloudToken: "cloud-tok", localToken: "local-tok");
+            var config = NewConfig(ConnectionMode.Cloud, localToken: "local-tok");
             Assert.AreEqual("machine-jwt", Resolve(config));
         }
 
         [Test]
-        public void Cloud_MachineCredentialEmpty_FallsBackToCloudToken()
+        public void Cloud_MachineCredentialEmpty_ReturnsNull()
         {
+            // T9: the machine store is the ONLY Cloud-mode credential source — the legacy cloudToken mirror
+            // was removed, so an empty machine credential yields an anonymous (null) connection, no fallback.
             UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = () => Task.FromResult<string?>(null);
-            var config = NewConfig(ConnectionMode.Cloud, cloudToken: "cloud-tok", localToken: "local-tok");
-            Assert.AreEqual("cloud-tok", Resolve(config));
+            var config = NewConfig(ConnectionMode.Cloud, localToken: "local-tok");
+            Assert.IsNull(Resolve(config));
         }
 
         [Test]
-        public void Cloud_NoMachineProvider_UsesCloudToken()
+        public void Cloud_NoMachineProvider_ReturnsNull()
         {
-            // CloudCredentialProvider is null (set in SetUp) — behaviour identical to the pre-b7 static token.
-            var config = NewConfig(ConnectionMode.Cloud, cloudToken: "cloud-tok", localToken: "local-tok");
-            Assert.AreEqual("cloud-tok", Resolve(config));
+            // CloudCredentialProvider is null (set in SetUp). With no machine store wired and no cloudToken
+            // fallback (T9), Cloud mode presents no credential (anonymous connection).
+            var config = NewConfig(ConnectionMode.Cloud, localToken: "local-tok");
+            Assert.IsNull(Resolve(config));
         }
 
         [Test]
         public void Custom_IgnoresMachineCredential_UsesLocalToken()
         {
             UnityMcpPlugin.UnityConnectionConfig.CloudCredentialProvider = () => Task.FromResult<string?>("machine-jwt");
-            var config = NewConfig(ConnectionMode.Custom, cloudToken: "cloud-tok", localToken: "local-tok");
+            var config = NewConfig(ConnectionMode.Custom, localToken: "local-tok");
             Assert.AreEqual("local-tok", Resolve(config));
         }
     }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Config/LocalTokenStabilityTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Config/LocalTokenStabilityTests.cs
@@ -59,18 +59,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         };
 
         [Test]
-        public void SetDefault_SeedsLocalToken_NotCloudToken()
+        public void SetDefault_SeedsLocalToken()
         {
-            // A freshly-constructed config (the ctor calls SetDefault) must carry a non-empty LOCAL token
-            // and a null cloud token. The prior bug routed GenerateToken() into CloudToken because
-            // SetDefault sets ConnectionMode=Cloud BEFORE assigning the token via the mode-routed setter,
-            // leaving LocalToken unseeded (and re-mintable by the generate-if-empty fallback).
+            // A freshly-constructed config (the ctor calls SetDefault) must carry a non-empty LOCAL server
+            // token. Cloud-mode credentials come from the shared machine store (T9 — the cloudToken mirror
+            // was removed), so SetDefault seeds only the local token and nothing cloud-related.
             var config = new UnityMcpPlugin.UnityConnectionConfig();
 
             Assert.IsFalse(string.IsNullOrEmpty(config.LocalToken),
                 "SetDefault must seed a non-empty LocalToken so the generate-if-empty fallback never has to mint it.");
-            Assert.IsNull(config.CloudToken,
-                "SetDefault must leave CloudToken null — the cloud token comes from Cloud sign-in, not GenerateToken().");
         }
 
         [Test]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
@@ -28,17 +28,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
     {
         const string DiskHost = "http://localhost:24029";
         const string DiskLocalToken = "DISK_LOCAL_TOKEN";
-        const string DiskCloudToken = "DISK_CLOUD_TOKEN";
 
         static UnityMcpPlugin.UnityConnectionConfig BuildDiskConfig(ConnectionMode mode = ConnectionMode.Cloud)
         {
-            // Simulates a config that came back from disk: explicit values for both
-            // local and cloud tokens, default mode = Cloud (matching the plugin's default).
+            // Simulates a config that came back from disk: an explicit local token and the plugin's default
+            // mode = Cloud. Cloud credentials no longer live in the config (T9 — the cloudToken mirror was
+            // removed); the shared machine store owns them.
             return new UnityMcpPlugin.UnityConnectionConfig
             {
                 LocalHost = DiskHost,
                 LocalToken = DiskLocalToken,
-                CloudToken = DiskCloudToken,
                 ConnectionMode = mode,
                 AuthOption = AuthOption.required,
                 KeepConnected = true,
@@ -74,7 +73,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             Assert.IsFalse(record.HasAny, "Expected no overrides when env and args are empty.");
             Assert.AreEqual(DiskHost, config.LocalHost);
-            Assert.AreEqual(DiskCloudToken, config.CloudToken);
             Assert.AreEqual(DiskLocalToken, config.LocalToken);
             Assert.AreEqual(ConnectionMode.Cloud, config.ConnectionMode);
             Assert.AreEqual(AuthOption.required, config.AuthOption);
@@ -83,19 +81,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         // --- Env var override ---
 
         [Test]
-        public void Override_EnvToken_WritesToCloudTokenWhenModeIsCloud()
+        public void Override_EnvToken_WritesToLocalTokenEvenWhenModeIsCloud()
         {
+            // T9: the env/flag token override targets the LOCAL token only. Cloud-mode credentials come from
+            // the shared machine store, so UNITY_MCP_TOKEN no longer seeds a persisted cloud token; it always
+            // routes to LocalToken (inert for the Cloud connection, which the machine store serves).
             var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
             var env = Env((EnvironmentUtils.EnvToken, "ENV_TOKEN"));
 
             var record = EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
 
             Assert.IsTrue(record.HasAny);
-            Assert.IsTrue(record.Contains(EnvironmentUtils.FieldCloudToken),
-                "Expected the CloudToken backing field to be tracked when mode is Cloud.");
-            Assert.AreEqual("ENV_TOKEN", config.CloudToken);
-            Assert.AreEqual(DiskLocalToken, config.LocalToken,
-                "LocalToken must remain at the disk baseline when mode is Cloud.");
+            Assert.IsTrue(record.Contains(EnvironmentUtils.FieldLocalToken),
+                "Expected the LocalToken backing field to be tracked for the token override.");
+            Assert.AreEqual("ENV_TOKEN", config.LocalToken);
         }
 
         [Test]
@@ -107,7 +106,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
 
             Assert.AreEqual("ENV_TOKEN", config.LocalToken);
-            Assert.AreEqual(DiskCloudToken, config.CloudToken);
         }
 
         // --- Flag override (highest priority, beats env) ---
@@ -121,7 +119,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             EnvironmentUtils.ApplyEnvironmentOverrides(config, args, env);
 
-            Assert.AreEqual("FLAG_TOKEN", config.CloudToken,
+            Assert.AreEqual("FLAG_TOKEN", config.LocalToken,
                 "When both --token and UNITY_MCP_TOKEN are set, the flag must win.");
         }
 
@@ -136,7 +134,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             EnvironmentUtils.ApplyEnvironmentOverrides(config, args, env);
 
-            Assert.AreEqual("FLAG_VIA_FULL_NAME", config.CloudToken);
+            Assert.AreEqual("FLAG_VIA_FULL_NAME", config.LocalToken);
         }
 
         // --- Per-field layering ---
@@ -151,7 +149,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             Assert.AreEqual(DiskHost, config.LocalHost,
                 "Host must remain at the disk baseline when only the token was overridden.");
-            Assert.AreEqual("ENV_TOKEN", config.CloudToken);
+            Assert.AreEqual("ENV_TOKEN", config.LocalToken);
         }
 
         // --- Trailing-slash robustness ---
@@ -185,8 +183,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             // Worktree scenario: disk says Cloud, env supplies a localhost URL.
             // Expected: ConnectionMode is inferred to Custom so the worktree's local
-            // dev token routes to LocalToken (not CloudToken) and the SignalR client
-            // talks to <host>/hub/mcp-server (not <host>/mcp/hub/mcp-server).
+            // dev token routes to LocalToken and the SignalR client talks to
+            // <host>/hub/mcp-server (not <host>/mcp/hub/mcp-server).
             var config = BuildDiskConfig(mode: ConnectionMode.Cloud);
             var env = Env(
                 (EnvironmentUtils.EnvCloudUrl, "http://localhost:5220/"),
@@ -199,8 +197,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.AreEqual("http://localhost:5220", config.LocalHost);
             Assert.AreEqual("WORKTREE_TOKEN", config.LocalToken,
                 "Token override must route to LocalToken once mode is inferred Custom.");
-            Assert.AreEqual(DiskCloudToken, config.CloudToken,
-                "CloudToken on disk must NOT be clobbered by the env override.");
             Assert.IsTrue(record.Contains(EnvironmentUtils.FieldConnectionMode));
             Assert.IsTrue(record.Contains(EnvironmentUtils.FieldHost));
             Assert.IsTrue(record.Contains(EnvironmentUtils.FieldLocalToken));
@@ -302,7 +298,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             EnvironmentUtils.ApplyEnvironmentOverrides(config, NoArgs(), env);
 
-            Assert.AreEqual("QUOTED_TOKEN", config.CloudToken);
+            Assert.AreEqual("QUOTED_TOKEN", config.LocalToken);
         }
 
         // --- Helpers ---

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/MainWindowEditor.StatusLogicTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/MainWindowEditor.StatusLogicTests.cs
@@ -206,46 +206,40 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
         #region ComputeCloudAuthState
 
+        // T9: the "has credential" input now comes from the shared machine store (AccountCredentialService
+        // .IsSignedIn), not a persisted cloudToken — so ComputeCloudAuthState takes a bool, not a token string.
+
         [Test]
-        public void ComputeCloudAuthState_Cloud_NullToken()
+        public void ComputeCloudAuthState_Cloud_NoCredential()
         {
-            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Cloud, null);
+            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Cloud, false);
             Assert.IsTrue(needsAuth);
             Assert.IsFalse(hasToken);
             Assert.IsTrue(isCloud);
         }
 
         [Test]
-        public void ComputeCloudAuthState_Cloud_EmptyToken()
+        public void ComputeCloudAuthState_Cloud_WithCredential()
         {
-            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Cloud, "");
-            Assert.IsTrue(needsAuth);
-            Assert.IsFalse(hasToken);
-            Assert.IsTrue(isCloud);
-        }
-
-        [Test]
-        public void ComputeCloudAuthState_Cloud_ValidToken()
-        {
-            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Cloud, "abc");
+            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Cloud, true);
             Assert.IsFalse(needsAuth);
             Assert.IsTrue(hasToken);
             Assert.IsTrue(isCloud);
         }
 
         [Test]
-        public void ComputeCloudAuthState_Custom_NullToken()
+        public void ComputeCloudAuthState_Custom_NoCredential()
         {
-            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Custom, null);
+            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Custom, false);
             Assert.IsFalse(needsAuth);
             Assert.IsFalse(hasToken);
             Assert.IsFalse(isCloud);
         }
 
         [Test]
-        public void ComputeCloudAuthState_Custom_ValidToken()
+        public void ComputeCloudAuthState_Custom_WithCredential()
         {
-            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Custom, "abc");
+            var (needsAuth, hasToken, isCloud) = MainWindowEditor.ComputeCloudAuthState(ConnectionMode.Custom, true);
             Assert.IsFalse(needsAuth);
             Assert.IsTrue(hasToken);
             Assert.IsFalse(isCloud);


### PR DESCRIPTION
## Summary
- Stop mirroring the Cloud access token into `UserSettings/AI-Game-Developer-Config.json` (`cloudToken`); the shared machine store (`~/.ai-game-dev/credentials.json`) is now the single Cloud credential source.
- Remove `UnityConnectionConfig.CloudToken` and all read fallbacks — the Cloud-mode `CredentialProvider` returns the machine-store token or `null` (anonymous); the cloud-auth UI and `UNITY_MCP_TOKEN`/`--token` override are rewired accordingly (UI reads `AccountCredentialService.IsSignedIn`; the env/flag override targets the local token only). Existing user configs keep the stale `cloudToken` key harmlessly (no migration).

## Test plan
- [x] Target-specific local tests passed (Unity EditMode chunked gate `failing=0`; PlayMode 1/1) — see profile test.md

Closes #908