### PR TITLE
docs: sync Unity/CLI/Installer READMEs with shipped OAuth login & pinned setup-mcp

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/README.md
+++ b/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/README.md
@@ -65,8 +65,8 @@ npm install -g unity-mcp-cli
 # 2. Install "AI Game Developer" in Unity project
 unity-mcp-cli install-plugin ./MyUnityProject
 
-# 3. Login to cloud server
-unity-mcp-cli login ./MyUnityProject
+# 3. Sign in to ai-game.dev (opens your browser — OAuth device flow)
+unity-mcp-cli login
 
 # 4. Open Unity project (auto-connects and generates skills)
 unity-mcp-cli open ./MyUnityProject
@@ -95,6 +95,8 @@ That's it. Ask your AI *"Create 3 cubes in a circle with radius 2"* and watch it
 # Skills and Tools Reference
 
 The plugin ships with 70+ built-in tools across four categories. Each tool brings AI skill. All tools are available immediately after installation — no extra configuration required. See [docs/default-mcp-tools.md](docs/default-mcp-tools.md) for the full reference with detailed descriptions.
+
+> 🧰 Browse the full MCP tools registry online: [ai-game.dev/docs/tools](https://ai-game.dev/docs/tools)
 
 <details>
   <summary>Project & Assets</summary>
@@ -198,8 +200,15 @@ Install extensions when need more tools or [create your own tools](#add-custom-t
 | Extension | Description |
 | --- | --- |
 | **[AI Animation](https://github.com/IvanMurzak/Unity-AI-Animation/)** | Set of additional tools for Unity Animations |
+| **[AI Cinemachine](https://github.com/IvanMurzak/Unity-AI-Cinemachine/)** | MCP Tools for Cinemachine |
+| **[AI InputSystem](https://github.com/IvanMurzak/Unity-AI-InputSystem/)** | MCP Tools for the Unity Input System |
+| **[AI Navigation](https://github.com/IvanMurzak/Unity-AI-Navigation/)** | MCP Tools for AI Navigation (NavMesh surfaces, baking, agents, links) |
 | **[AI ParticleSystem](https://github.com/IvanMurzak/Unity-AI-ParticleSystem/)** | Set of additional tools for Unity Particle System |
 | **[AI ProBuilder](https://github.com/IvanMurzak/Unity-AI-ProBuilder/)** | Set of additional tools for Unity ProBuilder |
+| **[AI Splines](https://github.com/IvanMurzak/Unity-AI-Splines/)** | MCP Tools for Unity Splines |
+| **[AI Terrain](https://github.com/IvanMurzak/Unity-AI-Terrain/)** | Set of additional tools for Unity Terrain |
+| **[AI Tilemap](https://github.com/IvanMurzak/Unity-AI-Tilemap/)** | MCP Tools for Unity 2D Tilemaps |
+| **[AI Timeline](https://github.com/IvanMurzak/Unity-AI-Timeline/)** | MCP Tools for Unity Timeline cutscenes and sequences |
 
 ![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 
@@ -303,8 +312,8 @@ unity-mcp-cli create-project ./MyUnityProject              #  │ codex         
 # 2. Install "AI Game Developer" in Unity project          #  │ gemini             │
 unity-mcp-cli install-plugin ./MyUnityProject              #  │ github-copilot-cli │
                                                            #  │ kilo-code          │
-# 3. Login to cloud server                                 #  │ open-code          │
-unity-mcp-cli login ./MyUnityProject                       #  │ rider-junie        │
+# 3. Sign in to ai-game.dev (OAuth device flow)            #  │ open-code          │
+unity-mcp-cli login                                        #  │ rider-junie        │
                                                            #  │ unity-ai           │
 # 4. Open Unity project (auto-connects and generates skills)  │ vs-copilot         │
 unity-mcp-cli open ./MyUnityProject                        #  │ vscode-copilot     │
@@ -314,6 +323,8 @@ unity-mcp-cli wait-for-ready ./MyUnityProject
 ```
 
 > See [full CLI documentation](https://github.com/IvanMurzak/Unity-MCP/blob/main/cli/README.md) for all available commands.
+
+> **Cloud sign-in & project pinning:** `unity-mcp-cli login` runs the browser OAuth device flow and stores the credential in the shared machine store (`~/.ai-game-dev/credentials.json`) — there is no personal access token to paste. By default the AI-agent config that `setup-mcp` writes points at a per-project **pinned** endpoint (`https://ai-game.dev/mcp/p/<pin>`); pass `--no-pin` to use the shared `https://ai-game.dev/mcp` endpoint instead. Teams can distribute access with an **enrollment code**: `unity-mcp-cli install-plugin --enroll <code>`.
 
 ## Step 2: Install `AI agent`
 
@@ -592,8 +603,8 @@ Doesn't matter what launch option you choose, all of them support custom configu
 | `MCP_PLUGIN_PORT`             | `--port`                 | **Client** -> **Server** <- **Plugin** connection port (default: 8080)       |
 | `MCP_PLUGIN_CLIENT_TIMEOUT`   | `--plugin-timeout`       | **Plugin** -> **Server** connection timeout (ms) (default: 10000)            |
 | `MCP_PLUGIN_CLIENT_TRANSPORT` | `--client-transport`     | **Client** -> **Server** transport type: `stdio` or `streamableHttp` (default: `streamableHttp`) |
-| `MCP_AUTHORIZATION`           | `--authorization`        | Authentication mode for incoming **Client** connections: `none` or `required` (default: `none`) |
-| `MCP_PLUGIN_TOKEN`            | `--token`                | Bearer token required from the **Client** when `--authorization=required` (default: unset) |
+| `MCP_AUTHORIZATION`           | `--authorization`        | Authentication mode for incoming **Client** connections: `none`, `oauth`, or `token` (default: `none`; the legacy `required` mode was removed) |
+| `MCP_PLUGIN_TOKEN`            | `--token`                | Bearer token required from the **Client** when authorization is `token` (default: unset) |
 | `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | Shut down the server after this many seconds with no connections (default: 600) |
 
 > Command line args support also the option with a single `-` prefix (`-port`) and an option without prefix at all (`port`).
@@ -611,7 +622,7 @@ The Unity MCP Plugin reads the following environment variables (and command-line
 | `UNITY_MCP_CLOUD_URL`       | `-url`                      | URL string                    | Override the MCP Server URL (`UNITY_MCP_HOST` is a legacy alias)     |
 | `UNITY_MCP_CONNECTION_MODE` | `-UNITY_MCP_CONNECTION_MODE`| `Cloud` / `Custom`            | Force the connection mode (a loopback URL implies `Custom`)          |
 | `UNITY_MCP_KEEP_CONNECTED`  | `-UNITY_MCP_KEEP_CONNECTED` | `true` / `false`              | Force enable or disable the active connection                       |
-| `UNITY_MCP_AUTH_OPTION`     | `-auth`                     | `none` / `required`           | Force set the authentication mode                                   |
+| `UNITY_MCP_AUTH_OPTION`     | `-auth`                     | `none` / `oauth` / `token`    | Force set the authentication mode (legacy `required` migrates to `token`) |
 | `UNITY_MCP_TOKEN`           | `-token`                    | string                        | Force set the authentication token                                  |
 | `UNITY_MCP_TRANSPORT`       | `-UNITY_MCP_TRANSPORT`      | `stdio` / `streamableHttp`    | Force the client transport the plugin configures                    |
 | `UNITY_MCP_START_SERVER`    | `-UNITY_MCP_START_SERVER`   | `true` / `false`              | Force whether the plugin keeps a local server process running       |
@@ -623,9 +634,9 @@ The Unity MCP Plugin reads the following environment variables (and command-line
 
 ```bash
 Unity.exe -batchmode -nographics \
-  -UNITY_MCP_HOST=http://localhost:8080 \
+  -UNITY_MCP_CLOUD_URL=http://localhost:8080 \
   -UNITY_MCP_KEEP_CONNECTED=true \
-  -UNITY_MCP_AUTH_OPTION=required \
+  -UNITY_MCP_AUTH_OPTION=token \
   -UNITY_MCP_TOKEN=my-secret-token
 ```
 
@@ -846,6 +857,15 @@ It is a bridge between `MCP Client` and "something else", in this particular cas
 - "When creating UI elements, always add them to the Canvas in Scene/UI/MainCanvas"
 - "Performance is critical - prefer object pooling for frequently instantiated objects"
 - "This project follows SOLID principles - explain any architecture decisions"
+
+![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
+
+# Uninstall 🧹
+
+To completely remove the plugin from your Unity project:
+
+1. Open **Window ▸ Package Manager**, select the **AI Game Developer — MCP** package, and click **Remove**.
+2. Close Unity, then delete the `Assets/Plugins/NuGet` folder (along with its `Assets/Plugins/NuGet.meta` file).
 
 ![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ npm install -g unity-mcp-cli
 # 2. Install "AI Game Developer" in Unity project
 unity-mcp-cli install-plugin ./MyUnityProject
 
-# 3. Login to cloud server
-unity-mcp-cli login ./MyUnityProject
+# 3. Sign in to ai-game.dev (opens your browser — OAuth device flow)
+unity-mcp-cli login
 
 # 4. Open Unity project (auto-connects and generates skills)
 unity-mcp-cli open ./MyUnityProject
@@ -312,8 +312,8 @@ unity-mcp-cli create-project ./MyUnityProject              #  │ codex         
 # 2. Install "AI Game Developer" in Unity project          #  │ gemini             │
 unity-mcp-cli install-plugin ./MyUnityProject              #  │ github-copilot-cli │
                                                            #  │ kilo-code          │
-# 3. Login to cloud server                                 #  │ open-code          │
-unity-mcp-cli login ./MyUnityProject                       #  │ rider-junie        │
+# 3. Sign in to ai-game.dev (OAuth device flow)            #  │ open-code          │
+unity-mcp-cli login                                        #  │ rider-junie        │
                                                            #  │ unity-ai           │
 # 4. Open Unity project (auto-connects and generates skills)  │ vs-copilot         │
 unity-mcp-cli open ./MyUnityProject                        #  │ vscode-copilot     │
@@ -323,6 +323,8 @@ unity-mcp-cli wait-for-ready ./MyUnityProject
 ```
 
 > See [full CLI documentation](https://github.com/IvanMurzak/Unity-MCP/blob/main/cli/README.md) for all available commands.
+
+> **Cloud sign-in & project pinning:** `unity-mcp-cli login` runs the browser OAuth device flow and stores the credential in the shared machine store (`~/.ai-game-dev/credentials.json`) — there is no personal access token to paste. By default the AI-agent config that `setup-mcp` writes points at a per-project **pinned** endpoint (`https://ai-game.dev/mcp/p/<pin>`); pass `--no-pin` to use the shared `https://ai-game.dev/mcp` endpoint instead. Teams can distribute access with an **enrollment code**: `unity-mcp-cli install-plugin --enroll <code>`.
 
 ## Step 2: Install `AI agent`
 
@@ -601,8 +603,8 @@ Doesn't matter what launch option you choose, all of them support custom configu
 | `MCP_PLUGIN_PORT`             | `--port`                 | **Client** -> **Server** <- **Plugin** connection port (default: 8080)       |
 | `MCP_PLUGIN_CLIENT_TIMEOUT`   | `--plugin-timeout`       | **Plugin** -> **Server** connection timeout (ms) (default: 10000)            |
 | `MCP_PLUGIN_CLIENT_TRANSPORT` | `--client-transport`     | **Client** -> **Server** transport type: `stdio` or `streamableHttp` (default: `streamableHttp`) |
-| `MCP_AUTHORIZATION`           | `--authorization`        | Authentication mode for incoming **Client** connections: `none` or `required` (default: `none`) |
-| `MCP_PLUGIN_TOKEN`            | `--token`                | Bearer token required from the **Client** when `--authorization=required` (default: unset) |
+| `MCP_AUTHORIZATION`           | `--authorization`        | Authentication mode for incoming **Client** connections: `none`, `oauth`, or `token` (default: `none`; the legacy `required` mode was removed) |
+| `MCP_PLUGIN_TOKEN`            | `--token`                | Bearer token required from the **Client** when authorization is `token` (default: unset) |
 | `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | Shut down the server after this many seconds with no connections (default: 600) |
 
 > Command line args support also the option with a single `-` prefix (`-port`) and an option without prefix at all (`port`).
@@ -620,7 +622,7 @@ The Unity MCP Plugin reads the following environment variables (and command-line
 | `UNITY_MCP_CLOUD_URL`       | `-url`                      | URL string                    | Override the MCP Server URL (`UNITY_MCP_HOST` is a legacy alias)     |
 | `UNITY_MCP_CONNECTION_MODE` | `-UNITY_MCP_CONNECTION_MODE`| `Cloud` / `Custom`            | Force the connection mode (a loopback URL implies `Custom`)          |
 | `UNITY_MCP_KEEP_CONNECTED`  | `-UNITY_MCP_KEEP_CONNECTED` | `true` / `false`              | Force enable or disable the active connection                       |
-| `UNITY_MCP_AUTH_OPTION`     | `-auth`                     | `none` / `required`           | Force set the authentication mode                                   |
+| `UNITY_MCP_AUTH_OPTION`     | `-auth`                     | `none` / `oauth` / `token`    | Force set the authentication mode (legacy `required` migrates to `token`) |
 | `UNITY_MCP_TOKEN`           | `-token`                    | string                        | Force set the authentication token                                  |
 | `UNITY_MCP_TRANSPORT`       | `-UNITY_MCP_TRANSPORT`      | `stdio` / `streamableHttp`    | Force the client transport the plugin configures                    |
 | `UNITY_MCP_START_SERVER`    | `-UNITY_MCP_START_SERVER`   | `true` / `false`              | Force whether the plugin keeps a local server process running       |
@@ -632,9 +634,9 @@ The Unity MCP Plugin reads the following environment variables (and command-line
 
 ```bash
 Unity.exe -batchmode -nographics \
-  -UNITY_MCP_HOST=http://localhost:8080 \
+  -UNITY_MCP_CLOUD_URL=http://localhost:8080 \
   -UNITY_MCP_KEEP_CONNECTED=true \
-  -UNITY_MCP_AUTH_OPTION=required \
+  -UNITY_MCP_AUTH_OPTION=token \
   -UNITY_MCP_TOKEN=my-secret-token
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -66,8 +66,8 @@ unity-mcp-cli create-project ./MyUnityProject              #  │ codex         
 # 2. Install "AI Game Developer" in Unity project          #  │ gemini             │
 unity-mcp-cli install-plugin ./MyUnityProject              #  │ github-copilot-cli │
                                                            #  │ kilo-code          │
-# 3. Login to cloud server                                 #  │ open-code          │
-unity-mcp-cli login ./MyUnityProject                       #  │ rider-junie        │
+# 3. Sign in to ai-game.dev (OAuth device flow)            #  │ open-code          │
+unity-mcp-cli login                                        #  │ rider-junie        │
                                                            #  │ unity-ai           │
 # 4. Open Unity project (auto-connects and generates skills)  │ vs-copilot         │
 unity-mcp-cli open ./MyUnityProject                        #  │ vscode-copilot     │
@@ -95,6 +95,7 @@ npx unity-mcp-cli install-plugin /path/to/unity/project
   - [`create-project`](#create-project)
   - [`install-plugin`](#install-plugin)
   - [`install-unity`](#install-unity)
+  - [`login`](#login)
   - [`open`](#open)
   - [`close`](#close)
   - [`run-tool`](#run-tool)
@@ -182,16 +183,22 @@ unity-mcp-cli create-project ./MyGame --unity 2022.3.62f1
 
 ## `install-plugin`
 
-Install the Unity-MCP plugin into a Unity project's `Packages/manifest.json`.
+Install the Unity-MCP plugin into a Unity project's `Packages/manifest.json`. Optionally download the RID-matched MCP server binary and redeem a team enrollment code in the same run.
 
 ```bash
-unity-mcp-cli install-plugin ./MyGame
+# Run from inside the Unity project folder — the path is optional
+cd ./MyGame && unity-mcp-cli install-plugin
 ```
 
 | Option | Required | Description |
 |---|---|---|
-| `[path]` | Yes | Path to the Unity project (positional or `--path`) |
+| `[path]` | No | Path to the Unity project (positional or `--path`). Defaults to the current directory; the resolved directory is verified to be a real Unity project (`Packages/manifest.json` marker) and, on a miss, the error lists exactly what was checked. |
 | `--plugin-version <version>` | No | Plugin version to install (defaults to latest from [OpenUPM](https://openupm.com/packages/com.ivanmurzak.unity.mcp/)) |
+| `--with-server` | No | Also download the RID-matched [GameDev-MCP-Server](https://github.com/IvanMurzak/GameDev-MCP-Server) binary into the CLI-managed directory |
+| `--server-version <version>` | No | Server version to download with `--with-server` (default: the CLI's pinned server version) |
+| `--server-source <path-or-url>` | No | Offline/CI override — install the server from a local zip path or URL (skips checksum verification) |
+| `--enroll <code>` | No | Redeem an enrollment code for a plugin credential (planted in the shared machine store and pinned to this project) |
+| `--enroll-stdin` | No | Read the enrollment code from stdin instead of argv (keeps it out of shell history) |
 
 This command:
 1. Adds the **OpenUPM scoped registry** with all required scopes
@@ -202,6 +209,12 @@ This command:
 
 ```bash
 unity-mcp-cli install-plugin ./MyGame --plugin-version 0.51.6
+```
+
+**Example — redeem a team enrollment code (path defaults to cwd):**
+
+```bash
+cd ./MyGame && unity-mcp-cli install-plugin --enroll <code>
 ```
 
 > After running this command, open the project in Unity Editor to complete the package installation.
@@ -231,6 +244,35 @@ unity-mcp-cli install-unity --path ./MyGame
 
 ![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 
+## `login`
+
+Sign in to **ai-game.dev** and store the credential in the shared machine credential store (`~/.ai-game-dev/credentials.json`). Runs the browser-based **OAuth 2.1 device flow** — there is no personal access token to create or paste. The stored credential is the single source of truth for cloud authentication (consumed by `open`, `run-tool`, and the Unity Editor plugin).
+
+```bash
+unity-mcp-cli login
+```
+
+| Option | Required | Description |
+|---|---|---|
+| `--project <path>` | No | Store the credential in a project-local store (`<path>/.ai-game-dev/`) instead of the shared machine store |
+| `--force` | No | Re-authenticate even if a credential already exists |
+
+The command prints a short user code and a verification URL, opens your browser, and polls until you approve the sign-in. If a credential already exists it exits early with *"Already signed in"* — pass `--force` to replace it.
+
+**Example — sign in (shared machine store):**
+
+```bash
+unity-mcp-cli login
+```
+
+**Example — store the credential next to a specific project:**
+
+```bash
+unity-mcp-cli login --project ./MyGame
+```
+
+![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
+
 ## `open`
 
 Open a Unity project in the Unity Editor. By default, sets MCP connection environment variables if connection options are provided. Use `--no-connect` to open without MCP connection.
@@ -249,10 +291,10 @@ cd ./MyGame && unity-mcp-cli open
 | `--unity <version>` | — | No | Specific Unity Editor version to use (defaults to version from project settings, falls back to highest installed) |
 | `--editor-path <path>` | — | No | Explicit path to the Unity Editor executable. Skips Unity Hub discovery, useful for custom install locations. |
 | `--no-connect` | — | No | Open without MCP connection environment variables |
-| `--url <url>` | `UNITY_MCP_HOST` | No | MCP server URL to connect to |
+| `--url <url>` | `UNITY_MCP_CLOUD_URL` | No | MCP server URL to connect to (the CLI still exports the legacy alias `UNITY_MCP_HOST`, which the plugin also accepts) |
 | `--keep-connected` | `UNITY_MCP_KEEP_CONNECTED` | No | Force keep the connection alive |
 | `--token <token>` | `UNITY_MCP_TOKEN` | No | Authentication token |
-| `--auth <option>` | `UNITY_MCP_AUTH_OPTION` | No | Auth mode: `none` or `required` |
+| `--auth <option>` | `UNITY_MCP_AUTH_OPTION` | No | Auth mode: `none`, `oauth`, or `token` |
 | `--tools <names>` | `UNITY_MCP_TOOLS` | No | Comma-separated list of tools to enable |
 | `--transport <method>` | `UNITY_MCP_TRANSPORT` | No | Transport method: `streamableHttp` or `stdio` |
 | `--start-server <value>` | `UNITY_MCP_START_SERVER` | No | Set to `true` or `false` to control MCP server auto-start |
@@ -292,7 +334,7 @@ unity-mcp-cli open ./MyGame --no-connect
 unity-mcp-cli open ./MyGame \
   --url http://my-server:8080 \
   --token my-secret-token \
-  --auth required \
+  --auth token \
   --tools gameobject-create,gameobject-find
 ```
 
@@ -428,6 +470,8 @@ unity-mcp-cli wait-for-ready --url http://localhost:8080 --timeout 30000
 
 Write MCP config files for AI agents, enabling headless/CI setup without the Unity Editor UI. Supports all 14 agents (Claude Code, Cursor, Gemini, Codex, etc.).
 
+By default the written config is **credential-free** (the client authenticates with your native OAuth sign-in from [`login`](#login)) and **pinned** to this project via a per-project URL (`https://ai-game.dev/mcp/p/<pin>` for http transport, or a `project=<pin>` argument for stdio). Pass `--no-pin` for the shared, unpinned endpoint, or `--token` to opt into writing a static credential (PAT) into the config. This output matches the Unity Editor's **Configure MCP** button byte-for-byte.
+
 ```bash
 unity-mcp-cli setup-mcp claude-code ./MyGame
 ```
@@ -438,7 +482,8 @@ unity-mcp-cli setup-mcp claude-code ./MyGame
 | `[path]` | No | Unity project path (defaults to cwd) |
 | `--transport <transport>` | No | Transport method: `stdio` or `http` (default: `http`) |
 | `--url <url>` | No | Server URL override (for http transport) |
-| `--token <token>` | No | Auth token override |
+| `--token <token>` | No | Explicit PAT opt-in — writes a static credential into the config (default: credential-free, native OAuth) |
+| `--no-pin` | No | Write an unpinned URL / omit the `project=` argument (default: pin to this project via `/mcp/p/<pin>`) |
 | `--list` | No | List all available agent IDs |
 
 **Example — list all supported agents:**
@@ -451,6 +496,12 @@ unity-mcp-cli setup-mcp --list
 
 ```bash
 unity-mcp-cli setup-mcp cursor ./MyGame --transport stdio
+```
+
+**Example — write an unpinned config (shared `/mcp` endpoint):**
+
+```bash
+unity-mcp-cli setup-mcp claude-code ./MyGame --no-pin
 ```
 
 ![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
@@ -568,8 +619,8 @@ unity-mcp-cli install-plugin ./MyAIGame
 # 3. Enable all MCP tools
 unity-mcp-cli configure ./MyAIGame --enable-all-tools
 
-# 4. Login to cloud server (authenticates and saves token)
-unity-mcp-cli login ./MyAIGame
+# 4. Sign in to ai-game.dev (browser OAuth; credential saved to ~/.ai-game-dev)
+unity-mcp-cli login
 
 # 5. Open the project (auto-connects and generates skills for claude-code)
 unity-mcp-cli open ./MyAIGame


### PR DESCRIPTION
## Summary
- Updates the three public-facing READMEs (root `README.md`, `cli/README.md`, Installer `README.md`) to describe **shipped** behavior after the CLI OAuth-login migration (e1) and `cloudToken` cleanup (d2).
- Login → **OAuth 2.1 device flow** (credential in `~/.ai-game-dev/`, no PAT to paste); auth vocabulary `none`/`required` → `none`/`oauth`/`token` (legacy `required` removed); CI batch example fixed to `UNITY_MCP_CLOUD_URL` + `AUTH_OPTION=token`.
- `cli/README.md`: documents `login` in the command reference, makes `install-plugin` path optional (+ `--with-server`/`--enroll` options), maps `open --url` → `UNITY_MCP_CLOUD_URL`, and documents pinned `setup-mcp` (`--no-pin`).
- **Installer README regenerated from root** — was 3 extensions (now 10) and lacked the Uninstall section; now identical to root with all auth fixes.

## Test plan
- [x] Docs-only change (three `.md` files) — no `Unity-MCP-Plugin/**` code touched, so Unity EditMode/PlayMode suites do not apply.
- [x] CLI vitest suite green: `512 passed, 2 skipped, 0 failed` (`npm run build && npx vitest run`).
- [x] Grep-verified: no legacy device-flow / PAT-mint login documented; no stale `--auth required` / `UNITY_MCP_HOST=` in examples.

Closes #910