### PR TITLE
ci: add workflow_dispatch to release.yml (manual escape hatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
   push:
     branches:
       - main
+  # Manual escape hatch: a merge to `main` does not ALWAYS create the push
+  # event (observed 2026-07-19 across several repos - merge landed, zero runs).
+  # Without this, a release that misses its push event cannot be cut at all.
+  workflow_dispatch:
 
 jobs:
   test-cli:


### PR DESCRIPTION
Adds `workflow_dispatch:` to `release.yml`, matching Godot-MCP and AI-Game-Dev-Server.

**Why now:** on 2026-07-19 several merges to `main` landed correctly but created **no push event at all** — verified across AI-Game-Dev-Server (`93ce9129`) and Godot-MCP (`caccda91`, zero runs including `CI`), with GitHub Actions reporting *operational*. Godot and AGS were recoverable because their workflows expose `workflow_dispatch`; **Unity-MCP was not**, so a release that misses its push event currently cannot be cut at all.

This is a pure escape hatch — the `push: [main]` trigger and the `check-version-tag` gate are unchanged, so a dispatch still only cuts a release when the version gate says it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmhxryEuZcqu2KDsVbyvt6