### PR TITLE
chore(release): bump version to 0.85.1

### DIFF
--- a/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
+++ b/Installer/Assets/com.IvanMurzak/AI Game Dev Installer/Installer.cs
@@ -19,7 +19,7 @@ namespace com.IvanMurzak.Unity.MCP.Installer
     public static partial class Installer
     {
         public const string PackageId = "com.ivanmurzak.unity.mcp";
-        public const string Version = "0.85.0";
+        public const string Version = "0.85.1";
 
         static Installer()
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.cs
@@ -27,7 +27,7 @@ namespace com.IvanMurzak.Unity.MCP
 
     public partial class UnityMcpPlugin : IDisposable
     {
-        public const string Version = "0.85.0";
+        public const string Version = "0.85.1";
 
         private static int _singletonCount = 0;
         public static bool HasAnyInstance => _singletonCount > 0;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/package.json
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/package.json
@@ -15,7 +15,7 @@
     "Unity MCP",
     "Unity Skills"
   ],
-  "version": "0.85.0",
+  "version": "0.85.1",
   "unity": "2022.3",
   "description": "AI Skills, MCP Tools, and CLI for Unity Engine. Full AI develop and test loop. Use cli for quick setup. Efficient token usage, advanced tools. Any C# method may be turned into a tool by a single line. Works with Claude Code, Gemini, Copilot, Cursor and any other absolutely for free.",
   "documentationUrl": "https://github.com/IvanMurzak/Unity-MCP/blob/main/README.md",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unity-mcp-cli",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unity-mcp-cli",
-      "version": "0.85.0",
+      "version": "0.85.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@baizor/gamedev-cli-core": "^0.1.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-mcp-cli",
-  "version": "0.85.0",
+  "version": "0.85.1",
   "description": "Cross-platform CLI tool for AI Game Developer (Skills & MCP). Full AI develop and test loop. Efficient token usage, advanced tools. Creates Unity project, installs plugins, configures tools, and manages HTTP connection with Unity Editor and a game made with Unity. Works with Claude Code, Gemini, Copilot, Cursor and any other absolutely for free.",
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Automated release bump for Unity-MCP `0.85.1` (classification: explicit). Merging to `main` fires `release.yml` (OpenUPM signed UPM + NuGet + Installer .unitypackage + the unity-ai-* extension cascade). Previous: `0.85.0`. Merged with `--admin` -- the pipeline identity is the sole code-owner of a 1-approval branch.