### PR TITLE
chore(ci): upgrade Node20-deprecated actions to Node24-capable versions

### DIFF
--- a/.github/workflows/publish_test_results.yml
+++ b/.github/workflows/publish_test_results.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Download all test result artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,7 +445,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create Tag and Release with all assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.check-version-tag.outputs.version }}
           name: ${{ needs.check-version-tag.outputs.version }}
@@ -562,21 +562,21 @@ jobs:
     if: always()
     steps:
       - name: Delete Unity Package artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: unity-installer-package
           failOnError: false
         continue-on-error: true
 
       - name: Delete signed UPM package artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: signed-upm-package
           failOnError: false
         continue-on-error: true
 
       - name: Delete release notes artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: release-notes
           failOnError: false

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -51,7 +51,7 @@ jobs:
       # 2-b. Free disk space
       # --------------------------------------------------------------------- #
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           android: true


### PR DESCRIPTION
GitHub is force-running these actions on Node 24 already; the pinned
majors below are the last Node20-based releases. Runtime-compatibility
fix, not cosmetics.

  actions/download-artifact   v4 -> v6   (publish_test_results.yml, x1)
  softprops/action-gh-release v2 -> v3   (release.yml, x1)
  geekyeggo/delete-artifact   v5 -> v6   (release.yml, x3)

Also, out of the deprecation scope but a supply-chain fix worth taking
in the same pass:

  jlumbroso/free-disk-space   @main -> @v1.3.1  (test_unity_plugin.yml, x1)

`@main` is a mutable ref — upstream can change the action's code under
us at any time, with full access to the runner. v1.3.1 is the pinned
release every other repo in this fleet already uses.

Deliberately unchanged: actions/cache@v5 (x3) is not a legacy v3-era SHA
pin and is not deprecated; game-ci/unity-test-runner stays on its
node24-runtime SHA (PR #304); mukunku/tag-exists-action@v1.7.0 is
already Node24.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012WxMrEo6Nk4RCQZjA4LkFC
