### PR TITLE
fix(ci): download-artifact v6 -> v7 (v6 is still Node20)

### DIFF
--- a/.github/workflows/publish_test_results.yml
+++ b/.github/workflows/publish_test_results.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Download all test result artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,19 +403,19 @@ jobs:
       release_notes: ${{ steps.read_notes.outputs.release_body }}
     steps:
       - name: Download release notes artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: release-notes
           path: ./release-notes
 
       - name: Download Unity installer artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: unity-installer-package
           path: ./assets
 
       - name: Download signed UPM package artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: signed-upm-package
           path: ./assets


### PR DESCRIPTION
Follow-up correction to #920.

`actions/download-artifact@v6` declares `runs.using: node20` — unlike its sibling
`actions/upload-artifact@v6`, which is `node24`. The two repos diverged at v6, so
bumping download-artifact to v6 did **not** clear the deprecation.

Verified directly against each tag's `action.yml`:

| ref | `runs.using` |
|---|---|
| `download-artifact@v4` / `@v5` / `@v6` | node20 |
| `download-artifact@v7` | **node24** ✅ |
| `download-artifact@v8` | node24, but makes digest-mismatch a hard error |

Targets **v7**: Node24-capable without v8's stricter digest behaviour.

4 occurrences: `publish_test_results.yml` ×1, `release.yml` ×3.

Note: `publish_test_results.yml` is `workflow_run`-triggered, so GitHub always runs it from
the default branch copy — this fix goes live only after merge, not on this PR's own CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WxMrEo6Nk4RCQZjA4LkFC