### PR TITLE
Fix tests-run state being wiped by PlayerPrefs.DeleteAll (#870)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.Run.cs
@@ -110,7 +110,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 // Running tests against a dirty scene is unsafe: Unity may reload the scene on
                 // play-mode entry, silently discarding edits and producing non-reproducible
                 // results. Throws InvalidOperationException listing every dirty scene so the
-                // caller can save and retry. MUST run before PlayerPrefs writes and before
+                // caller can save and retry. MUST run before test-run state writes and before
                 // AssetDatabase.Refresh so nothing is side-effected on abort.
                 ThrowIfAnyOpenSceneIsDirty();
 
@@ -119,7 +119,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                         .Error(Error.TestsAlreadyRunning(activeRequestId))
                         .SetRequestID(requestId);
 
-                // Save display options to PlayerPrefs BEFORE AssetDatabase.Refresh —
+                // Save display options to SessionState BEFORE AssetDatabase.Refresh —
                 // these must be persisted before a potential domain reload
                 TestResultCollector.IncludePassingTests.Value = includePassingTests;
                 TestResultCollector.IncludeMessage.Value = includeMessages;

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests.cs
@@ -145,20 +145,18 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             if (string.IsNullOrEmpty(requestId) || TestResultCollector.TestCallRequestID.Value == requestId)
             {
                 TestResultCollector.TestCallRequestID.Value = string.Empty;
-                PlayerPrefs.DeleteKey(ActiveTestRunStartedUtcTicksKey);
-                PlayerPrefs.Save();
+                SessionState.EraseString(ActiveTestRunStartedUtcTicksKey);
             }
         }
 
         internal static void SetActiveTestRunStartedUtc(DateTime utcStarted)
         {
-            PlayerPrefs.SetString(ActiveTestRunStartedUtcTicksKey, utcStarted.ToUniversalTime().Ticks.ToString());
-            PlayerPrefs.Save();
+            SessionState.SetString(ActiveTestRunStartedUtcTicksKey, utcStarted.ToUniversalTime().Ticks.ToString());
         }
 
         static bool IsActiveTestRunStale(DateTime utcNow)
         {
-            var rawTicks = PlayerPrefs.GetString(ActiveTestRunStartedUtcTicksKey, string.Empty);
+            var rawTicks = SessionState.GetString(ActiveTestRunStartedUtcTicksKey, string.Empty);
             if (!long.TryParse(rawTicks, out var ticks))
                 return true;
 
@@ -202,6 +200,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
             {
                 ClearPendingTestRun();
                 ClearActiveTestRun(requestId);
+                if (string.IsNullOrEmpty(requestId))
+                {
+                    UnityMcpPluginEditor.Instance.LogError(
+                        "Compilation failed after a deferred test run, but the pending MCP request id was missing. The error response cannot be delivered to the client.",
+                        typeof(Tool_Tests));
+                    return;
+                }
 
                 var errorDetails = ScriptUtils.GetCompilationErrorDetails();
                 var response = ResponseCallValueTool<TestRunResponse>
@@ -248,7 +253,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
         /// Running tests while a scene is dirty is unsafe: Unity may reload the scene when
         /// entering play mode, silently discarding the unsaved edits and producing a test run
         /// against a scene state that does not match either the in-memory scene or the asset
-        /// on disk. This check aborts before any state is mutated (no PlayerPrefs, no
+        /// on disk. This check aborts before any state is mutated (no test-run state, no
         /// AssetDatabase.Refresh, no domain reload is triggered).
         ///
         /// MUST be called on the Unity main thread.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateBool.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateBool.cs
@@ -1,0 +1,33 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using UnityEditor;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
+{
+    public sealed class SessionStateBool
+    {
+        readonly string _key;
+        readonly bool _defaultValue;
+
+        public SessionStateBool(string key, bool defaultValue = false)
+        {
+            _key = key;
+            _defaultValue = defaultValue;
+        }
+
+        public bool Value
+        {
+            get => SessionState.GetBool(_key, _defaultValue);
+            set => SessionState.SetBool(_key, value);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateBool.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateBool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7adc6463a00d7640a0596116ffdb3c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateInt.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateInt.cs
@@ -1,0 +1,33 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using UnityEditor;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
+{
+    public sealed class SessionStateInt
+    {
+        readonly string _key;
+        readonly int _defaultValue;
+
+        public SessionStateInt(string key, int defaultValue = 0)
+        {
+            _key = key;
+            _defaultValue = defaultValue;
+        }
+
+        public int Value
+        {
+            get => SessionState.GetInt(_key, _defaultValue);
+            set => SessionState.SetInt(_key, value);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateInt.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateInt.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a32002168c98fd488a9a5b5ab835dc8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateString.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateString.cs
@@ -1,0 +1,39 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using UnityEditor;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
+{
+    public sealed class SessionStateString
+    {
+        readonly string _key;
+        readonly string _defaultValue;
+
+        public SessionStateString(string key, string defaultValue = "")
+        {
+            _key = key;
+            _defaultValue = defaultValue;
+        }
+
+        public string Value
+        {
+            get => SessionState.GetString(_key, _defaultValue);
+            set
+            {
+                if (string.IsNullOrEmpty(value) && string.IsNullOrEmpty(_defaultValue))
+                    SessionState.EraseString(_key);
+                else
+                    SessionState.SetString(_key, value);
+            }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateString.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/SessionStateString.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2652c2f338e9993478e71dd962f843e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/TestResultCollector.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/Tests/TestResultCollector.cs
@@ -15,7 +15,6 @@ using System.Linq;
 using com.IvanMurzak.McpPlugin.Common.Model;
 using com.IvanMurzak.Unity.MCP.Editor.API;
 using com.IvanMurzak.Unity.MCP.Runtime.Utils;
-using Extensions.Unity.PlayerPrefsEx;
 using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
 
@@ -51,15 +50,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
             _ => "Unknown"
         };
 
-        public static PlayerPrefsString TestCallRequestID = new PlayerPrefsString("Unity_MCP_TestRunner_TestCallRequestID");
+        public static SessionStateString TestCallRequestID = new("Unity_MCP_TestRunner_TestCallRequestID");
 
-        public static PlayerPrefsBool IncludePassingTests = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludePassingTests");
-        public static PlayerPrefsBool IncludeMessage = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeMessage", true);
-        public static PlayerPrefsBool IncludeMessageStacktrace = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeStacktrace");
+        public static SessionStateBool IncludePassingTests = new("Unity_MCP_TestRunner_IncludePassingTests");
+        public static SessionStateBool IncludeMessage = new("Unity_MCP_TestRunner_IncludeMessage", true);
+        public static SessionStateBool IncludeMessageStacktrace = new("Unity_MCP_TestRunner_IncludeStacktrace");
 
-        public static PlayerPrefsBool IncludeLogs = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeLogs");
-        public static PlayerPrefsInt IncludeLogsMinLevel = new PlayerPrefsInt("Unity_MCP_TestRunner_IncludeLogsMinLevel", (int)LogType.Warning);
-        public static PlayerPrefsBool IncludeLogsStacktrace = new PlayerPrefsBool("Unity_MCP_TestRunner_IncludeLogsStacktrace");
+        public static SessionStateBool IncludeLogs = new("Unity_MCP_TestRunner_IncludeLogs");
+        public static SessionStateInt IncludeLogsMinLevel = new("Unity_MCP_TestRunner_IncludeLogsMinLevel", (int)LogType.Warning);
+        public static SessionStateBool IncludeLogsStacktrace = new("Unity_MCP_TestRunner_IncludeLogsStacktrace");
 
         public TestResultCollector()
         {
@@ -149,6 +148,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
                     RequestId = requestId,
                     Result = response
                 });
+            }
+            else
+            {
+                UnityMcpPluginEditor.Instance.LogError(
+                    "Test run finished, but the pending MCP request id was missing. The test results cannot be delivered to the client.",
+                    typeof(TestResultCollector));
             }
         }
 
@@ -292,5 +297,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API.TestRunner
                 _ => TestResultStatus.Skipped
             };
         }
+
     }
 }


### PR DESCRIPTION
This pull request refactors how test run state and user options are stored during test execution in the Unity MCP plugin. It replaces the use of `PlayerPrefs` with Unity's `SessionState` for all test-run-related state, making the state editor-session-scoped instead of persistent across Unity restarts. The update introduces new helper classes for `SessionState` storage and improves error handling for missing request IDs during test runs.

**Migration from PlayerPrefs to SessionState for Test Runner State:**

- All test run state and user option storage in `TestResultCollector` and related logic now use `SessionState` instead of `PlayerPrefs`, ensuring that test state is not persisted across editor restarts and is safer for editor tooling. [[1]](diffhunk://#diff-ee199314e110d3b5540dee6d2208c67d511f0512c82bdc7285aa78b74b9a0e36L54-R61) [[2]](diffhunk://#diff-a281e6a1ef8ad5717434a59bd7d1a48c5918ca147259603d70d1b4d08314e449L148-R159) [[3]](diffhunk://#diff-a281e6a1ef8ad5717434a59bd7d1a48c5918ca147259603d70d1b4d08314e449R203-R209) [[4]](diffhunk://#diff-0dcf20fedae5362e40820ded833edf602d3020fe47b81b7d14d0165e0ecbde37L113-R113) [[5]](diffhunk://#diff-0dcf20fedae5362e40820ded833edf602d3020fe47b81b7d14d0165e0ecbde37L122-R122) [[6]](diffhunk://#diff-ee199314e110d3b5540dee6d2208c67d511f0512c82bdc7285aa78b74b9a0e36L18) [[7]](diffhunk://#diff-ee199314e110d3b5540dee6d2208c67d511f0512c82bdc7285aa78b74b9a0e36R300) [[8]](diffhunk://#diff-a281e6a1ef8ad5717434a59bd7d1a48c5918ca147259603d70d1b4d08314e449L251-R256)

**New SessionState Helper Classes:**

- Added `SessionStateBool`, `SessionStateInt`, and `SessionStateString` classes to encapsulate and simplify using Unity's `SessionState` API for different data types. [[1]](diffhunk://#diff-1f6134e321ec0e28eec42495611a6634356d564a73540537228dcc2770af3150R1-R33) [[2]](diffhunk://#diff-41522045cad209c92a8807c1cbcd14ff318d83cc084560d07a45bf453089395bR1-R33) [[3]](diffhunk://#diff-e877b4fa6386661128230e84aab37bb32c076ccf3616f550cf649428e6d5fa07R1-R39)

**Improved Error Handling:**

- Added error logging for cases where a test run finishes or resumes but the MCP request ID is missing, preventing silent failures and improving debugging. [[1]](diffhunk://#diff-ee199314e110d3b5540dee6d2208c67d511f0512c82bdc7285aa78b74b9a0e36R152-R157) [[2]](diffhunk://#diff-a281e6a1ef8ad5717434a59bd7d1a48c5918ca147259603d70d1b4d08314e449R203-R209)

These changes make test run state management safer and more predictable within the Unity Editor session.