### PR TITLE
fix(cli): read the machine-store credential for Cloud run-tool auth (defect E / D11)

### DIFF
--- a/cli/src/commands/run-tool-builder.ts
+++ b/cli/src/commands/run-tool-builder.ts
@@ -69,10 +69,16 @@ export function buildRunToolCommand(cfg: BuilderOptions): Command {
       // Resolve path + connection up front so the heading and verbose
       // output reflect the final endpoint before the HTTP call fires.
       const projectPath = resolveAndValidateProjectPath(positionalPath, options);
-      const { url: baseUrl, token } = resolveConnection(projectPath, options);
+      const { url: baseUrl, token, cloudAuthMissing } = resolveConnection(projectPath, options);
+      if (cloudAuthMissing) {
+        ui.error(
+          'Not logged in to ai-game.dev. Run `unity-mcp-cli login` to sign in, then retry — or pass --token / --url to target a specific server.',
+        );
+        process.exit(1);
+      }
       const body = parseInput(options);
       const endpoint = `${baseUrl}${cfg.routePrefix}/${encodeURIComponent(toolName)}`;
-      const authSource = options.token ? '--token flag' : 'config';
+      const authSource = options.token ? '--token flag' : 'config or machine store';
 
       verbose(`${cfg.verboseLabel}: ${toolName}`);
       verbose(`Endpoint: ${endpoint}`);

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -5,7 +5,7 @@
 // - Errors are returned in `{ kind: 'failure', success: false, ... }`,
 //   never thrown past the public boundary.
 
-import { readConfig, resolveConnectionFromConfig } from '../utils/config.js';
+import { readConfig, resolveConnectionFromConfig, isCloudMode } from '../utils/config.js';
 import { generatePortFromDirectory } from '../utils/port.js';
 import { requireProjectPath } from './validation.js';
 import type {
@@ -166,14 +166,28 @@ function resolveConnection(
 
   const config = readConfig(projectPath);
   const fromConfig = config
-    ? resolveConnectionFromConfig(config)
+    ? resolveConnectionFromConfig(config, { readCloudToken: opts.readCloudToken })
     : { url: undefined, token: undefined };
 
   const url = fromConfig.url
     ? fromConfig.url.replace(/\/$/, '')
     : `http://localhost:${generatePortFromDirectory(projectPath)}`;
 
-  return { kind: 'success', url, token: opts.token ?? fromConfig.token };
+  const token = opts.token ?? fromConfig.token;
+
+  // Cloud mode draws its Bearer from the shared machine credential store; when the user is not
+  // logged in the token is undefined. Fail actionably rather than issue a silent unauthenticated
+  // cloud request (defect E / D11).
+  if (config && isCloudMode(config) && !token) {
+    return makeFailure({
+      endpoint: '',
+      reason: 'not-authenticated',
+      message:
+        'Not logged in to ai-game.dev. Run `unity-mcp-cli login` to sign in, or pass an explicit --token / --url.',
+    });
+  }
+
+  return { kind: 'success', url, token };
 }
 
 function serializeInput(input: unknown): { json: string } | { error: Error } {

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -567,6 +567,7 @@ export type CreateProjectResult = CreateProjectSuccess | CreateProjectFailure;
  */
 export type RunToolFailureReason =
   | 'invalid-input'
+  | 'not-authenticated'
   | 'connection-refused'
   | 'connection-reset'
   | 'network-error'
@@ -622,6 +623,13 @@ export interface RunToolOptions {
    * implementation. Defaults to the global `fetch`.
    */
   fetchImpl?: typeof fetch;
+  /**
+   * Optional injection point for the Cloud-mode Bearer credential read from the shared machine
+   * credential store (`~/.ai-game-dev/credentials.json`). Only consulted when the resolved project
+   * config is in Cloud mode and neither `url` nor `token` was supplied. Defaults to reading the real
+   * per-machine store; tests inject a deterministic value.
+   */
+  readCloudToken?: () => string | undefined;
 }
 
 /** Successful `runTool` / `runSystemTool` outcome. Narrow with `kind === 'success'`. */

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { generatePortFromDirectory } from './port.js';
+import { MachineCredentialStore } from './machine-credentials.js';
 
 const CONFIG_RELATIVE_PATH = 'UserSettings/AI-Game-Developer-Config.json';
 
@@ -171,20 +172,54 @@ export const CLOUD_SERVER_BASE_URL = 'https://ai-game.dev';
 export const CLOUD_SERVER_URL = 'https://ai-game.dev/mcp';
 
 /**
- * Resolve the server URL and auth token from a project config based on connectionMode.
- * - Custom mode (string "Custom" or integer 0): uses `host` and `token`
- * - Cloud mode (string "Cloud" or integer 1): uses hardcoded cloud URL and `cloudToken`
- * In Custom mode, `url` and `token` may be undefined if the corresponding config fields are not set.
- * In Cloud mode, `url` is always the hardcoded cloud URL, while `token` comes from `cloudToken` and may be undefined.
+ * Read the Cloud-mode Bearer credential from the shared machine credential store
+ * (`~/.ai-game-dev/credentials.json`, managed by `@baizor/gamedev-cli-core`).
+ *
+ * Post-T9 the Unity plugin no longer writes `cloudToken` into the project config — the cloud auth
+ * token now lives once per machine in the shared store (written by `unity-mcp-cli login`). Returns the
+ * stored `accessToken`, or `undefined` when the user is not logged in OR the store is unreadable — a
+ * corrupt/undecryptable store must degrade to "not logged in", never crash a tool call.
  */
-export function resolveConnectionFromConfig(config: UnityConnectionConfig): {
+export function readMachineStoreCloudToken(): string | undefined {
+  try {
+    return new MachineCredentialStore().read()?.accessToken ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Options for {@link resolveConnectionFromConfig}. */
+export interface ResolveConnectionFromConfigOptions {
+  /**
+   * Reads the Cloud-mode Bearer credential from the shared machine credential store. Injectable so
+   * tests (and advanced callers) can supply a deterministic value without touching the real
+   * per-machine store. Defaults to {@link readMachineStoreCloudToken}.
+   */
+  readCloudToken?: () => string | undefined;
+}
+
+/**
+ * Resolve the server URL and auth token from a project config based on connectionMode.
+ * - Custom mode (string "Custom" or integer 0): uses `host` and `token` (self-host / derived-port).
+ * - Cloud mode (string "Cloud" or integer 1): uses the hardcoded cloud URL and the Bearer credential
+ *   from the shared machine credential store (`~/.ai-game-dev/credentials.json`) — NOT the on-disk
+ *   `cloudToken`, which the plugin stopped writing post-T9 (defect E / D11).
+ * In Custom mode, `url` and `token` may be undefined if the corresponding config fields are not set.
+ * In Cloud mode, `url` is always the hardcoded cloud URL, while `token` is the stored credential and is
+ * `undefined` when the user is not logged in — the caller surfaces an actionable "not logged in" error
+ * rather than issuing a silent unauthenticated request.
+ */
+export function resolveConnectionFromConfig(
+  config: UnityConnectionConfig,
+  options: ResolveConnectionFromConfigOptions = {},
+): {
   url: string | undefined;
   token: string | undefined;
 } {
-  const cloud = isCloudMode(config);
+  if (isCloudMode(config)) {
+    const readCloudToken = options.readCloudToken ?? readMachineStoreCloudToken;
+    return { url: CLOUD_SERVER_URL, token: readCloudToken() };
+  }
 
-  return {
-    url: cloud ? CLOUD_SERVER_URL : config.host,
-    token: cloud ? config.cloudToken : config.token,
-  };
+  return { url: config.host, token: config.token };
 }

--- a/cli/src/utils/connection.ts
+++ b/cli/src/utils/connection.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { verbose } from './ui.js';
 import { generatePortFromDirectory } from './port.js';
-import { readConfig, resolveConnectionFromConfig } from './config.js';
+import { readConfig, resolveConnectionFromConfig, isCloudMode } from './config.js';
 import * as ui from './ui.js';
 
 export interface ConnectionOptions {
@@ -61,23 +61,37 @@ export function resolveAndValidateProjectPath(positionalPath: string | undefined
  *
  * Token priority:
  *   1. --token flag (explicit override)
- *   2. Config file token
+ *   2. Config file token (Custom mode) / shared machine credential store (Cloud mode)
  */
+export interface ResolveConnectionDeps {
+  /**
+   * Injection point for the Cloud-mode machine-store credential read. Forwarded to
+   * `resolveConnectionFromConfig`; defaults to the real per-machine store. Tests inject a
+   * deterministic value.
+   */
+  readCloudToken?: () => string | undefined;
+}
+
 export function resolveConnection(
   projectPath: string,
   options: ConnectionOptions,
-): { url: string; token: string | undefined } {
+  deps: ResolveConnectionDeps = {},
+): { url: string; token: string | undefined; cloudAuthMissing: boolean } {
   const config = readConfig(projectPath);
-  const fromConfig = config ? resolveConnectionFromConfig(config) : { url: undefined, token: undefined };
+  const fromConfig = config
+    ? resolveConnectionFromConfig(config, { readCloudToken: deps.readCloudToken })
+    : { url: undefined, token: undefined };
 
   verbose(`Config loaded: connectionMode=${config?.connectionMode ?? 'N/A'}, configUrl=${fromConfig.url ?? 'N/A'}, hasToken=${!!fromConfig.token}`);
 
   let url: string;
+  let usingCloudUrl = false;
   if (options.url) {
     url = options.url.replace(/\/$/, '');
     verbose(`Using explicit --url: ${url}`);
   } else if (fromConfig.url) {
     url = fromConfig.url.replace(/\/$/, '');
+    usingCloudUrl = !!config && isCloudMode(config);
     verbose(`Using URL from config (${config?.connectionMode} mode): ${url}`);
   } else {
     const port = generatePortFromDirectory(projectPath);
@@ -90,5 +104,12 @@ export function resolveConnection(
     verbose('Using explicit --token');
   }
 
-  return { url, token };
+  // Cloud mode resolves its Bearer from the shared machine credential store (see
+  // resolveConnectionFromConfig). When the store holds no credential AND the caller overrode
+  // neither the endpoint (--url) nor the token (--token), the request would go out unauthenticated —
+  // signal this so the run-tool command surfaces an actionable "not logged in" error instead of a
+  // silent unauthenticated cloud call (defect E / D11).
+  const cloudAuthMissing = usingCloudUrl && !token;
+
+  return { url, token, cloudAuthMissing };
 }

--- a/cli/tests/lib-run-tool.test.ts
+++ b/cli/tests/lib-run-tool.test.ts
@@ -393,6 +393,77 @@ describe('runTool — connection resolution', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Cloud mode — machine-store credential + not-logged-in guard (defect E / D11)
+// ---------------------------------------------------------------------------
+
+describe('runTool — Cloud mode auth', () => {
+  function writeCloudConfig(projectPath: string, extra: Record<string, unknown> = {}): void {
+    fs.mkdirSync(path.join(projectPath, 'UserSettings'), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectPath, 'UserSettings', 'AI-Game-Developer-Config.json'),
+      JSON.stringify({ connectionMode: 'Cloud', ...extra }),
+    );
+  }
+
+  it('sends the machine-store credential as the Bearer token against the cloud URL', async () => {
+    const projectPath = mkUnityProject();
+    // A legacy on-disk cloudToken must be ignored; auth comes from the machine store.
+    writeCloudConfig(projectPath, { cloudToken: 'legacy-ignored' });
+    const spy = makeFetchSpy(async () => jsonResponse({ status: 'success', content: [] }));
+
+    const result = await runTool({
+      toolName: 'ping',
+      unityProjectPath: projectPath,
+      readCloudToken: () => 'store-bearer-token',
+      fetchImpl: spy.fetch,
+    });
+
+    expect(result.kind).toBe('success');
+    expect(spy.calls[0].url).toBe('https://ai-game.dev/mcp/api/tools/ping');
+    const headers = spy.calls[0].init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer store-bearer-token');
+  });
+
+  it('errors actionably (never fires an unauthenticated request) when not logged in', async () => {
+    const projectPath = mkUnityProject();
+    writeCloudConfig(projectPath, { cloudToken: 'legacy-ignored' });
+    const spy = makeFetchSpy(async () => jsonResponse({ status: 'success', content: [] }));
+
+    const result = await runTool({
+      toolName: 'ping',
+      unityProjectPath: projectPath,
+      readCloudToken: () => undefined, // empty machine store ⇒ not logged in
+      fetchImpl: spy.fetch,
+    });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.reason).toBe('not-authenticated');
+    expect(result.message).toContain('Not logged in to ai-game.dev');
+    // No silent unauthenticated cloud call.
+    expect(spy.calls).toHaveLength(0);
+  });
+
+  it('honors an explicit token override in Cloud mode (no login required)', async () => {
+    const projectPath = mkUnityProject();
+    writeCloudConfig(projectPath);
+    const spy = makeFetchSpy(async () => jsonResponse({ status: 'success', content: [] }));
+
+    const result = await runTool({
+      toolName: 'ping',
+      unityProjectPath: projectPath,
+      token: 'explicit-token',
+      readCloudToken: () => undefined,
+      fetchImpl: spy.fetch,
+    });
+
+    expect(result.kind).toBe('success');
+    const headers = spy.calls[0].init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer explicit-token');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Library hygiene
 // ---------------------------------------------------------------------------
 

--- a/cli/tests/run-tool.test.ts
+++ b/cli/tests/run-tool.test.ts
@@ -4,17 +4,28 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { fileURLToPath } from 'url';
-import { resolveConnectionFromConfig, isCloudMode, CLOUD_SERVER_URL, type UnityConnectionConfig } from '../src/utils/config.js';
+import {
+  resolveConnectionFromConfig,
+  readMachineStoreCloudToken,
+  isCloudMode,
+  CLOUD_SERVER_URL,
+  type UnityConnectionConfig,
+} from '../src/utils/config.js';
+import { resolveConnection } from '../src/utils/connection.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
 
-function runCli(args: string[], options?: { cwd?: string }): { stdout: string; exitCode: number } {
+function runCli(
+  args: string[],
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+): { stdout: string; exitCode: number } {
   try {
     const stdout = execFileSync('node', [CLI_PATH, ...args], {
       encoding: 'utf-8',
       timeout: 10000,
       cwd: options?.cwd,
+      env: options?.env,
     });
     return { stdout, exitCode: 0 };
   } catch (err: unknown) {
@@ -24,6 +35,20 @@ function runCli(args: string[], options?: { cwd?: string }): { stdout: string; e
       exitCode: error.status ?? 1,
     };
   }
+}
+
+/**
+ * A fresh, empty `$HOME` / `%USERPROFILE%` so the CLI's shared machine credential store
+ * (`<home>/.ai-game-dev/credentials.json`) resolves to a directory that holds NO credential —
+ * i.e. the "not logged in" state — deterministically, regardless of whether this dev machine is
+ * actually signed in. Used by the Cloud-mode integration tests.
+ */
+function loggedOutEnv(): { env: NodeJS.ProcessEnv; cleanup: () => void } {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-logged-out-'));
+  return {
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+    cleanup: () => fs.rmSync(home, { recursive: true, force: true }),
+  };
 }
 
 // ── resolveConnectionFromConfig unit tests ────────────────────────────────────
@@ -41,16 +66,30 @@ describe('resolveConnectionFromConfig', () => {
     expect(result.token).toBe('custom-secret');
   });
 
-  it('returns hardcoded cloud URL and cloudToken in Cloud mode', () => {
+  it('returns hardcoded cloud URL and the machine-store credential in Cloud mode', () => {
+    // Post-T9 the plugin no longer writes `cloudToken`; the Cloud-mode Bearer now comes from the
+    // shared machine credential store, NOT the on-disk `cloudToken` (defect E / D11).
     const config: UnityConnectionConfig = {
       connectionMode: 'Cloud',
       host: 'http://localhost:55000',
       token: 'custom-secret',
       cloudToken: 'cloud-secret',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = resolveConnectionFromConfig(config, { readCloudToken: () => 'store-bearer-token' });
     expect(result.url).toBe(CLOUD_SERVER_URL);
-    expect(result.token).toBe('cloud-secret');
+    expect(result.token).toBe('store-bearer-token');
+  });
+
+  it('does NOT read cloudToken in Cloud mode (store empty ⇒ undefined token)', () => {
+    // The dead `cloudToken` read is gone: even with a `cloudToken` present in the config, an empty
+    // machine store resolves to no token (which the caller turns into a "not logged in" error).
+    const config: UnityConnectionConfig = {
+      connectionMode: 'Cloud',
+      cloudToken: 'cloud-secret',
+    };
+    const result = resolveConnectionFromConfig(config, { readCloudToken: () => undefined });
+    expect(result.url).toBe(CLOUD_SERVER_URL);
+    expect(result.token).toBeUndefined();
   });
 
   it('defaults to Custom mode when connectionMode is undefined', () => {
@@ -72,11 +111,11 @@ describe('resolveConnectionFromConfig', () => {
     expect(result.token).toBeUndefined();
   });
 
-  it('returns hardcoded cloud URL and undefined token when fields are missing in Cloud mode', () => {
+  it('returns hardcoded cloud URL and undefined token when not logged in (Cloud mode)', () => {
     const config: UnityConnectionConfig = {
       connectionMode: 'Cloud',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = resolveConnectionFromConfig(config, { readCloudToken: () => undefined });
     expect(result.url).toBe(CLOUD_SERVER_URL);
     expect(result.token).toBeUndefined();
   });
@@ -91,14 +130,14 @@ describe('resolveConnectionFromConfig', () => {
     expect(result.token).toBe('custom-only');
   });
 
-  it('does not cross-contaminate Cloud token with Custom token', () => {
+  it('ignores both config.token and config.cloudToken in Cloud mode (uses the machine store)', () => {
     const config: UnityConnectionConfig = {
       connectionMode: 'Cloud',
       token: 'custom-only',
       cloudToken: 'cloud-only',
     };
-    const result = resolveConnectionFromConfig(config);
-    expect(result.token).toBe('cloud-only');
+    const result = resolveConnectionFromConfig(config, { readCloudToken: () => 'store-bearer' });
+    expect(result.token).toBe('store-bearer');
   });
 
   // Legacy integer enum values (written by older Unity plugin versions)
@@ -115,16 +154,117 @@ describe('resolveConnectionFromConfig', () => {
     expect(result.token).toBe('custom-secret');
   });
 
-  it('handles legacy integer 1 as Cloud mode with hardcoded URL', () => {
+  it('handles legacy integer 1 as Cloud mode with the machine-store credential', () => {
     const config: UnityConnectionConfig = {
       connectionMode: 1,
       host: 'http://localhost:55000',
       token: 'custom-secret',
       cloudToken: 'cloud-secret',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = resolveConnectionFromConfig(config, { readCloudToken: () => 'store-bearer-token' });
     expect(result.url).toBe(CLOUD_SERVER_URL);
-    expect(result.token).toBe('cloud-secret');
+    expect(result.token).toBe('store-bearer-token');
+  });
+});
+
+// ── machine-store credential wiring (default, un-injected path) ───────────────
+
+describe('readMachineStoreCloudToken', () => {
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
+  let home: string;
+
+  beforeEach(() => {
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    // Point the shared machine store at an empty dir ⇒ deterministic "not logged in".
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-store-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it('returns undefined when the machine store holds no credential', () => {
+    expect(readMachineStoreCloudToken()).toBeUndefined();
+  });
+
+  it('is the default Cloud-mode token source for resolveConnectionFromConfig (empty store ⇒ undefined)', () => {
+    // No injected readCloudToken ⇒ the resolver falls through to the real (here empty) machine store.
+    const result = resolveConnectionFromConfig({ connectionMode: 'Cloud', cloudToken: 'ignored' });
+    expect(result.url).toBe(CLOUD_SERVER_URL);
+    expect(result.token).toBeUndefined();
+  });
+});
+
+// ── resolveConnection cloud-auth-missing signal (feeds the run-tool guard) ─────
+
+describe('resolveConnection — Cloud auth missing', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-resolve-conn-'));
+    fs.mkdirSync(path.join(tmpDir, 'Assets'));
+    fs.mkdirSync(path.join(tmpDir, 'UserSettings'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeCloudConfig(): void {
+    fs.writeFileSync(
+      path.join(tmpDir, 'UserSettings', 'AI-Game-Developer-Config.json'),
+      JSON.stringify({ connectionMode: 'Cloud' }),
+    );
+  }
+
+  it('flags cloudAuthMissing when Cloud mode has no machine-store credential', () => {
+    writeCloudConfig();
+    const result = resolveConnection(tmpDir, {}, { readCloudToken: () => undefined });
+    expect(result.url).toBe(CLOUD_SERVER_URL);
+    expect(result.token).toBeUndefined();
+    expect(result.cloudAuthMissing).toBe(true);
+  });
+
+  it('does not flag cloudAuthMissing when the store has a credential', () => {
+    writeCloudConfig();
+    const result = resolveConnection(tmpDir, {}, { readCloudToken: () => 'store-bearer' });
+    expect(result.token).toBe('store-bearer');
+    expect(result.cloudAuthMissing).toBe(false);
+  });
+
+  it('does not flag cloudAuthMissing when --token overrides in Cloud mode', () => {
+    writeCloudConfig();
+    const result = resolveConnection(tmpDir, { token: 'explicit' }, { readCloudToken: () => undefined });
+    expect(result.token).toBe('explicit');
+    expect(result.cloudAuthMissing).toBe(false);
+  });
+
+  it('does not flag cloudAuthMissing when --url overrides the endpoint in Cloud mode', () => {
+    writeCloudConfig();
+    const result = resolveConnection(
+      tmpDir,
+      { url: 'http://localhost:9999' },
+      { readCloudToken: () => undefined },
+    );
+    expect(result.url).toBe('http://localhost:9999');
+    expect(result.cloudAuthMissing).toBe(false);
+  });
+
+  it('never flags cloudAuthMissing in Custom mode (self-host / derived-port)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'UserSettings', 'AI-Game-Developer-Config.json'),
+      JSON.stringify({ connectionMode: 'Custom', host: 'http://localhost:55000' }),
+    );
+    const result = resolveConnection(tmpDir, {}, { readCloudToken: () => undefined });
+    expect(result.cloudAuthMissing).toBe(false);
   });
 });
 
@@ -232,20 +372,27 @@ describe('run-tool config resolution', () => {
     expect(stdout).toContain('http://localhost:55555');
   });
 
-  it('reads hardcoded cloud URL in Cloud mode (--verbose shows resolved URL)', () => {
+  it('resolves the hardcoded cloud URL in Cloud mode, then refuses when not logged in', () => {
     writeProjectConfig({
       connectionMode: 'Cloud',
       host: 'http://localhost:55555',
       authOption: 'none',
     });
-    const { stdout } = runCli([
-      'run-tool', 'test-tool',
-      '--path', tmpDir,
-      '--verbose',
-      '--raw',
-    ]);
-    expect(stdout).toContain('Cloud mode');
-    expect(stdout).toContain('https://ai-game.dev/mcp');
+    const { env, cleanup } = loggedOutEnv();
+    try {
+      const { stdout, exitCode } = runCli(
+        ['run-tool', 'test-tool', '--path', tmpDir, '--verbose', '--raw'],
+        { env },
+      );
+      // The cloud URL still resolves (verbose shows it) ...
+      expect(stdout).toContain('Cloud mode');
+      expect(stdout).toContain('https://ai-game.dev/mcp');
+      // ... but with no machine-store credential the call is refused, never sent unauthenticated.
+      expect(stdout).toContain('Not logged in to ai-game.dev');
+      expect(exitCode).toBe(1);
+    } finally {
+      cleanup();
+    }
   });
 
   it('--url flag overrides config URL', () => {
@@ -291,19 +438,26 @@ describe('run-tool config resolution', () => {
     expect(stdout).toContain('Authorization header set');
   });
 
-  it('reads cloudToken from config in Cloud mode (--verbose shows hasToken)', () => {
+  it('ignores a legacy cloudToken in Cloud mode (auth comes from the machine store)', () => {
     writeProjectConfig({
       connectionMode: 'Cloud',
       cloudToken: 'cloud-token-123',
     });
-    const { stdout } = runCli([
-      'run-tool', 'test-tool',
-      '--path', tmpDir,
-      '--verbose',
-      '--raw',
-    ]);
-    expect(stdout).toContain('hasToken=true');
-    expect(stdout).toContain('Authorization header set');
+    const { env, cleanup } = loggedOutEnv();
+    try {
+      const { stdout, exitCode } = runCli(
+        ['run-tool', 'test-tool', '--path', tmpDir, '--verbose', '--raw'],
+        { env },
+      );
+      // The on-disk cloudToken is NOT read: with an empty store the resolver sees no token ...
+      expect(stdout).toContain('hasToken=false');
+      expect(stdout).not.toContain('Authorization header set');
+      // ... and the run-tool command refuses to fire an unauthenticated cloud request.
+      expect(stdout).toContain('Not logged in to ai-game.dev');
+      expect(exitCode).toBe(1);
+    } finally {
+      cleanup();
+    }
   });
 
   it('does not set auth header when config has no token', () => {


### PR DESCRIPTION
## Summary
- Post-T9 the Unity plugin no longer writes `cloudToken`, but the CLI's connection resolver still read `config.cloudToken` for the Cloud-mode Bearer — so cloud `run-tool` calls went out **unauthenticated**. `resolveConnectionFromConfig` now resolves the Cloud-mode token from the shared machine credential store (`@baizor/gamedev-cli-core` `MachineCredentialStore`, `~/.ai-game-dev/credentials.json`) via `accessToken`. Custom mode (host/token + derived-port fallback) is unchanged.
- Missing-credential path now errors **actionably** instead of firing a silent unauthenticated request: the CLI `run-tool` command exits non-zero with a "not logged in — run `unity-mcp-cli login`" message; the library `runTool` returns a `not-authenticated` failure and never issues the request.
- The bug-asserting test (`run-tool.test.ts`) now asserts the fix; added coverage for the store-credential Bearer path, the missing-credential refusal (unit + lib), and the `cloudAuthMissing` signal.

## Test plan
- [x] Target-specific local tests passed (see profile test.md) — full `cli/` vitest suite green (523 passed, 2 pre-existing skips) via `npm run build && npx vitest run --testTimeout=30000`.

Closes #924