### PR TITLE
feat: MPPM (Multiplayer Play Mode) support — clones as read-only hub clients

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -150,9 +150,20 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         public const string ExecutableName = "gamedev-mcp-server";
 
         public static string McpServerName
-            => string.IsNullOrEmpty(Application.productName)
-                ? "Unity Unknown"
-                : $"Unity {Application.productName}";
+        {
+            get
+            {
+                var baseName = string.IsNullOrEmpty(Application.productName)
+                    ? "Unity Unknown"
+                    : $"Unity {Application.productName}";
+                // MPPM virtual-player clones share the product name with the main editor — include
+                // the clone identity (e.g. "Unity MyGame (Player 2)") so their hub connections and
+                // any config entries stay distinguishable.
+                return MppmUtils.IsMppmClone
+                    ? $"{baseName} ({MppmUtils.CloneName})"
+                    : baseName;
+            }
+        }
 
         public static string OperationSystem =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" :
@@ -385,6 +396,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         /// </param>
         public static Task<bool> DownloadServerBinaryIfNeeded(bool unattended = false)
         {
+            // MPPM virtual-player clones never launch their own server (they connect to the main
+            // editor's), so they must not download a duplicate binary into their cloned Library/.
+            if (MppmUtils.IsMppmClone)
+                return Task.FromResult(IsBinaryExists());
+
             if (EnvironmentUtils.IsCi())
             {
                 // Ignore in CI environment

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Startup.cs
@@ -9,11 +9,16 @@
 */
 
 #nullable enable
+using System.Collections.Generic;
+using System.Text.Json;
 using com.IvanMurzak.Unity.MCP.Editor.UI;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
 using com.IvanMurzak.Unity.MCP.Utils;
+using Microsoft.Extensions.Logging;
 using UnityEditor;
 using UnityEngine;
+using static com.IvanMurzak.McpPlugin.Common.Consts.MCP.Server;
 using AiAgentConfiguratorRegistry = com.IvanMurzak.McpPlugin.AgentConfig.AiAgentConfiguratorRegistry;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
@@ -26,8 +31,14 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         static Startup()
         {
+            if (MppmUtils.IsMppmClone)
+                ConfigureMppmClone();
+
             UnityMcpPluginEditor.Instance.BuildMcpPluginIfNeeded();
             UnityMcpPluginEditor.Instance.AddUnityLogCollectorIfNeeded(() => new BufferedFileLogStorage());
+
+            if (MppmUtils.IsMppmClone)
+                DisableWriteToolsForClone();
 
             if (Application.dataPath.Contains(" "))
                 Debug.LogError("The project path contains spaces, which may cause issues during usage of AI Game Developer. Please consider the move the project to a folder without spaces.");
@@ -39,18 +50,100 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             UpdateChecker.Init();
             PackageUtils.Init();
 
-            // Auto-generate skill files for the selected agent if enabled
-            var savedAgentId = MainWindowEditor.selectedAiAgentId.Value;
-            var agent = AiAgentConfiguratorRegistry.GetByAgentId(savedAgentId);
-            if (agent?.SupportsSkills == true && UnityMcpPluginEditor.IsAutoGenerateSkills(agent.AgentId))
+            if (!MppmUtils.IsMppmClone)
             {
-                UnityMcpPluginEditor.SkillsPath = agent.SkillsPath!;
-                UnityMcpPluginEditor.Instance.McpPluginInstance!.GenerateSkillFiles(UnityMcpPluginEditor.ProjectRootPath);
+                // Auto-generate skill files for the selected agent if enabled
+                var savedAgentId = MainWindowEditor.selectedAiAgentId.Value;
+                var agent = AiAgentConfiguratorRegistry.GetByAgentId(savedAgentId);
+                if (agent?.SupportsSkills == true && UnityMcpPluginEditor.IsAutoGenerateSkills(agent.AgentId))
+                {
+                    UnityMcpPluginEditor.SkillsPath = agent.SkillsPath!;
+                    UnityMcpPluginEditor.Instance.McpPluginInstance!.GenerateSkillFiles(UnityMcpPluginEditor.ProjectRootPath);
+                }
             }
 
             // DEV-ONLY: start the 127.0.0.1 inject/control bridge, gated on UNITY_MCP_DEV_CONTROL=1
             // (process env > project-root .env > default). No-op / never listens in a shipped plugin.
             StartDevControlIfEnabled();
+        }
+
+        /// <summary>
+        /// MPPM (Multiplayer Play Mode) virtual-player clones never run their own MCP server —
+        /// they connect as hub clients to the MAIN editor's server. The clone lives at
+        /// <c>&lt;project&gt;/Library/VP/&lt;cloneId&gt;/</c>, so the main project root is four levels up
+        /// from the clone's <c>Application.dataPath</c>. Read the main project's saved config to get
+        /// the host/port the main editor's server is actually listening on (falling back to the
+        /// deterministic port derived from the main project directory) and force the clone into
+        /// connect-only mode.
+        /// </summary>
+        static void ConfigureMppmClone()
+        {
+            UnityMcpPluginEditor.KeepConnected = true;
+            UnityMcpPluginEditor.KeepServerRunning = false;
+
+            var mainProjectDir = System.IO.Path.GetFullPath(
+                System.IO.Path.Combine(Application.dataPath, "..", "..", "..", ".."));
+            var mainConfigPath = System.IO.Path.Combine(
+                mainProjectDir, "UserSettings", "AI-Game-Developer-Config.json");
+
+            var mainHost = $"http://localhost:{UnityMcpPlugin.GeneratePortFromDirectory(mainProjectDir)}";
+            string? mainToken = null;
+            if (System.IO.File.Exists(mainConfigPath))
+            {
+                try
+                {
+                    var json = System.IO.File.ReadAllText(mainConfigPath);
+                    using var doc = JsonDocument.Parse(json);
+                    if (doc.RootElement.TryGetProperty("host", out var hostProp))
+                    {
+                        var h = hostProp.GetString();
+                        if (!string.IsNullOrEmpty(h))
+                            mainHost = h;
+                    }
+                    if (doc.RootElement.TryGetProperty("token", out var tokenProp))
+                        mainToken = tokenProp.GetString();
+                }
+                catch (System.Exception ex)
+                {
+                    _logger.LogWarning("Failed to read main project config at {path}: {error}", mainConfigPath, ex.Message);
+                }
+            }
+
+            // Custom mode so Host resolves to the local URL below (Cloud mode would redirect the
+            // clone to the cloud endpoint instead of the main editor's local server).
+            UnityMcpPluginEditor.ConnectionMode = ConnectionMode.Custom;
+            UnityMcpPluginEditor.Host = mainHost;
+            UnityMcpPluginEditor.LocalHost = mainHost;
+            if (mainToken != null)
+                UnityMcpPluginEditor.Token = mainToken;
+            UnityMcpPluginEditor.AuthOption = AuthOption.none;
+        }
+
+        /// <summary>
+        /// MPPM clones share the main project's Assets/ (read-only) — mutating tools would either
+        /// fail or corrupt shared state, so they are disabled on the clone's hub connection.
+        /// </summary>
+        static void DisableWriteToolsForClone()
+        {
+            var tools = UnityMcpPluginEditor.Instance.Tools;
+            if (tools == null) return;
+
+            var writeTools = new HashSet<string>
+            {
+                "script-update-or-create", "script-delete", "script-execute",
+                "assets-create-folder", "assets-delete", "assets-move", "assets-copy", "assets-modify",
+                "assets-prefab-create", "assets-prefab-save", "assets-prefab-close", "assets-prefab-open",
+                "assets-prefab-instantiate", "assets-material-create", "assets-refresh",
+                "scene-create", "scene-save",
+                "package-add", "package-remove",
+                "gameobject-create", "gameobject-destroy", "gameobject-duplicate",
+                "gameobject-modify", "gameobject-set-parent",
+                "gameobject-component-add", "gameobject-component-destroy", "gameobject-component-modify",
+                "object-modify",
+            };
+
+            foreach (var toolName in writeTools)
+                tools.SetToolEnabled(toolName, false);
         }
     }
 }

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Utils/UpdateChecker.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using com.IvanMurzak.Unity.MCP.Editor.UI;
 using Microsoft.Extensions.Logging;
 using UnityEditor;
+using UnityEditor.PackageManager;
 using UnityEngine;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
@@ -184,6 +185,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
         /// </remarks>
         public static bool ShouldCheckForUpdates()
         {
+            if (!ShouldCheckForUpdatesForCurrentPackageSource())
+                return false;
+
             // 1. Team-wide kill-switch — short-circuits before any per-user state is consulted.
             if (IsDisabledForProject)
                 return false;
@@ -204,6 +208,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Utils
             }
 
             return true;
+        }
+
+        internal static bool ShouldCheckForUpdatesForPackageSource(PackageSource source)
+        {
+            return source == PackageSource.Registry;
+        }
+
+        private static bool ShouldCheckForUpdatesForCurrentPackageSource()
+        {
+            var packageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(UpdateChecker).Assembly);
+            return packageInfo == null || ShouldCheckForUpdatesForPackageSource(packageInfo.source);
         }
 
         /// <summary>

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/MppmUtils.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/MppmUtils.cs
@@ -1,0 +1,73 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Text.RegularExpressions;
+
+namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
+{
+    public static class MppmUtils
+    {
+        static readonly bool _isMppmClone;
+        static readonly string? _cloneName;
+        static readonly string? _cloneId;
+        static readonly string _cloneSuffix;
+
+        public static bool IsMppmClone => _isMppmClone;
+        public static string? CloneName => _cloneName;
+        public static string? CloneId => _cloneId;
+        public static string CloneSuffix => _cloneSuffix;
+
+        static MppmUtils()
+        {
+            var args = Environment.GetCommandLineArgs();
+            _isMppmClone = false;
+            _cloneName = null;
+            _cloneId = null;
+            _cloneSuffix = string.Empty;
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                var arg = args[i];
+
+                if (arg == "-editor-mode" && i + 1 < args.Length && args[i + 1] == "com.unity.mppm.clone")
+                {
+                    _isMppmClone = true;
+                    i++;
+                }
+                else if (arg == "-name" && i + 1 < args.Length)
+                {
+                    _cloneName = args[i + 1];
+                    i++;
+                }
+                else if (arg.StartsWith("-vpId=", StringComparison.Ordinal))
+                {
+                    _cloneId = arg.Substring("-vpId=".Length);
+                }
+                else if (arg == "-vpId" && i + 1 < args.Length)
+                {
+                    _cloneId = args[i + 1];
+                    i++;
+                }
+            }
+
+            if (_cloneName != null)
+                _cloneSuffix = ToKebabCase(_cloneName);
+        }
+
+        static string ToKebabCase(string name)
+        {
+            var lower = name.Trim().ToLowerInvariant();
+            var kebab = Regex.Replace(lower, @"[^a-z0-9]+", "-").Trim('-');
+            return string.IsNullOrEmpty(kebab) ? string.Empty : $"-{kebab}";
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/MppmUtils.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/MppmUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95cb2aa3eab84f17aed89841ad4a6a99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Utils/UpdateCheckerTests.cs
@@ -12,6 +12,7 @@
 using System.IO;
 using NUnit.Framework;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
+using UnityEditor.PackageManager;
 
 namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 {
@@ -158,6 +159,34 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             Assert.Greater(UpdateChecker.CompareVersions("1.0.0.1", "1.0.0"), 0);
             Assert.Less(UpdateChecker.CompareVersions("1.0.0", "1.0.0.1"), 0);
+        }
+
+        #endregion
+
+        #region Package Source Tests
+
+        [Test]
+        public void ShouldCheckForUpdatesForPackageSource_Registry_ReturnsTrue()
+        {
+            Assert.IsTrue(UpdateChecker.ShouldCheckForUpdatesForPackageSource(PackageSource.Registry));
+        }
+
+        [Test]
+        public void ShouldCheckForUpdatesForPackageSource_Local_ReturnsFalse()
+        {
+            Assert.IsFalse(UpdateChecker.ShouldCheckForUpdatesForPackageSource(PackageSource.Local));
+        }
+
+        [Test]
+        public void ShouldCheckForUpdatesForPackageSource_Git_ReturnsFalse()
+        {
+            Assert.IsFalse(UpdateChecker.ShouldCheckForUpdatesForPackageSource(PackageSource.Git));
+        }
+
+        [Test]
+        public void ShouldCheckForUpdatesForPackageSource_Embedded_ReturnsFalse()
+        {
+            Assert.IsFalse(UpdateChecker.ShouldCheckForUpdatesForPackageSource(PackageSource.Embedded));
         }
 
         #endregion


### PR DESCRIPTION
## What

Adds Unity Multiplayer Play Mode (MPPM) support: virtual-player clone editors are detected at startup and run as **read-only hub clients of the main editor's MCP server**, instead of fighting the main editor over server lifecycle, ports, and binaries.

- **`MppmUtils` (Runtime/Utils)** — clone detection via command-line args (`-editor-mode com.unity.mppm.clone`, `-name`, `-vpId`). No Unity API dependencies.
- **Startup** — on a clone: force `KeepConnected=true`, `KeepServerRunning=false`, `ConnectionMode=Custom`; resolve the main editor's host/port (and local token) by reading the main project's `UserSettings/AI-Game-Developer-Config.json` (clone lives at `<project>/Library/VP/<cloneId>/`), falling back to the deterministic port derived from the main project directory; disable write/mutating MCP tools (clones share the project's assets); skip skill-file auto-generation.
- **McpServerManager** — clones never download a duplicate server binary into their cloned `Library/`; `McpServerName` carries the clone identity (e.g. `Unity MyGame (Player 2)`) so hub connections stay distinguishable.
- **UpdateChecker** — skip update checks when the package source is not `Registry` (local/embedded/git dev installs), with EditMode tests.

## Why clones don't get their own server

An earlier iteration of this branch registered a separate MCP server per clone on per-clone deterministic ports. That fell apart in practice (no server listening on the clone port, auth failures, duplicate server registration), so the design pivoted: one server (the main editor's), clones connect as additional hub clients, mutating tools disabled clone-side. This PR is the rebased, squashed result of that final design onto current `main` — the per-clone config registration was intentionally dropped, which also sidesteps the removed Unity-local configurator files (superseded by the shared `com.IvanMurzak.McpPlugin.AgentConfig` module in #834).

Per-directory PID keys and `GeneratePortFromDirectory(string)` from the original branch were dropped too — current `main` already provides both (`ProcessIdKeyForDirectory`, `ProjectIdentity.DerivePortV2`).

## Notes / limitations

- The write-tool blocklist in `Startup.DisableWriteToolsForClone()` is name-based; new mutating tools need to be added there.
- If the main editor runs in Cloud mode, its saved local `host` may be stale; clones fall back to the derived deterministic port. The MPPM flow presumes the main editor runs the local server (default outside CI).
- Developed and manually tested against a Unity 6 project with MPPM clones controlling separate AI clients; EditMode tests cover the new `UpdateChecker` package-source gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)