### PR TITLE
chore: bump gamedev-mcp-server to 9.2.4

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -145,7 +145,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor
         /// <c>v&lt;ServerVersion&gt;</c> release with all 7 RID zips exists on GameDev-MCP-Server
         /// BEFORE cutting a plugin release that pins it — otherwise the download 404s).
         /// </summary>
-        public const string ServerVersion = "9.2.3";
+        public const string ServerVersion = "9.2.4";
 
         public const string ExecutableName = "gamedev-mcp-server";
 

--- a/cli/src/utils/server-version.ts
+++ b/cli/src/utils/server-version.ts
@@ -15,7 +15,7 @@
  * package ships no plugin sources — the plugin release cadence bumps both in the same PR, and the
  * drift-guard test fails CI if a bump touches only one side.
  */
-export const DEFAULT_SERVER_VERSION = '9.2.3';
+export const DEFAULT_SERVER_VERSION = '9.2.4';
 
 /** GitHub `owner/repo` that hosts the shared server's tagged releases + per-RID zips. */
 export const SERVER_RELEASE_REPO = 'IvanMurzak/GameDev-MCP-Server';


### PR DESCRIPTION
Automated downstream bump of the pinned GameDev-MCP-Server version `9.2.3` -> `9.2.4` (adopts the just-released `v9.2.4` server: NuGet + Docker tag + all 7 RID zips are already live).