### PR TITLE
ci(release): budget the ellipsis line in the Discord truncation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -512,7 +512,13 @@ jobs:
           if [ ${#full_message} -gt 2000 ]; then
             # Remove lines from the end until it fits, keeping the link
             link_text=$'\n\n'"📦 **[View Full Release](${release_url})**"
-            max_length=$((2000 - ${#link_text}))
+            # The truncated message is reassembled below as `<notes>` + `\n...` + `<link>`,
+            # so the ellipsis line costs 4 more characters on top of the link. Budget for
+            # BOTH, otherwise the assembled message reaches 2004 chars and Discord rejects
+            # the whole announcement with a 400 — silently, since the step does not gate on
+            # the response. Godot-MCP and Unreal-MCP carry the identical budget.
+            ellipsis_text=$'\n'"..."
+            max_length=$((2000 - ${#link_text} - ${#ellipsis_text}))
 
             # Split into lines and rebuild until we exceed the limit
             truncated_notes=""


### PR DESCRIPTION
## The defect

The truncation branch of the Discord announcement budgets `2000 - len(link_text)`, but then
reassembles the message as `<notes>` + `\n...` + `<link>`. The ellipsis line's 4 characters are
never accounted for, so the assembled message can exceed Discord's 2000-character limit.

Discord rejects an over-length message with a **400**, and the step does not gate on the response —
so the failure is silent and the release simply gets no announcement.

## Why it has never fired

Reaching the limit needs **alignment, not merely length**. The truncation loop keeps the last line
that fits, so the assembled text only exceeds 2000 when it happens to land within 4 characters of
the budget. Ordinary release notes stop well short of it.

For reference, `0.86.3`'s announcement assembled to 1819 characters — under the limit, and it would
have been under it with the old budget too.

## Verification

Simulated the exact loop from this file:

| line packing | old budget | new budget |
|---|---|---|
| ~28-char lines | 1998 | 1998 |
| 1-char lines (worst case) | **2003** — rejected | 1999 |

Theoretical bound of the old formula is 2004; 2003 is what 1-char packing reaches, because the loop
appends two characters at a time.

## Consistency

Godot-MCP and Unreal-MCP already carry this exact budget. This brings Unity-MCP in line with them,
so all three assemble a provably-<=2000 message. No visible change to the announcement's formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)