### PR TITLE
ci(release): gate the Discord announcement on the HTTP response

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -541,12 +541,59 @@ jobs:
             --arg content "$full_message" \
             '{content: $content, flags: 4}')
 
-          # Send to Discord webhook
-          curl -X POST "$DISCORD_WEBHOOK" \
+          # Send to the Discord webhook and GATE ON THE RESPONSE.
+          #
+          # curl exits 0 on an HTTP error status, so a bare `curl -X POST` proves only
+          # that a request was attempted -- never that Discord accepted it. Capture the
+          # status explicitly: 400 (payload over the 2000-char limit), 429 (rate
+          # limited) and 401/404 (revoked or wrong webhook) all used to leave this job
+          # green with no announcement posted and nothing in the log to say so. That
+          # blind spot is how the truncation-budget bug fixed above went unnoticed.
+          #
+          # `--retry 3` covers only what a retry can fix -- curl's transient set (429,
+          # 5xx and timeouts), honouring Discord's `Retry-After` header -- and
+          # `--retry-max-time` bounds it. A 4xx other than 429 is a permanent rejection
+          # and is never retried, and neither is a refused connection (that would need
+          # `--retry-connrefused`); both fail fast and loudly below. Accepted tradeoff:
+          # a webhook execute has no idempotency key, so a retry whose predecessor was
+          # actually processed (response lost in flight) can post the announcement
+          # twice. A duplicate announcement is strictly better than a missing one.
+          #
+          # The webhook URL is a credential: it is never echoed and `-v` is never
+          # passed (curl's own `-S` error text names at most the host). The response
+          # body IS printed -- it is Discord's JSON error object, the single most
+          # useful thing for whoever debugs the next failure.
+          response_file="$(mktemp)"
+          curl_exit=0
+          http_code=$(curl -sS -X POST "$DISCORD_WEBHOOK" \
             -H "Content-Type: application/json" \
-            -d "$json_payload"
+            -d "$json_payload" \
+            --retry 3 \
+            --retry-max-time 60 \
+            -o "$response_file" \
+            -w '%{http_code}') || curl_exit=$?
 
-          echo "Release notes sent to Discord for version $version"
+          # Safe to fail here: nothing downstream depends on this job and the release is
+          # already published, so a red step cannot block or undo it. It DOES redden the
+          # workflow run conclusion (and the release badge) -- that is the intended
+          # visibility, and the message below states exactly what did and did not ship.
+          if [ "$curl_exit" -ne 0 ]; then
+            echo "::error::Discord announcement for version ${version} was NOT delivered (curl exit ${curl_exit}). The release itself is published; only the announcement is missing."
+            exit 1
+          fi
+
+          case "$http_code" in
+            2??)
+              echo "Release notes accepted by Discord for version ${version} (HTTP ${http_code})."
+              ;;
+            *)
+              echo "::error::Discord REJECTED the release notes for version ${version} (HTTP ${http_code}). The release itself is published; only the announcement is missing."
+              echo "Discord response body:"
+              head -c 2000 "$response_file"
+              echo ""
+              exit 1
+              ;;
+          esac
 
   deploy:
     needs: release-unity-plugin


### PR DESCRIPTION
## The defect

The `publish_discord` step POSTed the release notes with `curl` and then printed

```
Release notes sent to Discord for version <v>
```

**unconditionally**. `curl` exits 0 for an HTTP *error* status, so the step never learned whether Discord
accepted the message. Any rejection — 400 (message over Discord's 2000-char limit), 429 (rate limited),
401/404 (revoked or wrong webhook) — left the job green with no announcement posted and nothing in the log
to say so.

This is not hypothetical. Reproduced against a stubbed endpoint using the **pre-fix** script extracted
verbatim from this file:

```
bad-400  exit=0  ->  {"message": "Invalid Form Body", "code": 50035, ...}Release notes sent to Discord for version 9.9.9
bad-404  exit=0  ->  {"message": "Unknown Webhook", "code": 10015}Release notes sent to Discord for version 9.9.9
bad-429  exit=0  ->  {"message": "You are being rate limited.", ...}Release notes sent to Discord for version 9.9.9
```

Discord's error object was already being dumped into the log — immediately followed by the success line,
with exit 0. Notably, the 4-character truncation-budget bug fixed just above this block survived for months
precisely because a rejected POST is invisible here.

## The change

- Capture the status with `-o <file> -w '%{http_code}'` and treat **only 2xx as success**.
- On non-2xx: `::error::` naming the status, print Discord's response body (its JSON error object explains
  the rejection — the single most useful thing for whoever debugs this next), `exit 1`.
- On success: print the status alongside the message (`accepted by Discord ... (HTTP 204)`) so a reader can
  tell "sent" from "accepted".
- A transport-level failure (no HTTP status at all) is diagnosed separately with curl's exit code.
- `--retry 3 --retry-max-time 60` gives a **bounded** retry for the statuses curl treats as transient
  (429 — honouring Discord's `Retry-After` header — 5xx and timeouts). A 4xx other than 429 is a permanent
  rejection and is never retried. The final failure is loud.
- `-sS` also removes the curl progress meter that used to be dumped into the release log.
- The webhook URL is a credential: it is never echoed, `-v` is never passed, and every test asserts the
  token does not appear in the output.

## Fail the step, or let the release stay green?

**Fail the step.** Reasoning:

- `publish_discord` is a leaf job — nothing `needs:` it, and it runs after the release is published.
  Failing it therefore cannot block, cancel, or undo any release work. The artifacts are already out.
- The realistic alternative is `::warning::` + green. That is the exact shape this change exists to
  eliminate: a warning does not change the run's conclusion badge and is trivially missed. "I could not
  verify" must not render as "verified".
- A red job turns the run conclusion red, which is visible in the Actions list, on the commit status and in
  run notifications — the outcome is visible without being able to break anything.
- The error text states the blast radius explicitly ("The release itself is published; only the
  announcement is missing"), so whoever sees the red knows immediately that the release shipped and that the
  remedy is to re-post the announcement.

This is also what this job was designed to do — the job's own comment already says a webhook hiccup should
"surface as a red job for visibility". Until now it could not, because the step never looked at the response.

### The consequence to be aware of

A red leaf job still turns the **workflow run conclusion** red, even though every release job succeeded.
Two things key off that, and neither is a job dependency:

1. The `release.yml` status badge in the README will show failing on a release that actually shipped.
2. The release orchestration that drives these repos gates on the run conclusion for Unity-MCP and
   Unreal-MCP (Godot-MCP's gate is job-granular and checks `release-addon`/`deploy` by name, so it is
   unaffected). For those two, a rejected announcement will halt the orchestration *after* the artifacts
   are published, until an operator resumes it.

That is a real cost, and it is the intended one: the alternative is a release that silently has no
announcement. The durable fix for the noise is to make those two gates job-granular the way Godot-MCP's
already is — treating `publish_discord` as advisory, recorded but never gated on. That lives outside these
three workflow files and is filed as follow-up rather than smuggled into this PR.

## Verification

Both halves were exercised. The step script is extracted **verbatim from this workflow file** by a
PyYAML-based harness (no hand-copied shell, so the harness cannot drift from what ships) and run under
`bash -e` — the way GitHub Actions invokes a `run:` block — against a local stub returning Discord-shaped
responses. The live webhook was never contacted.

| case | stub | expected | result |
| --- | --- | --- | --- |
| good-204 | 204 | exit 0, "accepted ... (HTTP 204)" | PASS, 1 request |
| good-204, long notes (truncation branch) | 204 | exit 0 | PASS, 1 request, payload 2000 chars |
| bad-400 | 400 | exit 1, status + body printed | PASS, 1 request (no retry) |
| bad-404 | 404 | exit 1, status + body printed | PASS, 1 request (no retry) |
| bad-429, exhausted | 429 x5 | exit 1, status + body printed | PASS, 4 requests then loud failure |
| 429 then 204 | 429, 204 | exit 0 | PASS, 2 requests (retry recovers) |
| 500 then 204 | 500, 204 | exit 0 | PASS, 2 requests (retry recovers) |
| no listener | — | exit 1, curl exit diagnosed | PASS, `curl exit 7` reported |

Every case additionally asserts that the webhook token never appears in the output, that the payload is
valid `{content, flags: 4}` JSON, and that `content` is <= 2000 characters.

Anti-vacuity: the same harness run against the **pre-fix** script fails every "bad" case (exit 0 where 1 is
required), so it genuinely distinguishes fixed from broken rather than passing everything.

Static checks: the workflow parses (PyYAML), `bash -n` is clean on the extracted script, and `shellcheck
--shell=bash --severity=warning` reports nothing. The only shellcheck output at `info` level is a
pre-existing SC2153 on `$RELEASE_NOTES`/`$VERSION`, which are supplied by the step's `env:`.

**Not verified until a real release runs:** the happy path against the real Discord API (deliberately not
POSTed to the live webhook) and the real endpoint's exact `Retry-After` behaviour. The stub returns
Discord's documented status codes and body shapes; the harness ran on Git Bash/Windows rather than
`ubuntu-latest`.
