### PR TITLE
d2: unity-mcp-cli adopts cli-core MachineCredentialProvider + --tools-only

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -246,7 +246,7 @@ unity-mcp-cli install-unity --path ./MyGame
 
 ## `login`
 
-Sign in to **ai-game.dev** and store the credential in the shared machine credential store (`~/.ai-game-dev/credentials.json`). Runs the browser-based **OAuth 2.1 device flow** — there is no personal access token to create or paste. The stored credential is the single source of truth for cloud authentication (consumed by `open`, `run-tool`, and the Unity Editor plugin).
+Sign in to **ai-game.dev** and store the credential in the shared machine credential store (`~/.ai-game-dev/credentials.json`). Runs the browser-based **OAuth 2.1 device flow** — there is no personal access token to create or paste. The sign-in authorizes the whole machine: it mints an **agent** credential and derives an engine-tools credential from it, and every consumer (the CLI's cloud commands, the Unity Editor plugin, the desktop app) refreshes it automatically — tokens rotate in the background, so you sign in once per machine, not once per session.
 
 ```bash
 unity-mcp-cli login
@@ -256,13 +256,21 @@ unity-mcp-cli login
 |---|---|---|
 | `--project <path>` | No | Store the credential in a project-local store (`<path>/.ai-game-dev/`) instead of the shared machine store |
 | `--force` | No | Re-authenticate even if a credential already exists |
+| `--tools-only` | No | Authorize **engine tools only** (no agent credential is stored, so desktop-app pickup is impossible). Intended for CI / automation runners, which then appear as their own revocable device group |
+| `--yes` | No | Assume "yes" for prompts — required to confirm an **account switch** non-interactively (signing in as a different account than the machine currently holds) |
 
-The command prints a short user code and a verification URL, opens your browser, and polls until you approve the sign-in. If a credential already exists it exits early with *"Already signed in"* — pass `--force` to replace it.
+The command prints a short user code and a verification URL, opens your browser, and polls until you approve the sign-in. If a credential already exists it exits early with *"Already signed in"* — pass `--force` to replace it. Signing in as a **different account** than the one the machine holds asks for confirmation first (declining leaves everything unchanged); pass `--yes` to confirm in scripts.
 
 **Example — sign in (shared machine store):**
 
 ```bash
 unity-mcp-cli login
+```
+
+**Example — CI runner, engine tools only:**
+
+```bash
+unity-mcp-cli login --tools-only
 ```
 
 **Example — store the credential next to a specific project:**

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.87.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@baizor/gamedev-cli-core": "^0.1.0",
+        "@baizor/gamedev-cli-core": "^0.4.0",
         "chalk": "^5.6.2",
         "commander": "^13.1.0",
         "yocto-spinner": "^1.1.0"
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@baizor/gamedev-cli-core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@baizor/gamedev-cli-core/-/gamedev-cli-core-0.1.0.tgz",
-      "integrity": "sha512-LFpO0WAXuMs+BtQpLn6mqK8JoiL7udYptrvFhv40aLk/AOz7yhCs2pPXwMdd29XH1siv3rPPc7fv+gNVqCNN1A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@baizor/gamedev-cli-core/-/gamedev-cli-core-0.4.0.tgz",
+      "integrity": "sha512-vIsgw/hu3gSo1yyRmD/2SLhJvMSp29+Od0gdYe8muCSZmM5GuJra1YVg9j62n1EwMevSuMJWGD32LVVOLnE87A==",
       "license": "MIT",
       "engines": {
         "node": ">=22.14.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -62,7 +62,7 @@
     "node": "^20.19.0 || >=22.12.0"
   },
   "dependencies": {
-    "@baizor/gamedev-cli-core": "^0.1.0",
+    "@baizor/gamedev-cli-core": "^0.4.0",
     "chalk": "^5.6.2",
     "commander": "^13.1.0",
     "yocto-spinner": "^1.1.0"

--- a/cli/src/commands/install-plugin.ts
+++ b/cli/src/commands/install-plugin.ts
@@ -17,6 +17,7 @@ interface InstallPluginOptions {
   serverSource?: string;
   enroll?: string;
   enrollStdin?: boolean;
+  yes?: boolean;
 }
 
 export const installPluginCommand = new Command('install-plugin')
@@ -29,6 +30,7 @@ export const installPluginCommand = new Command('install-plugin')
   .option('--server-source <path-or-url>', 'Offline/CI override: install the server from a local zip path or URL (skips SHA256SUMS verification)')
   .option('--enroll <code>', 'Redeem an enrollment code for a plugin credential (planted in the shared machine store)')
   .option('--enroll-stdin', 'Read the enrollment code from stdin (never argv/shell history)')
+  .option('--yes', 'Assume "yes" for prompts (e.g. confirming an account switch during --enroll)')
   .action(async (positionalPath: string | undefined, options: InstallPluginOptions) => {
     // T5/B1: path is OPTIONAL — resolve `path? → --path? → cwd`, then verify the directory is a real
     // Unity project (marker probe for `Packages/manifest.json`). On a miss the error lists exactly
@@ -137,7 +139,29 @@ export const installPluginCommand = new Command('install-plugin')
           projectPath,
           adapter: unityAdapter,
           store: new MachineCredentialStore(),
+          // D6/F7 account-switch guard (`--yes`-gated): enroll is a non-interactive surface, so
+          // without --yes a subject mismatch is DECLINED (the just-redeemed family is revoked
+          // best-effort by cli-core; the store stays untouched).
+          confirmAccountSwitch: async (info) => {
+            if (options.yes) return true;
+            ui.warn(
+              `This machine is signed in as "${info.storedSubject}"; the enrollment code belongs to "${info.newSubject}".`,
+            );
+            return false;
+          },
         });
+        if (enrolled.status === 'switch-declined') {
+          enrollSpinner.error('Enrollment aborted');
+          ui.error(
+            'Account switch declined — nothing was changed. Re-run with --yes to switch this machine to the new account.',
+          );
+          process.exit(1);
+        }
+        if (enrolled.status === 'aborted') {
+          enrollSpinner.error('Enrollment aborted');
+          ui.error('The credential store changed while enrolling. Re-run the command.');
+          process.exit(1);
+        }
         enrollSpinner.success('Enrollment complete');
         ui.label('Credential', enrolled.credentialPath);
         ui.label('Server target', enrolled.serverTarget);

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -6,12 +6,16 @@ import * as path from 'path';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
 import { CLOUD_SERVER_BASE_URL } from '../utils/config.js';
-import { runCloudLogin } from '../utils/cloud-login.js';
+import { runCloudLogin, completePluginDerivation } from '../utils/cloud-login.js';
+import { createCloudCredentialProvider } from '../utils/cloud-credentials.js';
 import { MachineCredentialStore, MACHINE_STORE_DIR_NAME } from '../utils/machine-credentials.js';
+import { effectiveFamilies, LoginRequiredError } from '@baizor/gamedev-cli-core';
 
 interface LoginOptions {
   project?: string;
   force?: boolean;
+  toolsOnly?: boolean;
+  yes?: boolean;
 }
 
 /**
@@ -26,6 +30,30 @@ function resolveStore(options: LoginOptions): MachineCredentialStore {
   return new MachineCredentialStore();
 }
 
+/**
+ * Finish an interrupted F1 login (agent family committed, plugin derivation missing): mint a
+ * fresh agent access token through the credential provider and retry the derivation leg alone.
+ */
+async function finishPartialAuthorization(store: MachineCredentialStore): Promise<never> {
+  ui.info('Finishing a previously interrupted sign-in (deriving the tools credential)...');
+  const provider = createCloudCredentialProvider({ store });
+  let agentAccessToken: string;
+  try {
+    agentAccessToken = await provider.getAccessToken({ family: 'agent' });
+  } catch (err) {
+    if (err instanceof LoginRequiredError) {
+      ui.error('The stored sign-in is no longer valid. Re-run with --force to sign in again.');
+    } else {
+      ui.error(
+        `Could not refresh the stored sign-in: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    process.exit(1);
+  }
+  const ok = await completePluginDerivation(store, agentAccessToken);
+  process.exit(ok ? 0 : 1);
+}
+
 export const loginCommand = new Command('login')
   .description(
     'Sign in to ai-game.dev and store the credential in the shared machine credential store (~/.ai-game-dev/credentials.json)',
@@ -35,11 +63,30 @@ export const loginCommand = new Command('login')
     'Store the credential in a project-local store (<path>/.ai-game-dev/) instead of the shared machine store',
   )
   .option('--force', 'Re-authenticate even if already signed in')
+  .option(
+    '--tools-only',
+    'Authorize engine tools only (mcp:plugin scope): no agent credential is stored, so desktop-app pickup is impossible — intended for CI / automation runners',
+  )
+  .option('--yes', 'Assume "yes" for prompts (e.g. confirming an account switch)')
   .action(async (options: LoginOptions) => {
     const store = resolveStore(options);
     verbose(`Credential store: ${store.credentialsPath}`);
 
     if (store.exists && !options.force) {
+      // The sign-in gate consults ONLY the credential store (never a project config). When the
+      // store is readable, also detect the F1 `partial` state — an agent family committed with
+      // no plugin-plane family — and finish the derivation leg alone instead of short-circuiting.
+      const state = store.readState();
+      if (state.status === 'ok') {
+        const families = effectiveFamilies(state.credentials);
+        const hasPluginPlane = !!(
+          families.plugin?.accessToken ?? families.legacy?.accessToken
+        );
+        const hasAgent = !!families.agent?.accessToken;
+        if (hasAgent && !hasPluginPlane && !options.toolsOnly) {
+          await finishPartialAuthorization(store);
+        }
+      }
       ui.success('Already signed in.');
       ui.info(`Credential: ${store.credentialsPath}`);
       ui.info('Use --force to re-authenticate.');
@@ -48,9 +95,15 @@ export const loginCommand = new Command('login')
 
     ui.heading('Sign in to ai-game.dev');
     ui.label('Server', CLOUD_SERVER_BASE_URL);
+    if (options.toolsOnly) {
+      ui.label('Mode', 'tools-only (mcp:plugin)');
+    }
     ui.divider();
 
-    const token = await runCloudLogin(store);
+    const token = await runCloudLogin(store, {
+      toolsOnly: options.toolsOnly ?? false,
+      assumeYes: options.yes ?? false,
+    });
     if (token) {
       ui.success(`Signed in. Credential saved to ${store.credentialsPath}`);
     } else {

--- a/cli/src/commands/run-tool-builder.ts
+++ b/cli/src/commands/run-tool-builder.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import * as ui from '../utils/ui.js';
 import { verbose } from '../utils/ui.js';
 import { resolveAndValidateProjectPath, resolveConnection } from '../utils/connection.js';
+import { refreshCloudAccessToken } from '../utils/cloud-credentials.js';
 import { parseInput } from '../utils/input.js';
 import type { RunToolFailure, RunToolOptions, RunToolResult } from '../lib/types.js';
 
@@ -69,7 +70,8 @@ export function buildRunToolCommand(cfg: BuilderOptions): Command {
       // Resolve path + connection up front so the heading and verbose
       // output reflect the final endpoint before the HTTP call fires.
       const projectPath = resolveAndValidateProjectPath(positionalPath, options);
-      const { url: baseUrl, token, cloudAuthMissing } = resolveConnection(projectPath, options);
+      const { url: baseUrl, token, cloudAuthMissing, tokenFromCloudStore } =
+        await resolveConnection(projectPath, options);
       if (cloudAuthMissing) {
         ui.error(
           'Not logged in to ai-game.dev. Run `unity-mcp-cli login` to sign in, then retry — or pass --token / --url to target a specific server.',
@@ -97,13 +99,33 @@ export function buildRunToolCommand(cfg: BuilderOptions): Command {
 
       // The CLI already resolved url/token, so passing them explicitly
       // makes the lib's resolver a no-op rather than re-reading config.
-      const result = await cfg.invoke({
-        toolName,
-        url: baseUrl,
-        ...(token ? { token } : {}),
-        input: body,
-        timeoutMs,
-      });
+      const invokeOnce = (bearer: string | undefined): ReturnType<typeof cfg.invoke> =>
+        cfg.invoke({
+          toolName,
+          url: baseUrl,
+          ...(bearer ? { token: bearer } : {}),
+          input: body,
+          timeoutMs,
+        });
+
+      let result = await invokeOnce(token);
+
+      // Reactive refresh (unified-machine-auth 04 §3 rule 1): a 401 against a machine-store
+      // Bearer means revocation or clock skew the proactive check could not see — refresh the
+      // plugin family once under the cross-process lock and retry. Explicit --token/--url
+      // overrides are never refreshed.
+      if (
+        result.kind === 'failure' &&
+        result.reason === 'http-error' &&
+        result.httpStatus === 401 &&
+        tokenFromCloudStore
+      ) {
+        const fresh = await refreshCloudAccessToken();
+        if (fresh) {
+          verbose('Server answered 401; retrying once with a refreshed cloud credential.');
+          result = await invokeOnce(fresh);
+        }
+      }
 
       if (result.kind === 'success') {
         spinner?.success(`${toolName} completed`);

--- a/cli/src/commands/setup-skills.ts
+++ b/cli/src/commands/setup-skills.ts
@@ -96,7 +96,7 @@ export const setupSkillsCommand = new Command('setup-skills')
       verbose(`Skills path: ${skillsPath}`);
 
       // Resolve server connection
-      let { url: serverUrl, token } = resolveConnection(projectPath, options);
+      let { url: serverUrl, token } = await resolveConnection(projectPath, options);
 
       // Call the MCP server to generate skills
       const endpoint = `${serverUrl}/api/system-tools/unity-skill-generate`;

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -22,7 +22,7 @@ export const statusCommand = new Command('status')
   .option('--timeout <ms>', 'Probe timeout in milliseconds (default: 5000)', '5000')
   .action(async (positionalPath: string | undefined, options: StatusOptions) => {
     const projectPath = resolveAndValidateProjectPath(positionalPath, options);
-    const { url: configUrl, token } = resolveConnection(projectPath, options);
+    const { url: configUrl, token } = await resolveConnection(projectPath, options);
     const localPort = generatePortFromDirectory(projectPath);
     const localUrl = `http://localhost:${localPort}`;
 

--- a/cli/src/commands/wait-for-ready.ts
+++ b/cli/src/commands/wait-for-ready.ts
@@ -21,11 +21,11 @@ interface WaitForReadyOptions {
  * Otherwise, probe both the config-resolved URL and the deterministic local port
  * (if they differ), succeeding on whichever responds first.
  */
-function resolveProbeUrls(
+async function resolveProbeUrls(
   projectPath: string,
   options: WaitForReadyOptions,
-): string[] {
-  const { url: configUrl } = resolveConnection(projectPath, options);
+): Promise<string[]> {
+  const { url: configUrl } = await resolveConnection(projectPath, options);
   const urls = [configUrl];
 
   if (!options.url) {
@@ -50,8 +50,8 @@ export const waitForReadyCommand = new Command('wait-for-ready')
   .option('--interval <ms>', 'Polling interval in milliseconds (default: 3000)', '3000')
   .action(async (positionalPath: string | undefined, options: WaitForReadyOptions) => {
     const projectPath = resolveAndValidateProjectPath(positionalPath, options);
-    const { token } = resolveConnection(projectPath, options);
-    const probeUrls = resolveProbeUrls(projectPath, options);
+    const { token } = await resolveConnection(projectPath, options);
+    const probeUrls = await resolveProbeUrls(projectPath, options);
 
     const timeoutMs = parseInt(options.timeout ?? '120000', 10);
     const intervalMs = parseInt(options.interval ?? '3000', 10);

--- a/cli/src/lib/run-tool.ts
+++ b/cli/src/lib/run-tool.ts
@@ -6,6 +6,7 @@
 //   never thrown past the public boundary.
 
 import { readConfig, resolveConnectionFromConfig, isCloudMode } from '../utils/config.js';
+import { readCloudAccessToken, refreshCloudAccessToken } from '../utils/cloud-credentials.js';
 import { generatePortFromDirectory } from '../utils/port.js';
 import { requireProjectPath } from './validation.js';
 import type {
@@ -47,26 +48,12 @@ async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<Ru
   const validationFailure = validateOptions(opts);
   if (validationFailure) return validationFailure;
 
-  const resolved = resolveConnection(opts);
-  if (resolved.kind === 'failure') return resolved;
-  const { url, token } = resolved;
-
-  const body = serializeInput(opts.input);
-  if ('error' in body) {
-    return makeFailure({
-      endpoint: '',
-      reason: 'invalid-input',
-      message: body.error.message,
-      error: body.error,
-    });
-  }
-
-  const endpoint = `${url}${routePrefix}/${encodeURIComponent(opts.toolName)}`;
-
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
   const timeoutMs =
     typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
 
+  // Wire the abort/timeout plumbing BEFORE the first await so an external abort issued right
+  // after the call is never lost (connection resolution below may itself await a token refresh).
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   const externalAbort = (): void => controller.abort();
@@ -75,38 +62,85 @@ async function invokeTool(routePrefix: string, opts: RunToolOptions): Promise<Ru
     else opts.signal.addEventListener('abort', externalAbort, { once: true });
   }
 
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (token) headers['Authorization'] = `Bearer ${token}`;
-
+  let endpoint = '';
   try {
-    const response = await fetchImpl(endpoint, {
-      method: 'POST',
-      headers,
-      body: body.json,
-      signal: controller.signal,
-    });
+    const resolved = await resolveConnection(opts);
+    if (resolved.kind === 'failure') return resolved;
+    const { url, token } = resolved;
 
-    const text = await safeReadText(response);
-    const data = parseJsonOrText(text);
-
-    if (!response.ok) {
+    const body = serializeInput(opts.input);
+    if ('error' in body) {
       return makeFailure({
-        endpoint,
-        reason: 'http-error',
-        httpStatus: response.status,
-        data,
-        message: response.statusText || `HTTP ${response.status}`,
+        endpoint: '',
+        reason: 'invalid-input',
+        message: body.error.message,
+        error: body.error,
       });
     }
 
-    const success: RunToolSuccess = {
-      kind: 'success',
-      success: true,
-      endpoint,
-      httpStatus: response.status,
-      data,
-    };
-    return success;
+    endpoint = `${url}${routePrefix}/${encodeURIComponent(opts.toolName)}`;
+
+    // Reactive-refresh loop (unified-machine-auth 04 §3 rule 1): when the Bearer came from the
+    // shared machine credential store and the server answers 401 — revocation or clock skew the
+    // proactive expiry check could not see — refresh the plugin family once under the
+    // cross-process lock and retry the call with the rotated token. At most ONE reactive attempt
+    // per invocation; an explicit --token / --url override is never refreshed. Both attempts
+    // share one timeout.
+    let bearer = token;
+    let attemptedReactiveRefresh = false;
+
+    for (;;) {
+      // Mirror fetch's contract for an ALREADY-aborted signal (an external abort may land while
+      // connection resolution above is awaiting): reject up front instead of relying on the
+      // 'abort' event, which has already fired.
+      if (controller.signal.aborted) {
+        throw new DOMException('The operation was aborted', 'AbortError');
+      }
+
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
+
+      const response = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers,
+        body: body.json,
+        signal: controller.signal,
+      });
+
+      const text = await safeReadText(response);
+      const data = parseJsonOrText(text);
+
+      if (!response.ok) {
+        if (
+          response.status === 401 &&
+          resolved.tokenFromCloudStore &&
+          !attemptedReactiveRefresh
+        ) {
+          attemptedReactiveRefresh = true;
+          const fresh = await (opts.refreshCloudToken ?? refreshCloudAccessToken)();
+          if (fresh) {
+            bearer = fresh;
+            continue;
+          }
+        }
+        return makeFailure({
+          endpoint,
+          reason: 'http-error',
+          httpStatus: response.status,
+          data,
+          message: response.statusText || `HTTP ${response.status}`,
+        });
+      }
+
+      const success: RunToolSuccess = {
+        kind: 'success',
+        success: true,
+        endpoint,
+        httpStatus: response.status,
+        data,
+      };
+      return success;
+    }
   } catch (err) {
     return classifyFetchError(err, endpoint, timeoutMs);
   } finally {
@@ -143,11 +177,19 @@ function validateOptions(opts: RunToolOptions): RunToolFailure | null {
   return null;
 }
 
-function resolveConnection(
+async function resolveConnection(
   opts: RunToolOptions,
-): { kind: 'success'; url: string; token: string | undefined } | RunToolFailure {
+): Promise<
+  | { kind: 'success'; url: string; token: string | undefined; tokenFromCloudStore: boolean }
+  | RunToolFailure
+> {
   if (opts.url) {
-    return { kind: 'success', url: opts.url.replace(/\/$/, ''), token: opts.token };
+    return {
+      kind: 'success',
+      url: opts.url.replace(/\/$/, ''),
+      token: opts.token,
+      tokenFromCloudStore: false,
+    };
   }
 
   // `unityProjectPath` is library-only — does NOT require an `Assets/`
@@ -166,7 +208,9 @@ function resolveConnection(
 
   const config = readConfig(projectPath);
   const fromConfig = config
-    ? resolveConnectionFromConfig(config, { readCloudToken: opts.readCloudToken })
+    ? await resolveConnectionFromConfig(config, {
+        readCloudToken: opts.readCloudToken ?? readCloudAccessToken,
+      })
     : { url: undefined, token: undefined };
 
   const url = fromConfig.url
@@ -187,7 +231,8 @@ function resolveConnection(
     });
   }
 
-  return { kind: 'success', url, token };
+  const tokenFromCloudStore = !!config && isCloudMode(config) && !opts.token && !!token;
+  return { kind: 'success', url, token, tokenFromCloudStore };
 }
 
 function serializeInput(input: unknown): { json: string } | { error: Error } {

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -625,11 +625,20 @@ export interface RunToolOptions {
   fetchImpl?: typeof fetch;
   /**
    * Optional injection point for the Cloud-mode Bearer credential read from the shared machine
-   * credential store (`~/.ai-game-dev/credentials.json`). Only consulted when the resolved project
-   * config is in Cloud mode and neither `url` nor `token` was supplied. Defaults to reading the real
-   * per-machine store; tests inject a deterministic value.
+   * credential store. Only consulted when the resolved project config is in Cloud mode and neither
+   * `url` nor `token` was supplied. Defaults to cli-core's `MachineCredentialProvider` (proactive
+   * refresh under the cross-process lock — never a raw on-disk read); tests inject a deterministic
+   * value. Sync or async both work.
    */
-  readCloudToken?: () => string | undefined;
+  readCloudToken?: () => Promise<string | undefined> | string | undefined;
+  /**
+   * Optional injection point for the REACTIVE Cloud-mode refresh: invoked at most once per call
+   * when the server answers 401 to a machine-store Bearer (revocation / clock skew). Returns the
+   * rotated access token, or `undefined` when the credential family is dead (the call then fails
+   * with the original 401). Defaults to cli-core's `MachineCredentialProvider.refresh`. Never
+   * consulted for an explicit `token` / `url` override.
+   */
+  refreshCloudToken?: () => Promise<string | undefined> | string | undefined;
 }
 
 /** Successful `runTool` / `runSystemTool` outcome. Narrow with `kind === 'success'`. */

--- a/cli/src/utils/cloud-credentials.ts
+++ b/cli/src/utils/cloud-credentials.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import {
+  MachineCredentialProvider,
+  MachineCredentialStore,
+  MachineCredentialStoreUnreadableError,
+  CredentialLockBusyError,
+  HttpTokenRefresher,
+  LoginRequiredError,
+  unityAdapter,
+} from '@baizor/gamedev-cli-core';
+import { verbose } from './ui.js';
+import { CLOUD_SERVER_BASE_URL } from './config.js';
+
+/**
+ * The CLI's single seam onto cli-core's `MachineCredentialProvider` (unified-machine-auth 02/04,
+ * task d2 / W2). Every Cloud-mode Bearer the CLI presents comes through here — the provider owns
+ * proactive refresh (inside the 60 s expiry skew), reactive refresh (driven by a hub 401), the
+ * cross-process credential lock, and the family-aware machine-store view. The CLI never reads
+ * `accessToken` raw off disk: a raw read returns a token that may be seconds from expiry (or past
+ * it) with nobody refreshing, which is exactly the defect this module replaces
+ * (the pre-d2 `readMachineStoreCloudToken`).
+ */
+
+/** Injectable construction options — tests point the provider at a temp store + a fake AS. */
+export interface CloudCredentialProviderOptions {
+  /** The credential store to serve from; defaults to the shared per-machine store. */
+  store?: MachineCredentialStore;
+  /** Authorization-server base for the refresh endpoint; defaults to the hosted cloud. */
+  serverBaseUrl?: string;
+  /** Injectable `fetch` for the refresher (tests). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Build a `MachineCredentialProvider` wired the way this CLI consumes it:
+ * `HttpTokenRefresher` against the AS root, and `unity-mcp-cli` as the component-default client
+ * id — used ONLY for `families.legacy` (a stored family's own `clientId` always wins, 04 §3).
+ */
+export function createCloudCredentialProvider(
+  options: CloudCredentialProviderOptions = {},
+): MachineCredentialProvider {
+  const store = options.store ?? new MachineCredentialStore();
+  const refresher = new HttpTokenRefresher({
+    defaultServerBaseUrl: options.serverBaseUrl ?? CLOUD_SERVER_BASE_URL,
+    ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+  });
+  return new MachineCredentialProvider(store, refresher, {
+    defaultClientId: unityAdapter.clientId, // unity-mcp-cli
+    onWarning: (message) => verbose(`[credential-provider] ${message}`),
+    onTelemetry: (event) => verbose(`[credential-provider] ${event.type}: ${event.family} (${event.reason})`),
+  });
+}
+
+/** Lazy singleton for the default (real per-machine) store — one provider per CLI process. */
+let defaultProvider: MachineCredentialProvider | undefined;
+
+function resolveProvider(options?: CloudCredentialProviderOptions): MachineCredentialProvider {
+  if (options?.store || options?.serverBaseUrl || options?.fetchImpl) {
+    return createCloudCredentialProvider(options);
+  }
+  defaultProvider ??= createCloudCredentialProvider();
+  return defaultProvider;
+}
+
+/** TEST-ONLY: drop the cached default provider (e.g. after re-pointing HOME). */
+export function resetCloudCredentialProviderForTests(): void {
+  defaultProvider = undefined;
+}
+
+/**
+ * Read a valid plugin-plane access token for a Cloud-mode call, PROACTIVELY refreshing under the
+ * cross-process lock when the stored token is within the expiry skew. Returns `undefined` when the
+ * machine is effectively not signed in — no credential, a dead family, an unreadable store, or a
+ * lock that stayed contended — so callers surface their actionable "not logged in" error instead
+ * of issuing a silent unauthenticated request (defect E / D11). The precise reason is logged via
+ * `verbose()` (never token bytes).
+ */
+export async function readCloudAccessToken(
+  options?: CloudCredentialProviderOptions,
+): Promise<string | undefined> {
+  const provider = resolveProvider(options);
+  try {
+    return await provider.getAccessToken({ family: 'plugin' });
+  } catch (err) {
+    return degradeToSignedOut(err, 'read');
+  }
+}
+
+/**
+ * REACTIVELY refresh the plugin-plane family now — the hub answered 401 while the local expiry
+ * still looked fine (revocation, clock skew). Runs the same locked critical section as the
+ * proactive path. Returns the fresh access token, or `undefined` when the family is dead /
+ * signed out (the caller falls back to its "not logged in" error).
+ */
+export async function refreshCloudAccessToken(
+  options?: CloudCredentialProviderOptions,
+): Promise<string | undefined> {
+  const provider = resolveProvider(options);
+  try {
+    const document = await provider.refresh({ family: 'plugin' });
+    return document.accessToken ?? document.families?.plugin?.accessToken ?? undefined;
+  } catch (err) {
+    return degradeToSignedOut(err, 'refresh');
+  }
+}
+
+function degradeToSignedOut(err: unknown, operation: string): undefined {
+  if (err instanceof LoginRequiredError) {
+    verbose(`Cloud credential ${operation}: login required (${err.message})`);
+    return undefined;
+  }
+  if (err instanceof MachineCredentialStoreUnreadableError) {
+    verbose(`Cloud credential ${operation}: store unreadable — sign in again to replace it (${err.message})`);
+    return undefined;
+  }
+  if (err instanceof CredentialLockBusyError) {
+    verbose(`Cloud credential ${operation}: credential store busy — retry shortly (${err.message})`);
+    return undefined;
+  }
+  throw err;
+}

--- a/cli/src/utils/cloud-login.ts
+++ b/cli/src/utils/cloud-login.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Ivan Murzak. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+import * as readline from 'readline/promises';
 import * as ui from './ui.js';
 import { CLOUD_SERVER_BASE_URL } from './config.js';
 import { openBrowser } from './browser.js';
@@ -8,46 +9,213 @@ import { MachineCredentialStore } from './machine-credentials.js';
 import {
   deviceLogin,
   unityAdapter,
+  commitAgentLogin,
+  commitToolsOnlyLogin,
+  derivePluginFamily,
+  HttpTokenExchangeClient,
   DEFAULT_PLUGIN_SCOPE,
+  MCP_AGENT_SCOPE,
   type DeviceLoginResult,
   type DeviceLoginOptions,
+  type MachineCredentials,
+  type RevokeTokenFn,
+  type TokenExchangeClient,
 } from '@baizor/gamedev-cli-core';
 
 /**
- * The device-flow login now runs on `@baizor/gamedev-cli-core`'s OAuth 2.1 Device Authorization
- * Grant (RFC 8628) — client_id `unity-mcp-cli`, scope `mcp:plugin` — which mints an ES256 hub JWT
- * plus a rotating refresh token and NEVER mints a PAT (auth-fixes T1, closing B2/B3). The FULL
- * credential set (accessToken, refreshToken, expiresAt, serverTarget, subject) is persisted to the
- * shared machine credential store — the legacy flow dropped refresh/expiry/subject on the floor.
+ * The cloud sign-in flow (unified-machine-auth 03 F1/F7/F10, task d2). The device grant
+ * (RFC 8628, client_id `unity-mcp-cli`) now mints at **agent scope** (`mcp:agent`) by default and
+ * the commit goes through cli-core's login-commit machinery — the two-lock-hold sequence: agent
+ * family under the first hold, RFC 8693 token exchange with the lock released, derived plugin
+ * family (+ v1 mirror) under the second hold. A failed exchange leaves a valid committed agent
+ * family (`partial`) and the derivation alone is retried.
+ *
+ * `--tools-only` (O10/F10) mints at `mcp:plugin` scope and commits a plugin family ONLY — the
+ * store then holds no agent family, so App pickup is impossible by design and the runner appears
+ * as its own revocable device group.
+ *
+ * The D6/F7 account-switch guard runs before ANY write: a subject mismatch prompts
+ * (`--yes`-gated); decline revokes the just-minted family (best effort, RFC 7009) and aborts with
+ * the store untouched.
  */
 
-/** Injection seam so the login flow can be exercised offline in tests without the network. */
-export interface RunCloudLoginDeps {
+/** How many times the F1 `partial` state retries the derivation leg within one login run. */
+const DERIVE_RETRY_ATTEMPTS = 3;
+/** Base backoff between derivation retries (doubles per attempt). */
+const DERIVE_RETRY_BASE_MS = 500;
+
+/** Injection seams so the login flow can be exercised offline in tests without the network. */
+export interface RunCloudLoginOptions {
+  /** O10/F10: mint `scope=mcp:plugin` and commit a plugin-only store (no agent family). */
+  toolsOnly?: boolean;
+  /** F7: auto-confirm the account-switch prompt (the `--yes` flag). */
+  assumeYes?: boolean;
   /** Authorization-server base; defaults to the hosted `CLOUD_SERVER_BASE_URL`. */
   serverBaseUrl?: string;
   /** The device-login implementation; defaults to cli-core's `deviceLogin`. */
   login?: (options: DeviceLoginOptions) => Promise<DeviceLoginResult>;
+  /** The RFC 8693 exchange client; defaults to cli-core's `HttpTokenExchangeClient`. */
+  exchangeClient?: TokenExchangeClient;
+  /** The D6/F7 confirmation; defaults to an interactive prompt (auto-confirmed by `assumeYes`). */
+  confirmAccountSwitch?: (info: {
+    storedSubject: string;
+    newSubject: string;
+  }) => boolean | Promise<boolean>;
+  /** Injectable best-effort RFC 7009 revoker (tests). */
+  revokeToken?: RevokeTokenFn;
+  /** Injectable backoff sleep (tests make it a no-op). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * The D6/F7 account-switch confirmation used when no callback is injected:
+ * - `--yes` ⇒ confirmed without prompting (F7 "`--yes`-gated");
+ * - interactive TTY ⇒ y/N prompt (default No);
+ * - non-interactive without `--yes` ⇒ DECLINED (fail closed) with an actionable hint.
+ */
+function buildAccountSwitchConfirm(
+  assumeYes: boolean,
+): (info: { storedSubject: string; newSubject: string }) => Promise<boolean> {
+  return async (info) => {
+    ui.warn(
+      `This machine is currently signed in as "${info.storedSubject}"; you are signing in as "${info.newSubject}".`,
+    );
+    ui.info('Switching replaces the stored credential and signs the previous account out on this machine.');
+    if (assumeYes) {
+      ui.info('--yes given: switching accounts.');
+      return true;
+    }
+    if (!process.stdin.isTTY) {
+      ui.error('Account switch requires confirmation. Re-run with --yes to switch accounts.');
+      return false;
+    }
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      const answer = (await rl.question('Switch this machine to the new account? [y/N] ')).trim();
+      return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+    } finally {
+      rl.close();
+    }
+  };
+}
+
+/** The v2 document's plugin-plane access token (v1 mirror first — it IS the plugin family's). */
+function pluginPlaneToken(document: MachineCredentials): string | null {
+  return (
+    document.accessToken ??
+    document.families?.plugin?.accessToken ??
+    document.families?.legacy?.accessToken ??
+    null
+  );
+}
+
+/**
+ * Retry the F1.4 derivation leg alone (the `partial` state): RFC 8693 exchange → plugin family +
+ * v1 mirror under one lock hold. Returns the committed document, or null when every attempt
+ * failed or the store changed underneath (aborts are terminal — retrying cannot help).
+ */
+async function retryDerivePluginFamily(params: {
+  store: MachineCredentialStore;
+  exchangeClient: TokenExchangeClient;
+  agentAccessToken: string;
+  expectedSubject: string | undefined;
+  serverTarget: string | undefined;
+  revokeToken: RevokeTokenFn | undefined;
+  sleep: (ms: number) => Promise<void>;
+  attempts?: number;
+}): Promise<MachineCredentials | null> {
+  const attempts = params.attempts ?? DERIVE_RETRY_ATTEMPTS;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const result = await derivePluginFamily({
+      store: params.store,
+      exchangeClient: params.exchangeClient,
+      clientId: unityAdapter.clientId,
+      agentAccessToken: params.agentAccessToken,
+      ...(params.expectedSubject !== undefined ? { expectedSubject: params.expectedSubject } : {}),
+      ...(params.serverTarget !== undefined ? { serverTarget: params.serverTarget } : {}),
+      ...(params.revokeToken ? { revokeToken: params.revokeToken } : {}),
+      onWarning: ui.warn,
+    });
+    if (result.status === 'derived') {
+      return result.document;
+    }
+    if (result.status === 'aborted') {
+      // Store-missing / subject-changed / store-unreadable: a concurrent flow changed the world;
+      // the orphaned derived family was already revoked best-effort by cli-core. Terminal.
+      ui.error(`Could not finish authorization: ${result.reason}. Run \`unity-mcp-cli login\` again.`);
+      return null;
+    }
+    ui.warn(`Deriving the tools credential failed (${result.reason}) — attempt ${attempt}/${attempts}.`);
+    if (attempt < attempts) {
+      await params.sleep(DERIVE_RETRY_BASE_MS * 2 ** (attempt - 1));
+    }
+  }
+  return null;
+}
+
+/**
+ * Finish a previously interrupted agent login (F1 `partial`: agent family committed, plugin
+ * derivation missing) using a FRESH agent access token supplied by the caller. Returns true when
+ * the plugin family is committed.
+ */
+export async function completePluginDerivation(
+  store: MachineCredentialStore,
+  agentAccessToken: string,
+  options: Pick<RunCloudLoginOptions, 'serverBaseUrl' | 'exchangeClient' | 'revokeToken' | 'sleep'> = {},
+): Promise<boolean> {
+  const serverBaseUrl = options.serverBaseUrl ?? CLOUD_SERVER_BASE_URL;
+  const exchangeClient =
+    options.exchangeClient ?? new HttpTokenExchangeClient({ defaultServerBaseUrl: serverBaseUrl });
+  const stored = safeRead(store);
+  const document = await retryDerivePluginFamily({
+    store,
+    exchangeClient,
+    agentAccessToken,
+    expectedSubject: stored?.subject,
+    serverTarget: stored?.serverTarget,
+    revokeToken: options.revokeToken,
+    sleep: options.sleep ?? defaultSleep,
+  });
+  if (document) {
+    ui.success('Authorization completed: tools credential derived.');
+    return true;
+  }
+  return false;
+}
+
+function safeRead(store: MachineCredentialStore): MachineCredentials | null {
+  try {
+    return store.read();
+  } catch {
+    return null;
+  }
 }
 
 /**
  * Run the cloud device-auth flow: initiate, display the user code + verification URL, open the
- * browser, poll, and persist the FULL credential to the shared machine credential store.
+ * browser, poll, then commit through cli-core's login-commit machinery (two-lock-hold agent
+ * commit + exchange-derived plugin family, or the tools-only plugin commit — never a raw
+ * `store.write`).
  *
- * Returns the access token on success, or null on failure (errors are printed).
+ * Returns the plugin-plane access token on success, or null on failure (errors are printed).
  */
 export async function runCloudLogin(
   store: MachineCredentialStore,
-  deps: RunCloudLoginDeps = {},
+  options: RunCloudLoginOptions = {},
 ): Promise<string | null> {
-  const serverBaseUrl = deps.serverBaseUrl ?? CLOUD_SERVER_BASE_URL;
-  const login = deps.login ?? deviceLogin;
+  const serverBaseUrl = options.serverBaseUrl ?? CLOUD_SERVER_BASE_URL;
+  const login = options.login ?? deviceLogin;
+  const sleep = options.sleep ?? defaultSleep;
   let spinner: ReturnType<typeof ui.startSpinner> | undefined;
 
   try {
     const result = await login({
       serverBaseUrl,
       clientId: unityAdapter.clientId, // unity-mcp-cli
-      scope: DEFAULT_PLUGIN_SCOPE, // mcp:plugin
+      // Agent scope by default (03 §F1); plugin scope only for --tools-only (O10/F10).
+      scope: options.toolsOnly ? DEFAULT_PLUGIN_SCOPE : MCP_AGENT_SCOPE,
       onUserCode: (userCode, verificationUri) => {
         ui.info('Open this URL to authorize:');
         console.log();
@@ -61,20 +229,80 @@ export async function runCloudLogin(
       openBrowser,
     });
 
-    if (result.ok) {
-      spinner?.success('Authorized');
+    if (!result.ok) {
+      spinner?.stop();
+      ui.error(result.message);
+      return null;
+    }
+    spinner?.success('Authorized');
 
-      // Persist the FULL credential set (accessToken + refreshToken + expiresAt + serverTarget +
-      // subject) — never a project config file. This closes B3 (the legacy flow stored only
-      // accessToken + serverTarget, losing the refresh/expiry needed for proactive refresh).
-      store.write(result.credentials);
+    const confirmAccountSwitch =
+      options.confirmAccountSwitch ?? buildAccountSwitchConfirm(options.assumeYes ?? false);
 
-      return result.credentials.accessToken ?? null;
+    if (options.toolsOnly) {
+      const commit = await commitToolsOnlyLogin({
+        store,
+        clientId: unityAdapter.clientId,
+        credentials: result.credentials,
+        confirmAccountSwitch,
+        ...(options.revokeToken ? { revokeToken: options.revokeToken } : {}),
+        onWarning: ui.warn,
+      });
+      switch (commit.status) {
+        case 'committed':
+          return pluginPlaneToken(commit.document);
+        case 'switch-declined':
+          ui.error('Account switch declined — nothing was changed. The new sign-in was revoked.');
+          return null;
+        case 'aborted':
+          ui.error('The credential store changed while signing in. Run `unity-mcp-cli login` again.');
+          return null;
+      }
     }
 
-    spinner?.stop();
-    ui.error(result.message);
-    return null;
+    const exchangeClient =
+      options.exchangeClient ?? new HttpTokenExchangeClient({ defaultServerBaseUrl: serverBaseUrl });
+
+    const commit = await commitAgentLogin({
+      store,
+      exchangeClient,
+      clientId: unityAdapter.clientId,
+      credentials: result.credentials,
+      confirmAccountSwitch,
+      ...(options.revokeToken ? { revokeToken: options.revokeToken } : {}),
+      onWarning: ui.warn,
+    });
+
+    switch (commit.status) {
+      case 'committed':
+        return pluginPlaneToken(commit.document);
+      case 'partial': {
+        // F1 failure path: the agent family IS committed; retry the derivation leg alone.
+        ui.warn(`Partially authorized (${commit.exchangeFailure}). Retrying the tools credential...`);
+        const document = await retryDerivePluginFamily({
+          store,
+          exchangeClient,
+          agentAccessToken: result.credentials.accessToken ?? '',
+          expectedSubject: result.credentials.subject,
+          serverTarget: result.credentials.serverTarget,
+          revokeToken: options.revokeToken,
+          sleep,
+        });
+        if (document) {
+          return pluginPlaneToken(document);
+        }
+        ui.error(
+          'Signed in, but deriving the tools credential failed. Run `unity-mcp-cli login` again to finish authorization.',
+        );
+        return null;
+      }
+      case 'switch-declined':
+        ui.error('Account switch declined — nothing was changed. The new sign-in was revoked.');
+        return null;
+      case 'aborted':
+        ui.error('The credential store changed while signing in. Run `unity-mcp-cli login` again.');
+        return null;
+    }
   } catch (err) {
     spinner?.stop();
     const message = err instanceof Error ? err.message : String(err);

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { generatePortFromDirectory } from './port.js';
-import { MachineCredentialStore } from './machine-credentials.js';
 
 const CONFIG_RELATIVE_PATH = 'UserSettings/AI-Game-Developer-Config.json';
 
@@ -171,54 +170,40 @@ export function isCloudMode(config: UnityConnectionConfig): boolean {
 export const CLOUD_SERVER_BASE_URL = 'https://ai-game.dev';
 export const CLOUD_SERVER_URL = 'https://ai-game.dev/mcp';
 
-/**
- * Read the Cloud-mode Bearer credential from the shared machine credential store
- * (`~/.ai-game-dev/credentials.json`, managed by `@baizor/gamedev-cli-core`).
- *
- * Post-T9 the Unity plugin no longer writes `cloudToken` into the project config — the cloud auth
- * token now lives once per machine in the shared store (written by `unity-mcp-cli login`). Returns the
- * stored `accessToken`, or `undefined` when the user is not logged in OR the store is unreadable — a
- * corrupt/undecryptable store must degrade to "not logged in", never crash a tool call.
- */
-export function readMachineStoreCloudToken(): string | undefined {
-  try {
-    return new MachineCredentialStore().read()?.accessToken ?? undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 /** Options for {@link resolveConnectionFromConfig}. */
 export interface ResolveConnectionFromConfigOptions {
   /**
-   * Reads the Cloud-mode Bearer credential from the shared machine credential store. Injectable so
-   * tests (and advanced callers) can supply a deterministic value without touching the real
-   * per-machine store. Defaults to {@link readMachineStoreCloudToken}.
+   * Supplies the Cloud-mode Bearer credential. REQUIRED (no built-in default): the production
+   * value is `readCloudAccessToken` from `cloud-credentials.ts` — cli-core's
+   * `MachineCredentialProvider`, which proactively refreshes an expiring token under the
+   * cross-process lock (unified-machine-auth 04 §3). A raw on-disk `accessToken` read must never
+   * reappear here: it returns a token nobody refreshes (the pre-d2 defect). Tests inject a
+   * deterministic value; sync or async both work.
    */
-  readCloudToken?: () => string | undefined;
+  readCloudToken: () => Promise<string | undefined> | string | undefined;
 }
 
 /**
  * Resolve the server URL and auth token from a project config based on connectionMode.
  * - Custom mode (string "Custom" or integer 0): uses `host` and `token` (self-host / derived-port).
  * - Cloud mode (string "Cloud" or integer 1): uses the hardcoded cloud URL and the Bearer credential
- *   from the shared machine credential store (`~/.ai-game-dev/credentials.json`) — NOT the on-disk
- *   `cloudToken`, which the plugin stopped writing post-T9 (defect E / D11).
+ *   supplied by `options.readCloudToken` (production: the shared machine credential store via
+ *   cli-core's refreshing `MachineCredentialProvider`) — NOT the on-disk `cloudToken`, which the
+ *   plugin stopped writing post-T9 (defect E / D11).
  * In Custom mode, `url` and `token` may be undefined if the corresponding config fields are not set.
- * In Cloud mode, `url` is always the hardcoded cloud URL, while `token` is the stored credential and is
- * `undefined` when the user is not logged in — the caller surfaces an actionable "not logged in" error
- * rather than issuing a silent unauthenticated request.
+ * In Cloud mode, `url` is always the hardcoded cloud URL, while `token` is the provided credential and
+ * is `undefined` when the user is not logged in — the caller surfaces an actionable "not logged in"
+ * error rather than issuing a silent unauthenticated request.
  */
-export function resolveConnectionFromConfig(
+export async function resolveConnectionFromConfig(
   config: UnityConnectionConfig,
-  options: ResolveConnectionFromConfigOptions = {},
-): {
+  options: ResolveConnectionFromConfigOptions,
+): Promise<{
   url: string | undefined;
   token: string | undefined;
-} {
+}> {
   if (isCloudMode(config)) {
-    const readCloudToken = options.readCloudToken ?? readMachineStoreCloudToken;
-    return { url: CLOUD_SERVER_URL, token: readCloudToken() };
+    return { url: CLOUD_SERVER_URL, token: await options.readCloudToken() };
   }
 
   return { url: config.host, token: config.token };

--- a/cli/src/utils/connection.ts
+++ b/cli/src/utils/connection.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { verbose } from './ui.js';
 import { generatePortFromDirectory } from './port.js';
 import { readConfig, resolveConnectionFromConfig, isCloudMode } from './config.js';
+import { readCloudAccessToken } from './cloud-credentials.js';
 import * as ui from './ui.js';
 
 export interface ConnectionOptions {
@@ -66,20 +67,29 @@ export function resolveAndValidateProjectPath(positionalPath: string | undefined
 export interface ResolveConnectionDeps {
   /**
    * Injection point for the Cloud-mode machine-store credential read. Forwarded to
-   * `resolveConnectionFromConfig`; defaults to the real per-machine store. Tests inject a
-   * deterministic value.
+   * `resolveConnectionFromConfig`; defaults to `readCloudAccessToken` — cli-core's
+   * `MachineCredentialProvider` (proactive refresh under the cross-process lock, never a raw
+   * on-disk read). Tests inject a deterministic value.
    */
-  readCloudToken?: () => string | undefined;
+  readCloudToken?: () => Promise<string | undefined> | string | undefined;
 }
 
-export function resolveConnection(
+export async function resolveConnection(
   projectPath: string,
   options: ConnectionOptions,
   deps: ResolveConnectionDeps = {},
-): { url: string; token: string | undefined; cloudAuthMissing: boolean } {
+): Promise<{
+  url: string;
+  token: string | undefined;
+  cloudAuthMissing: boolean;
+  /** True when the Bearer came from the shared machine store (Cloud mode, no --token override). */
+  tokenFromCloudStore: boolean;
+}> {
   const config = readConfig(projectPath);
   const fromConfig = config
-    ? resolveConnectionFromConfig(config, { readCloudToken: deps.readCloudToken })
+    ? await resolveConnectionFromConfig(config, {
+        readCloudToken: deps.readCloudToken ?? readCloudAccessToken,
+      })
     : { url: undefined, token: undefined };
 
   verbose(`Config loaded: connectionMode=${config?.connectionMode ?? 'N/A'}, configUrl=${fromConfig.url ?? 'N/A'}, hasToken=${!!fromConfig.token}`);
@@ -110,6 +120,7 @@ export function resolveConnection(
   // signal this so the run-tool command surfaces an actionable "not logged in" error instead of a
   // silent unauthenticated cloud call (defect E / D11).
   const cloudAuthMissing = usingCloudUrl && !token;
+  const tokenFromCloudStore = usingCloudUrl && !options.token && !!token;
 
-  return { url, token, cloudAuthMissing };
+  return { url, token, cloudAuthMissing, tokenFromCloudStore };
 }

--- a/cli/tests/cloud-credential-provider.test.ts
+++ b/cli/tests/cloud-credential-provider.test.ts
@@ -1,0 +1,232 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import type { AddressInfo } from 'net';
+import { effectiveFamilies, identityCredentialCodec } from '@baizor/gamedev-cli-core';
+
+import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
+import {
+  readCloudAccessToken,
+  refreshCloudAccessToken,
+} from '../src/utils/cloud-credentials.js';
+
+/**
+ * INTEGRATION: the CLI works straight through token expiry with NO re-login (task d2 DoD).
+ *
+ * A real HTTP fake authorization server serves `POST /oauth/token`; the machine store holds an
+ * EXPIRED plugin-family access token plus its rotating refresh token. `readCloudAccessToken` —
+ * the exact seam every Cloud-mode call resolves its Bearer through — must come back with a FRESH
+ * access token minted via `grant_type=refresh_token`, rotate the stored family, and never touch
+ * any login/device-authorization endpoint.
+ *
+ * This test is the tripwire for the provider-bypass regression: if anyone restores the raw
+ * `store.read()?.accessToken` path (the pre-d2 defect), the expired token comes back verbatim and
+ * the assertions below go RED.
+ */
+
+interface RecordedTokenRequest {
+  grantType: string | null;
+  refreshToken: string | null;
+  clientId: string | null;
+  hasScope: boolean;
+  hasResource: boolean;
+}
+
+interface FakeAs {
+  baseUrl: string;
+  tokenRequests: RecordedTokenRequest[];
+  otherRequests: string[];
+  close: () => Promise<void>;
+}
+
+/** A minimal fake AS on an ephemeral 127.0.0.1 port (the OS picks it — no fixed-port collisions). */
+async function startFakeAs(): Promise<FakeAs> {
+  const tokenRequests: RecordedTokenRequest[] = [];
+  const otherRequests: string[] = [];
+
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk: Buffer) => (body += chunk.toString('utf-8')));
+    req.on('end', () => {
+      if (req.method === 'POST' && req.url === '/oauth/token') {
+        const params = new URLSearchParams(body);
+        tokenRequests.push({
+          grantType: params.get('grant_type'),
+          refreshToken: params.get('refresh_token'),
+          clientId: params.get('client_id'),
+          hasScope: params.has('scope'),
+          hasResource: params.has('resource'),
+        });
+        if (
+          params.get('grant_type') === 'refresh_token' &&
+          params.get('refresh_token') === 'rotating-refresh-1'
+        ) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              access_token: 'fresh-access-token',
+              refresh_token: 'rotating-refresh-2',
+              token_type: 'Bearer',
+              expires_in: 3600,
+            }),
+          );
+          return;
+        }
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid_grant' }));
+        return;
+      }
+      otherRequests.push(`${req.method} ${req.url}`);
+      res.writeHead(404);
+      res.end();
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    tokenRequests,
+    otherRequests,
+    close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+describe('cloud credential provider — expiry self-heal against a fake AS (integration)', () => {
+  let tmp: string;
+  let fakeAs: FakeAs;
+
+  beforeEach(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-provider-'));
+    fakeAs = await startFakeAs();
+  });
+
+  afterEach(async () => {
+    await fakeAs.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function seedExpiredPluginFamily(store: MachineCredentialStore): void {
+    store.write({
+      version: 2,
+      serverTarget: fakeAs.baseUrl,
+      subject: 'acct-1',
+      families: {
+        plugin: {
+          accessToken: 'expired-access-token',
+          refreshToken: 'rotating-refresh-1',
+          // Expired a minute ago: the provider MUST refresh, never serve this token.
+          expiresAt: new Date(Date.now() - 60_000).toISOString(),
+          clientId: 'unity-mcp-cli',
+          scope: 'mcp:plugin',
+        },
+      },
+    });
+  }
+
+  it('serves a FRESH token through expiry with no re-login, rotating the stored family', async () => {
+    const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'), identityCredentialCodec);
+    seedExpiredPluginFamily(store);
+
+    const token = await readCloudAccessToken({ store, serverBaseUrl: fakeAs.baseUrl });
+
+    // Through expiry: the served Bearer is the freshly minted one, NEVER the expired on-disk token.
+    expect(token).toBe('fresh-access-token');
+
+    // Exactly one refresh-grant call; no device-authorization / login endpoint was ever touched.
+    expect(fakeAs.tokenRequests).toHaveLength(1);
+    expect(fakeAs.otherRequests).toEqual([]);
+    const request = fakeAs.tokenRequests[0];
+    expect(request.grantType).toBe('refresh_token');
+    expect(request.refreshToken).toBe('rotating-refresh-1');
+    // 04 §3 rule 2: the family's STORED clientId is presented.
+    expect(request.clientId).toBe('unity-mcp-cli');
+    // 04 §3 rule 3 (P0-3): scope and resource are omitted ENTIRELY.
+    expect(request.hasScope).toBe(false);
+    expect(request.hasResource).toBe(false);
+
+    // The rotation was persisted under the lock: the stored family carries the new pair.
+    const families = effectiveFamilies(store.read() ?? {});
+    expect(families.plugin?.accessToken).toBe('fresh-access-token');
+    expect(families.plugin?.refreshToken).toBe('rotating-refresh-2');
+  });
+
+  it('a still-valid token is served as-is (no gratuitous refresh traffic)', async () => {
+    const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'), identityCredentialCodec);
+    store.write({
+      version: 2,
+      serverTarget: fakeAs.baseUrl,
+      families: {
+        plugin: {
+          accessToken: 'still-valid-token',
+          refreshToken: 'rotating-refresh-1',
+          expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+          clientId: 'unity-mcp-cli',
+          scope: 'mcp:plugin',
+        },
+      },
+    });
+
+    const token = await readCloudAccessToken({ store, serverBaseUrl: fakeAs.baseUrl });
+    expect(token).toBe('still-valid-token');
+    expect(fakeAs.tokenRequests).toHaveLength(0);
+  });
+
+  it('reactive refresh (hub 401 path) rotates a still-valid-looking family on demand', async () => {
+    const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'), identityCredentialCodec);
+    store.write({
+      version: 2,
+      serverTarget: fakeAs.baseUrl,
+      families: {
+        plugin: {
+          accessToken: 'locally-valid-but-revoked',
+          refreshToken: 'rotating-refresh-1',
+          expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+          clientId: 'unity-mcp-cli',
+          scope: 'mcp:plugin',
+        },
+      },
+    });
+
+    const token = await refreshCloudAccessToken({ store, serverBaseUrl: fakeAs.baseUrl });
+    expect(token).toBe('fresh-access-token');
+    expect(fakeAs.tokenRequests).toHaveLength(1);
+    const families = effectiveFamilies(store.read() ?? {});
+    expect(families.plugin?.refreshToken).toBe('rotating-refresh-2');
+  });
+
+  it('a dead family (invalid_grant) degrades to "not signed in" — undefined, store families intact', async () => {
+    const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'), identityCredentialCodec);
+    store.write({
+      version: 2,
+      serverTarget: fakeAs.baseUrl,
+      families: {
+        plugin: {
+          accessToken: 'expired-access-token',
+          refreshToken: 'unknown-refresh-token', // the fake AS answers invalid_grant
+          expiresAt: new Date(Date.now() - 60_000).toISOString(),
+          clientId: 'unity-mcp-cli',
+          scope: 'mcp:plugin',
+        },
+      },
+    });
+
+    const token = await readCloudAccessToken({ store, serverBaseUrl: fakeAs.baseUrl });
+    expect(token).toBeUndefined();
+    // The provider never deletes the store on a dead family (04 §3 rule 5).
+    expect(store.exists).toBe(true);
+  });
+
+  it('an empty store resolves to undefined without any network traffic', async () => {
+    const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'), identityCredentialCodec);
+    const token = await readCloudAccessToken({ store, serverBaseUrl: fakeAs.baseUrl });
+    expect(token).toBeUndefined();
+    expect(fakeAs.tokenRequests).toHaveLength(0);
+    expect(fakeAs.otherRequests).toEqual([]);
+  });
+});

--- a/cli/tests/cloud-login.test.ts
+++ b/cli/tests/cloud-login.test.ts
@@ -5,44 +5,129 @@ import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import type { DeviceLoginResult } from '@baizor/gamedev-cli-core';
+import {
+  effectiveFamilies,
+  identityCredentialCodec,
+  type DeviceLoginOptions,
+  type DeviceLoginResult,
+  type TokenExchangeClient,
+  type TokenExchangeRequest,
+} from '@baizor/gamedev-cli-core';
 
 import { runCloudLogin } from '../src/utils/cloud-login.js';
 import { MachineCredentialStore } from '../src/utils/machine-credentials.js';
 
-// runCloudLogin now runs cli-core's OAuth device flow (RFC 8628). We inject a `login` double that
-// resolves success WITHOUT the callbacks / network, so openBrowser and the spinner are never reached
-// and the FULL credential set is persisted.
-describe('runCloudLogin', () => {
-  it('persists the full OAuth credential to the credential store (never a project config file)', async () => {
+// runCloudLogin runs cli-core's OAuth device flow (RFC 8628) at AGENT scope by default and commits
+// through the login-commit machinery (two-lock-hold agent commit + RFC 8693 exchange-derived plugin
+// family), or — with `toolsOnly` — a plugin-only commit (O10/F10). Everything network-shaped is
+// injected: the device `login`, the `exchangeClient`, and the RFC 7009 `revokeToken`.
+
+const AGENT_MINT = {
+  accessToken: 'agent-access-token',
+  refreshToken: 'agent-refresh-token',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  serverTarget: 'https://ai-game.dev',
+  subject: 'acct-1',
+};
+
+function tempStore(tmp: string): MachineCredentialStore {
+  // The identity codec keeps these tests platform-independent (no DPAPI/PowerShell on Windows).
+  return new MachineCredentialStore(path.join(tmp, '.ai-game-dev'), identityCredentialCodec);
+}
+
+function loginDouble(
+  credentials: Record<string, unknown> = AGENT_MINT,
+  capture?: { scope?: string; clientId?: string },
+): (options: DeviceLoginOptions) => Promise<DeviceLoginResult> {
+  return async (options) => {
+    if (capture) {
+      capture.scope = options.scope;
+      capture.clientId = options.clientId;
+    }
+    return { ok: true, credentials };
+  };
+}
+
+function exchangeDouble(behaviour?: {
+  failures?: number;
+  calls?: TokenExchangeRequest[];
+}): TokenExchangeClient {
+  let remainingFailures = behaviour?.failures ?? 0;
+  return {
+    exchange: async (request) => {
+      behaviour?.calls?.push(request);
+      if (remainingFailures > 0) {
+        remainingFailures--;
+        return { ok: false, reason: 'exchange-unavailable' };
+      }
+      return {
+        ok: true,
+        accessToken: 'plugin-access-token',
+        refreshToken: 'plugin-refresh-token',
+        expiresAt: '2030-01-01T00:30:00.000Z',
+        scope: 'mcp:plugin',
+        sub: 'acct-1',
+      };
+    },
+  };
+}
+
+const noSleep = async (): Promise<void> => {};
+
+describe('runCloudLogin — agent login (default)', () => {
+  it('mints at mcp:agent scope with the unity-mcp-cli client id', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
     try {
-      const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'));
+      const capture: { scope?: string; clientId?: string } = {};
+      await runCloudLogin(tempStore(tmp), {
+        login: loginDouble(AGENT_MINT, capture),
+        exchangeClient: exchangeDouble(),
+        sleep: noSleep,
+      });
+      expect(capture.clientId).toBe('unity-mcp-cli');
+      expect(capture.scope).toBe('mcp:agent');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 
-      const login = async (): Promise<DeviceLoginResult> => ({
-        ok: true,
-        credentials: {
-          accessToken: 'test-access-token',
-          refreshToken: 'test-refresh-token',
-          expiresAt: '2030-01-01T00:00:00.000Z',
-          serverTarget: 'https://ai-game.dev',
-          subject: 'acct-1',
-        },
+  it('commits BOTH families (agent + exchange-derived plugin) with the v1 mirror — never a project config file', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const store = tempStore(tmp);
+      const exchangeCalls: TokenExchangeRequest[] = [];
+
+      const token = await runCloudLogin(store, {
+        login: loginDouble(),
+        exchangeClient: exchangeDouble({ calls: exchangeCalls }),
+        sleep: noSleep,
       });
 
-      const token = await runCloudLogin(store, { login });
-
-      expect(token).toBe('test-access-token');
+      // The returned token is the PLUGIN-plane credential (what cloud tool calls present).
+      expect(token).toBe('plugin-access-token');
       expect(store.exists).toBe(true);
 
-      const creds = store.read();
-      // B3 fix: the full credential set is persisted (not just accessToken + serverTarget).
-      expect(creds?.accessToken).toBe('test-access-token');
-      expect(creds?.refreshToken).toBe('test-refresh-token');
-      expect(creds?.expiresAt).toBe('2030-01-01T00:00:00.000Z');
-      expect(creds?.serverTarget).toBe('https://ai-game.dev');
-      expect(creds?.subject).toBe('acct-1');
-      expect(creds?.version).toBe(1);
+      const document = store.read();
+      expect(document?.version).toBe(2);
+      expect(document?.subject).toBe('acct-1');
+      expect(document?.serverTarget).toBe('https://ai-game.dev');
+
+      const families = effectiveFamilies(document ?? {});
+      expect(families.agent?.accessToken).toBe('agent-access-token');
+      expect(families.agent?.refreshToken).toBe('agent-refresh-token');
+      expect(families.agent?.clientId).toBe('unity-mcp-cli');
+      expect(families.plugin?.accessToken).toBe('plugin-access-token');
+      expect(families.plugin?.refreshToken).toBe('plugin-refresh-token');
+      expect(families.plugin?.clientId).toBe('unity-mcp-cli');
+
+      // v1 compat mirror: top-level token fields mirror the PLUGIN family (old readers key on them).
+      expect(document?.accessToken).toBe('plugin-access-token');
+      expect(document?.refreshToken).toBe('plugin-refresh-token');
+
+      // The exchange presented the fresh agent access token + our own client id (RFC 8693 / O2).
+      expect(exchangeCalls).toHaveLength(1);
+      expect(exchangeCalls[0].subjectToken).toBe('agent-access-token');
+      expect(exchangeCalls[0].clientId).toBe('unity-mcp-cli');
 
       // The login must NOT write the legacy per-project cloudToken config.
       expect(
@@ -53,26 +138,40 @@ describe('runCloudLogin', () => {
     }
   });
 
-  it('passes the unity-mcp-cli client id + mcp:plugin scope to the device flow (T1)', async () => {
+  it('F1 partial: a failed exchange leaves the committed agent family and the derivation retry completes the store', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
     try {
-      const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'));
-      let seenClientId: string | undefined;
-      let seenScope: string | undefined;
+      const store = tempStore(tmp);
+      // First exchange attempt (inside commitAgentLogin) fails; the retry loop's next attempt succeeds.
+      const token = await runCloudLogin(store, {
+        login: loginDouble(),
+        exchangeClient: exchangeDouble({ failures: 1 }),
+        sleep: noSleep,
+      });
 
-      const login = async (opts: {
-        clientId: string;
-        scope?: string;
-      }): Promise<DeviceLoginResult> => {
-        seenClientId = opts.clientId;
-        seenScope = opts.scope;
-        return { ok: true, credentials: { accessToken: 'tok', serverTarget: 'https://ai-game.dev' } };
-      };
+      expect(token).toBe('plugin-access-token');
+      const families = effectiveFamilies(store.read() ?? {});
+      expect(families.agent?.accessToken).toBe('agent-access-token');
+      expect(families.plugin?.accessToken).toBe('plugin-access-token');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 
-      await runCloudLogin(store, { login });
+  it('F1 partial, derivation never succeeds: returns null but the agent family stays committed', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const store = tempStore(tmp);
+      const token = await runCloudLogin(store, {
+        login: loginDouble(),
+        exchangeClient: exchangeDouble({ failures: 99 }),
+        sleep: noSleep,
+      });
 
-      expect(seenClientId).toBe('unity-mcp-cli');
-      expect(seenScope).toBe('mcp:plugin');
+      expect(token).toBeNull();
+      const families = effectiveFamilies(store.read() ?? {});
+      expect(families.agent?.accessToken).toBe('agent-access-token');
+      expect(families.plugin).toBeUndefined();
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
@@ -81,17 +180,193 @@ describe('runCloudLogin', () => {
   it('returns null and does not write the store on a failed sign-in', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
     try {
-      const store = new MachineCredentialStore(path.join(tmp, '.ai-game-dev'));
+      const store = tempStore(tmp);
       const login = async (): Promise<DeviceLoginResult> => ({
         ok: false,
         reason: 'denied',
         message: 'Authorization was denied.',
       });
 
-      const token = await runCloudLogin(store, { login });
+      const token = await runCloudLogin(store, { login, exchangeClient: exchangeDouble() });
 
       expect(token).toBeNull();
       expect(store.exists).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runCloudLogin — tools-only (O10/F10)', () => {
+  it('mints at mcp:plugin scope', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const capture: { scope?: string; clientId?: string } = {};
+      await runCloudLogin(tempStore(tmp), {
+        toolsOnly: true,
+        login: loginDouble({ ...AGENT_MINT, accessToken: 'plugin-mint' }, capture),
+        exchangeClient: exchangeDouble(),
+      });
+      expect(capture.scope).toBe('mcp:plugin');
+      expect(capture.clientId).toBe('unity-mcp-cli');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('produces a PLUGIN-ONLY store: no agent family, no token exchange (App pickup impossible by design)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const store = tempStore(tmp);
+      const exchangeCalls: TokenExchangeRequest[] = [];
+
+      const token = await runCloudLogin(store, {
+        toolsOnly: true,
+        login: loginDouble({
+          accessToken: 'tools-only-access',
+          refreshToken: 'tools-only-refresh',
+          expiresAt: '2030-01-01T00:00:00.000Z',
+          serverTarget: 'https://ai-game.dev',
+          subject: 'acct-1',
+        }),
+        exchangeClient: exchangeDouble({ calls: exchangeCalls }),
+      });
+
+      expect(token).toBe('tools-only-access');
+
+      const document = store.read();
+      const families = effectiveFamilies(document ?? {});
+      // F10: the plugin family is the ONLY family — a tools-only machine holds no agent credential.
+      expect(families.plugin?.accessToken).toBe('tools-only-access');
+      expect(families.plugin?.clientId).toBe('unity-mcp-cli');
+      expect(families.agent).toBeUndefined();
+      expect(families.legacy).toBeUndefined();
+      // The RFC 8693 exchange is for deriving a plugin family FROM an agent mint — it must not run.
+      expect(exchangeCalls).toHaveLength(0);
+      // v1 mirror still points old readers at the plugin credential.
+      expect(document?.accessToken).toBe('tools-only-access');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('runCloudLogin — account-switch guard (D6/F7)', () => {
+  function seedStoreAs(store: MachineCredentialStore, subject: string): void {
+    store.write({
+      version: 2,
+      serverTarget: 'https://ai-game.dev',
+      subject,
+      families: {
+        agent: {
+          accessToken: `${subject}-agent-access`,
+          refreshToken: `${subject}-agent-refresh`,
+          expiresAt: '2030-01-01T00:00:00.000Z',
+          clientId: 'unity-mcp-cli',
+          scope: 'mcp:agent',
+        },
+        plugin: {
+          accessToken: `${subject}-plugin-access`,
+          refreshToken: `${subject}-plugin-refresh`,
+          expiresAt: '2030-01-01T00:00:00.000Z',
+          clientId: 'unity-mcp-cli',
+          scope: 'mcp:plugin',
+        },
+      },
+    });
+  }
+
+  const MINT_AS_B = { ...AGENT_MINT, subject: 'acct-B' };
+
+  it('without --yes (non-interactive): a subject mismatch is DECLINED — store untouched, just-minted family revoked', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const store = tempStore(tmp);
+      seedStoreAs(store, 'acct-A');
+      const revoked: Array<{ token: string; clientId: string }> = [];
+
+      const token = await runCloudLogin(store, {
+        login: loginDouble(MINT_AS_B),
+        exchangeClient: exchangeDouble(),
+        // No confirmAccountSwitch injected and no assumeYes: the default confirm runs, and with
+        // a non-TTY stdin (vitest) it fails CLOSED — the F7 `--yes` gate.
+        revokeToken: (tok, clientId) => {
+          revoked.push({ token: tok, clientId });
+          return true;
+        },
+        sleep: noSleep,
+      });
+
+      expect(token).toBeNull();
+
+      // Store untouched: still account A's credential set.
+      const document = store.read();
+      expect(document?.subject).toBe('acct-A');
+      const families = effectiveFamilies(document ?? {});
+      expect(families.agent?.accessToken).toBe('acct-A-agent-access');
+      expect(families.plugin?.accessToken).toBe('acct-A-plugin-access');
+
+      // The just-minted B family was revoked best-effort (no orphan device row).
+      expect(revoked.some((r) => r.token === MINT_AS_B.refreshToken)).toBe(true);
+      // Account A's families were NOT revoked.
+      expect(revoked.some((r) => r.token === 'acct-A-agent-refresh')).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('with --yes: the switch is confirmed — store replaced with account B, old families revoked best-effort', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const store = tempStore(tmp);
+      seedStoreAs(store, 'acct-A');
+      const revoked: Array<{ token: string; clientId: string }> = [];
+
+      const token = await runCloudLogin(store, {
+        assumeYes: true,
+        login: loginDouble(MINT_AS_B),
+        exchangeClient: exchangeDouble(),
+        revokeToken: (tok, clientId) => {
+          revoked.push({ token: tok, clientId });
+          return true;
+        },
+        sleep: noSleep,
+      });
+
+      expect(token).toBe('plugin-access-token');
+
+      const document = store.read();
+      expect(document?.subject).toBe('acct-B');
+      const families = effectiveFamilies(document ?? {});
+      expect(families.agent?.accessToken).toBe('agent-access-token');
+      expect(families.plugin?.accessToken).toBe('plugin-access-token');
+      // Account A's material is gone from the store (single-account store, D6)...
+      expect(JSON.stringify(document)).not.toContain('acct-A-');
+      // ...and its families were revoked best-effort.
+      expect(revoked.some((r) => r.token === 'acct-A-agent-refresh')).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('matching subjects proceed without any confirmation', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloudlogin-'));
+    try {
+      const store = tempStore(tmp);
+      seedStoreAs(store, 'acct-1'); // same subject as AGENT_MINT
+
+      const token = await runCloudLogin(store, {
+        login: loginDouble(),
+        exchangeClient: exchangeDouble(),
+        // No revokeToken / confirm needed: same subject ⇒ plain merge, no guard prompt.
+        confirmAccountSwitch: () => {
+          throw new Error('confirm must not be called for a matching subject');
+        },
+        sleep: noSleep,
+      });
+
+      expect(token).toBe('plugin-access-token');
+      expect(store.read()?.subject).toBe('acct-1');
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/cli/tests/lib-run-tool.test.ts
+++ b/cli/tests/lib-run-tool.test.ts
@@ -461,6 +461,83 @@ describe('runTool — Cloud mode auth', () => {
     const headers = spy.calls[0].init?.headers as Record<string, string>;
     expect(headers['Authorization']).toBe('Bearer explicit-token');
   });
+
+  it('REACTIVELY refreshes on a 401 against a machine-store Bearer and retries once (04 §3 rule 1)', async () => {
+    const projectPath = mkUnityProject();
+    writeCloudConfig(projectPath);
+    let refreshCalls = 0;
+    const spy = makeFetchSpy(async (_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      return headers['Authorization'] === 'Bearer rotated-token'
+        ? jsonResponse({ status: 'success', content: [] })
+        : jsonResponse({ error: 'expired' }, 401, 'Unauthorized');
+    });
+
+    const result = await runTool({
+      toolName: 'ping',
+      unityProjectPath: projectPath,
+      readCloudToken: () => 'revoked-token',
+      refreshCloudToken: () => {
+        refreshCalls++;
+        return 'rotated-token';
+      },
+      fetchImpl: spy.fetch,
+    });
+
+    expect(result.kind).toBe('success');
+    expect(refreshCalls).toBe(1);
+    expect(spy.calls).toHaveLength(2);
+    const retryHeaders = spy.calls[1].init?.headers as Record<string, string>;
+    expect(retryHeaders['Authorization']).toBe('Bearer rotated-token');
+  });
+
+  it('a dead family (reactive refresh returns undefined) surfaces the original 401 — exactly one refresh attempt', async () => {
+    const projectPath = mkUnityProject();
+    writeCloudConfig(projectPath);
+    let refreshCalls = 0;
+    const spy = makeFetchSpy(async () => jsonResponse({ error: 'expired' }, 401, 'Unauthorized'));
+
+    const result = await runTool({
+      toolName: 'ping',
+      unityProjectPath: projectPath,
+      readCloudToken: () => 'revoked-token',
+      refreshCloudToken: () => {
+        refreshCalls++;
+        return undefined;
+      },
+      fetchImpl: spy.fetch,
+    });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('expected failure kind');
+    expect(result.reason).toBe('http-error');
+    expect(result.httpStatus).toBe(401);
+    expect(refreshCalls).toBe(1);
+    expect(spy.calls).toHaveLength(1);
+  });
+
+  it('never reactively refreshes an explicit --token override on 401', async () => {
+    const projectPath = mkUnityProject();
+    writeCloudConfig(projectPath);
+    let refreshCalls = 0;
+    const spy = makeFetchSpy(async () => jsonResponse({ error: 'nope' }, 401, 'Unauthorized'));
+
+    const result = await runTool({
+      toolName: 'ping',
+      unityProjectPath: projectPath,
+      token: 'explicit-token',
+      readCloudToken: () => undefined,
+      refreshCloudToken: () => {
+        refreshCalls++;
+        return 'should-never-be-used';
+      },
+      fetchImpl: spy.fetch,
+    });
+
+    expect(result.kind).toBe('failure');
+    expect(refreshCalls).toBe(0);
+    expect(spy.calls).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/cli/tests/login.test.ts
+++ b/cli/tests/login.test.ts
@@ -16,12 +16,16 @@ import { runCliAsync } from './helpers/cli.js';
 // ---------------------------------------------------------------------------
 
 describe('login command', () => {
-  it('shows help with --help (documents --force and --project)', async () => {
+  it('shows help with --help (documents --force, --project, --tools-only and --yes)', async () => {
     const { stdout, exitCode } = await runCliAsync(['login', '--help']);
     expect(exitCode).toBe(0);
     expect(stdout).toContain('login');
     expect(stdout).toContain('--force');
     expect(stdout).toContain('--project');
+    // O10 ruling: the CI/automation flag is named exactly --tools-only.
+    expect(stdout).toContain('--tools-only');
+    // F7: the account-switch prompt is --yes-gated.
+    expect(stdout).toContain('--yes');
   });
 
   it('reports "Already signed in" when a --project store credential exists (offline short-circuit)', async () => {

--- a/cli/tests/no-local-credential-store.test.ts
+++ b/cli/tests/no-local-credential-store.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Ivan Murzak. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * STRUCTURAL GATE (task d2 DoD): "No local credential-store code remains in the CLI beyond the
+ * explicit `--project` override path."
+ *
+ * The credential store's serializer lives ONCE, in `@baizor/gamedev-cli-core` (store v2, DPAPI /
+ * 0600, atomic writes, cross-process lock). This gate fails the build if store-serializer code —
+ * hand-built store paths, DPAPI plumbing, or the raw `read()?.accessToken` token grab that d2
+ * deleted — reappears anywhere in `src/` outside the two allowlisted files:
+ *
+ *  - `commands/login.ts` — the explicit `--project` override (it composes the project-local store
+ *    path and its user-facing help mentions the store location);
+ *  - `utils/machine-credentials.ts` — the thin cli-core re-export (the CLI's stable import path).
+ *
+ * Comments are stripped before matching so documentation may still NAME the store file; string
+ * literals and code cannot.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = path.resolve(__dirname, '..', 'src');
+
+const ALLOWLIST = new Set<string>([
+  path.join('commands', 'login.ts'),
+  path.join('utils', 'machine-credentials.ts'),
+]);
+
+/** Store-serializer smells. Applied to comment-stripped source of every non-allowlisted file. */
+const FORBIDDEN_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: 'store file name literal (credentials.json)', pattern: /credentials\.json/i },
+  { name: 'store directory literal (.ai-game-dev)', pattern: /\.ai-game-dev/ },
+  {
+    name: 'DPAPI plumbing (belongs to cli-core only)',
+    pattern: /CryptProtectData|CryptUnprotectData|ProtectedData|DPAPI/i,
+  },
+  {
+    name: 'raw store token read (read()?.accessToken — the pre-d2 defect)',
+    pattern: /\.read\(\)\s*[?!]?\.\s*accessToken/,
+  },
+];
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listSourceFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/** Strip line comments and block comments (string-aware enough for this gate). */
+function stripComments(source: string): string {
+  // Remove block comments first (non-greedy, across lines), then line comments. The `[^:]` guard
+  // keeps `https://…` URLs inside string literals intact.
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+describe('structural gate — no local credential-store code outside the --project override', () => {
+  it('the allowlisted files still exist (a rename must revisit this gate, not silently void it)', () => {
+    for (const rel of ALLOWLIST) {
+      expect(fs.existsSync(path.join(SRC_DIR, rel)), `${rel} missing`).toBe(true);
+    }
+  });
+
+  it('no src file outside the allowlist contains store-serializer code', () => {
+    const violations: string[] = [];
+
+    for (const file of listSourceFiles(SRC_DIR)) {
+      const rel = path.relative(SRC_DIR, file);
+      if (ALLOWLIST.has(rel)) continue;
+
+      const code = stripComments(fs.readFileSync(file, 'utf-8'));
+      for (const { name, pattern } of FORBIDDEN_PATTERNS) {
+        if (pattern.test(code)) {
+          violations.push(`${rel}: ${name}`);
+        }
+      }
+    }
+
+    expect(violations, `local credential-store code detected:\n  ${violations.join('\n  ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('the gate patterns can actually match (self-test: the pre-d2 defect shape trips the raw-read pattern)', () => {
+    // Guard the gate against pattern rot: the exact shape d2 deleted from config.ts must match.
+    const byName = (fragment: string): RegExp => {
+      const entry = FORBIDDEN_PATTERNS.find((p) => p.name.includes(fragment));
+      if (!entry) throw new Error(`gate pattern missing: ${fragment}`);
+      return entry.pattern;
+    };
+    const preD2Defect = 'return new MachineCredentialStore().read()?.accessToken ?? undefined;';
+    expect(byName('raw store token read').test(preD2Defect)).toBe(true);
+    expect(byName('store file name').test("path.join(base, 'credentials.json')")).toBe(true);
+    expect(byName('store directory').test("path.join(home, '.ai-game-dev')")).toBe(true);
+  });
+});

--- a/cli/tests/run-tool.test.ts
+++ b/cli/tests/run-tool.test.ts
@@ -6,12 +6,15 @@ import * as os from 'os';
 import { fileURLToPath } from 'url';
 import {
   resolveConnectionFromConfig,
-  readMachineStoreCloudToken,
   isCloudMode,
   CLOUD_SERVER_URL,
   type UnityConnectionConfig,
 } from '../src/utils/config.js';
 import { resolveConnection } from '../src/utils/connection.js';
+import {
+  readCloudAccessToken,
+  resetCloudCredentialProviderForTests,
+} from '../src/utils/cloud-credentials.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
@@ -53,20 +56,26 @@ function loggedOutEnv(): { env: NodeJS.ProcessEnv; cleanup: () => void } {
 
 // ── resolveConnectionFromConfig unit tests ────────────────────────────────────
 
+// The Cloud-mode credential seam is REQUIRED (no built-in default): production callers pass
+// cli-core's refreshing `MachineCredentialProvider` via `readCloudAccessToken`; these unit tests
+// pass deterministic values. `noCloudToken` stands in for Custom-mode cases where the seam must
+// never be consulted.
+const noCloudToken = (): string | undefined => undefined;
+
 describe('resolveConnectionFromConfig', () => {
-  it('returns host and token in Custom mode', () => {
+  it('returns host and token in Custom mode', async () => {
     const config: UnityConnectionConfig = {
       connectionMode: 'Custom',
       host: 'http://localhost:55000',
       token: 'custom-secret',
       cloudToken: 'cloud-secret',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = await resolveConnectionFromConfig(config, { readCloudToken: noCloudToken });
     expect(result.url).toBe('http://localhost:55000');
     expect(result.token).toBe('custom-secret');
   });
 
-  it('returns hardcoded cloud URL and the machine-store credential in Cloud mode', () => {
+  it('returns hardcoded cloud URL and the machine-store credential in Cloud mode', async () => {
     // Post-T9 the plugin no longer writes `cloudToken`; the Cloud-mode Bearer now comes from the
     // shared machine credential store, NOT the on-disk `cloudToken` (defect E / D11).
     const config: UnityConnectionConfig = {
@@ -75,93 +84,107 @@ describe('resolveConnectionFromConfig', () => {
       token: 'custom-secret',
       cloudToken: 'cloud-secret',
     };
-    const result = resolveConnectionFromConfig(config, { readCloudToken: () => 'store-bearer-token' });
+    const result = await resolveConnectionFromConfig(config, {
+      readCloudToken: () => 'store-bearer-token',
+    });
     expect(result.url).toBe(CLOUD_SERVER_URL);
     expect(result.token).toBe('store-bearer-token');
   });
 
-  it('does NOT read cloudToken in Cloud mode (store empty ⇒ undefined token)', () => {
+  it('supports an ASYNC readCloudToken (the provider seam is awaited)', async () => {
+    const config: UnityConnectionConfig = { connectionMode: 'Cloud' };
+    const result = await resolveConnectionFromConfig(config, {
+      readCloudToken: async () => 'async-bearer',
+    });
+    expect(result.token).toBe('async-bearer');
+  });
+
+  it('does NOT read cloudToken in Cloud mode (store empty ⇒ undefined token)', async () => {
     // The dead `cloudToken` read is gone: even with a `cloudToken` present in the config, an empty
     // machine store resolves to no token (which the caller turns into a "not logged in" error).
     const config: UnityConnectionConfig = {
       connectionMode: 'Cloud',
       cloudToken: 'cloud-secret',
     };
-    const result = resolveConnectionFromConfig(config, { readCloudToken: () => undefined });
+    const result = await resolveConnectionFromConfig(config, { readCloudToken: noCloudToken });
     expect(result.url).toBe(CLOUD_SERVER_URL);
     expect(result.token).toBeUndefined();
   });
 
-  it('defaults to Custom mode when connectionMode is undefined', () => {
+  it('defaults to Custom mode when connectionMode is undefined', async () => {
     const config: UnityConnectionConfig = {
       host: 'http://localhost:55000',
       token: 'my-token',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = await resolveConnectionFromConfig(config, { readCloudToken: noCloudToken });
     expect(result.url).toBe('http://localhost:55000');
     expect(result.token).toBe('my-token');
   });
 
-  it('returns undefined url and token when fields are missing in Custom mode', () => {
+  it('returns undefined url and token when fields are missing in Custom mode', async () => {
     const config: UnityConnectionConfig = {
       connectionMode: 'Custom',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = await resolveConnectionFromConfig(config, { readCloudToken: noCloudToken });
     expect(result.url).toBeUndefined();
     expect(result.token).toBeUndefined();
   });
 
-  it('returns hardcoded cloud URL and undefined token when not logged in (Cloud mode)', () => {
+  it('returns hardcoded cloud URL and undefined token when not logged in (Cloud mode)', async () => {
     const config: UnityConnectionConfig = {
       connectionMode: 'Cloud',
     };
-    const result = resolveConnectionFromConfig(config, { readCloudToken: () => undefined });
+    const result = await resolveConnectionFromConfig(config, { readCloudToken: noCloudToken });
     expect(result.url).toBe(CLOUD_SERVER_URL);
     expect(result.token).toBeUndefined();
   });
 
-  it('does not cross-contaminate Custom token with Cloud token', () => {
+  it('does not cross-contaminate Custom token with Cloud token', async () => {
     const config: UnityConnectionConfig = {
       connectionMode: 'Custom',
       token: 'custom-only',
       cloudToken: 'cloud-only',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = await resolveConnectionFromConfig(config, { readCloudToken: noCloudToken });
     expect(result.token).toBe('custom-only');
   });
 
-  it('ignores both config.token and config.cloudToken in Cloud mode (uses the machine store)', () => {
+  it('ignores both config.token and config.cloudToken in Cloud mode (uses the machine store)', async () => {
     const config: UnityConnectionConfig = {
       connectionMode: 'Cloud',
       token: 'custom-only',
       cloudToken: 'cloud-only',
     };
-    const result = resolveConnectionFromConfig(config, { readCloudToken: () => 'store-bearer' });
+    const result = await resolveConnectionFromConfig(config, {
+      readCloudToken: () => 'store-bearer',
+    });
     expect(result.token).toBe('store-bearer');
   });
 
   // Legacy integer enum values (written by older Unity plugin versions)
 
-  it('handles legacy integer 0 as Custom mode', () => {
+  it('handles legacy integer 0 as Custom mode', async () => {
     const config: UnityConnectionConfig = {
       connectionMode: 0,
       host: 'http://localhost:55000',
       token: 'custom-secret',
       cloudToken: 'cloud-secret',
     };
-    const result = resolveConnectionFromConfig(config);
+    const result = await resolveConnectionFromConfig(config, { readCloudToken: noCloudToken });
     expect(result.url).toBe('http://localhost:55000');
     expect(result.token).toBe('custom-secret');
   });
 
-  it('handles legacy integer 1 as Cloud mode with the machine-store credential', () => {
+  it('handles legacy integer 1 as Cloud mode with the machine-store credential', async () => {
     const config: UnityConnectionConfig = {
       connectionMode: 1,
       host: 'http://localhost:55000',
       token: 'custom-secret',
       cloudToken: 'cloud-secret',
     };
-    const result = resolveConnectionFromConfig(config, { readCloudToken: () => 'store-bearer-token' });
+    const result = await resolveConnectionFromConfig(config, {
+      readCloudToken: () => 'store-bearer-token',
+    });
     expect(result.url).toBe(CLOUD_SERVER_URL);
     expect(result.token).toBe('store-bearer-token');
   });
@@ -169,7 +192,7 @@ describe('resolveConnectionFromConfig', () => {
 
 // ── machine-store credential wiring (default, un-injected path) ───────────────
 
-describe('readMachineStoreCloudToken', () => {
+describe('readCloudAccessToken (the provider-backed default)', () => {
   let savedHome: string | undefined;
   let savedUserProfile: string | undefined;
   let home: string;
@@ -181,6 +204,7 @@ describe('readMachineStoreCloudToken', () => {
     home = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-store-'));
     process.env.HOME = home;
     process.env.USERPROFILE = home;
+    resetCloudCredentialProviderForTests();
   });
 
   afterEach(() => {
@@ -188,24 +212,36 @@ describe('readMachineStoreCloudToken', () => {
     else process.env.HOME = savedHome;
     if (savedUserProfile === undefined) delete process.env.USERPROFILE;
     else process.env.USERPROFILE = savedUserProfile;
+    resetCloudCredentialProviderForTests();
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  it('returns undefined when the machine store holds no credential', () => {
-    expect(readMachineStoreCloudToken()).toBeUndefined();
+  it('resolves undefined when the machine store holds no credential (login required)', async () => {
+    await expect(readCloudAccessToken()).resolves.toBeUndefined();
   });
 
-  it('is the default Cloud-mode token source for resolveConnectionFromConfig (empty store ⇒ undefined)', () => {
-    // No injected readCloudToken ⇒ the resolver falls through to the real (here empty) machine store.
-    const result = resolveConnectionFromConfig({ connectionMode: 'Cloud', cloudToken: 'ignored' });
-    expect(result.url).toBe(CLOUD_SERVER_URL);
-    expect(result.token).toBeUndefined();
+  it('is the Cloud-mode token source for resolveConnection (empty store ⇒ cloudAuthMissing)', async () => {
+    // No injected readCloudToken ⇒ resolveConnection falls through to the real provider seam
+    // (here: an empty machine store under the redirected HOME).
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-cloud-default-'));
+    try {
+      fs.mkdirSync(path.join(projectDir, 'UserSettings'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, 'UserSettings', 'AI-Game-Developer-Config.json'),
+        JSON.stringify({ connectionMode: 'Cloud', cloudToken: 'ignored' }),
+      );
+      const result = await resolveConnection(projectDir, {});
+      expect(result.url).toBe(CLOUD_SERVER_URL);
+      expect(result.token).toBeUndefined();
+      expect(result.cloudAuthMissing).toBe(true);
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 });
-
 // ── resolveConnection cloud-auth-missing signal (feeds the run-tool guard) ─────
 
-describe('resolveConnection — Cloud auth missing', () => {
+describe('resolveConnection — Cloud auth missing', async () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -225,31 +261,31 @@ describe('resolveConnection — Cloud auth missing', () => {
     );
   }
 
-  it('flags cloudAuthMissing when Cloud mode has no machine-store credential', () => {
+  it('flags cloudAuthMissing when Cloud mode has no machine-store credential', async () => {
     writeCloudConfig();
-    const result = resolveConnection(tmpDir, {}, { readCloudToken: () => undefined });
+    const result = await resolveConnection(tmpDir, {}, { readCloudToken: () => undefined });
     expect(result.url).toBe(CLOUD_SERVER_URL);
     expect(result.token).toBeUndefined();
     expect(result.cloudAuthMissing).toBe(true);
   });
 
-  it('does not flag cloudAuthMissing when the store has a credential', () => {
+  it('does not flag cloudAuthMissing when the store has a credential', async () => {
     writeCloudConfig();
-    const result = resolveConnection(tmpDir, {}, { readCloudToken: () => 'store-bearer' });
+    const result = await resolveConnection(tmpDir, {}, { readCloudToken: () => 'store-bearer' });
     expect(result.token).toBe('store-bearer');
     expect(result.cloudAuthMissing).toBe(false);
   });
 
-  it('does not flag cloudAuthMissing when --token overrides in Cloud mode', () => {
+  it('does not flag cloudAuthMissing when --token overrides in Cloud mode', async () => {
     writeCloudConfig();
-    const result = resolveConnection(tmpDir, { token: 'explicit' }, { readCloudToken: () => undefined });
+    const result = await resolveConnection(tmpDir, { token: 'explicit' }, { readCloudToken: () => undefined });
     expect(result.token).toBe('explicit');
     expect(result.cloudAuthMissing).toBe(false);
   });
 
-  it('does not flag cloudAuthMissing when --url overrides the endpoint in Cloud mode', () => {
+  it('does not flag cloudAuthMissing when --url overrides the endpoint in Cloud mode', async () => {
     writeCloudConfig();
-    const result = resolveConnection(
+    const result = await resolveConnection(
       tmpDir,
       { url: 'http://localhost:9999' },
       { readCloudToken: () => undefined },
@@ -258,12 +294,12 @@ describe('resolveConnection — Cloud auth missing', () => {
     expect(result.cloudAuthMissing).toBe(false);
   });
 
-  it('never flags cloudAuthMissing in Custom mode (self-host / derived-port)', () => {
+  it('never flags cloudAuthMissing in Custom mode (self-host / derived-port)', async () => {
     fs.writeFileSync(
       path.join(tmpDir, 'UserSettings', 'AI-Game-Developer-Config.json'),
       JSON.stringify({ connectionMode: 'Custom', host: 'http://localhost:55000' }),
     );
-    const result = resolveConnection(tmpDir, {}, { readCloudToken: () => undefined });
+    const result = await resolveConnection(tmpDir, {}, { readCloudToken: () => undefined });
     expect(result.cloudAuthMissing).toBe(false);
   });
 });


### PR DESCRIPTION
Taskflow `2026-08-14-unified-machine-auth`, task **d2-unity-cli-adoption** (builds on d1, `15ceb4e9`).

## What

`unity-mcp-cli` stops reading `accessToken` raw off disk with nobody refreshing it (the pre-d2 `config.ts` defect) and adopts `@baizor/gamedev-cli-core` **0.4.0** (the c4 release; `npm ls` resolves `@baizor/gamedev-cli-core@0.4.0`):

- **Provider everywhere.** New seam `cli/src/utils/cloud-credentials.ts` wraps cli-core's `MachineCredentialProvider` (proactive refresh inside the 60 s skew + reactive refresh on a hub 401, both under the cross-process lock). Every Cloud-mode Bearer — `run-tool`/`run-system-tool` (CLI + lib), `status`, `wait-for-ready`, `setup-skills` — resolves through it. `resolveConnectionFromConfig`'s `readCloudToken` seam is now **required** (no fail-open default) and async.
- **Agent-scope login with derivation.** `login` mints at `mcp:agent` and commits via cli-core's two-lock-hold sequence (`commitAgentLogin`): agent family under hold 1 → RFC 8693 exchange (lock released) → plugin family + v1 mirror under hold 2. A failed exchange leaves the committed agent family (`partial`) and the derivation leg is retried alone — in-run with backoff, and again on a later plain `login` run (which detects the agent-without-plugin state and calls `derivePluginFamily` only).
- **`--tools-only`** (O10 exact flag name; F10/J3): mints `mcp:plugin` and commits via `commitToolsOnlyLogin` — plugin family only, no agent family, App pickup impossible by design.
- **Account-switch guard (D6/F7)**, `--yes`-gated: subject mismatch prompts (TTY), auto-confirms with `--yes`, and **fails closed** non-interactively without it; decline revokes the just-minted family best-effort and leaves the store untouched. Also wired into `install-plugin --enroll` (0.4.0's `runEnroll` returns the guard union).
- **Reactive 401 retry** in lib `runTool`/`runSystemTool` and the CLI run-tool commands: exactly one refresh + retry per invocation, never for an explicit `--token`/`--url` override.
- **`login --project`** (project-local store override) untouched (W4 disposition is d4).
- Client id remains `unity-mcp-cli` from cli-core's `unityAdapter`.

## DoD evidence

- **Works through token expiry with no re-login** — `tests/cloud-credential-provider.test.ts` runs a real HTTP fake AS on an ephemeral `127.0.0.1` port: expired plugin family in the store → `readCloudAccessToken` returns the freshly minted token, exactly one `grant_type=refresh_token` call presenting the family's stored `client_id=unity-mcp-cli` with `scope`/`resource` **omitted entirely** (04 §3 r2/r3), rotation persisted, zero device-authorization traffic.
- **`--tools-only` produces a plugin-only store** — asserted: `families.plugin` present, `families.agent`/`families.legacy` undefined, RFC 8693 exchange never called.
- **Subject-mismatch prompts** — decline path (non-interactive, no `--yes`): store untouched, just-minted family revoked; confirm path (`--yes`): store replaced, old families revoked best-effort.
- **No local credential-store code beyond `--project`** — structural gate `tests/no-local-credential-store.test.ts` (comment-stripped scan of `src/` for `credentials.json` / `.ai-game-dev` literals, DPAPI plumbing, and the raw `read()?.accessToken` shape; allowlist: `commands/login.ts`, `utils/machine-credentials.ts` re-export).
- Full suite: **34 files, 542 passed, 2 skipped (pre-existing)** on the local run; CI legs node 20 + 22.

## Mandated plants (G-SEC-1) — each RED-verified, then reverted

| # | Plant | RED evidence |
|---|---|---|
| 1 | Restored the raw `accessToken` read in `readCloudAccessToken` (provider bypass) | `serves a FRESH token through expiry…` → `AssertionError: expected 'expired-access-token' to be 'fresh-access-token'`; the structural gate ALSO went red: `utils\cloud-credentials.ts: raw store token read (read()?.accessToken — the pre-d2 defect)` |
| 2 | `--tools-only` routed through the AGENT commit path (mints agent family + exchange) | `produces a PLUGIN-ONLY store…` → `AssertionError: expected 'plugin-access-token' to be 'tools-only-access'` (the exchange-derived credential surfaced where the direct plugin mint must be; `families.agent` no longer undefined) |
| 3 | Removed the `--yes` gate (`if (assumeYes)` → `if (true)`: every mismatch auto-confirms) | `without --yes (non-interactive): a subject mismatch is DECLINED…` → `AssertionError: expected 'plugin-access-token' to be null` (login proceeded instead of failing closed) |
| 4 | Re-added `src/utils/local-credential-store.ts` — a hand-rolled serializer stub | Gate RED: `local credential-store code detected: utils\local-credential-store.ts: store file name literal (credentials.json); utils\local-credential-store.ts: store directory literal (.ai-game-dev)` |

All four reverted; final tree is the green state (build + 542/542).

## Notes for review

- `resolveConnection` (utils + lib) went async; all call sites were already inside async actions.
- `readCloudAccessToken` degrades `LoginRequiredError` / store-unreadable / lock-busy to `undefined` (callers keep the actionable "not logged in" error; precise reason under `--verbose`, never token bytes).
- cli-core 0.4.0 also changed `RunEnrollResult` to a guard union — `install-plugin --enroll` now narrows it and gained `--yes`.
- Release rides d3 (CLIs release only as the final leg of the plugin cascade); no version bump here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015H4mErUXFNQrcg6nh4W1Jy