### PR TITLE
feat(cli): Unity extension rail — installExtension + extensions.catalog.json + build-failing parity tests (W1.7)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json
@@ -1,0 +1,151 @@
+{
+  "extensions": [
+    {
+      "name": "Animation",
+      "description": "AI-driven animation control and playback tools.",
+      "packageId": "com.ivanmurzak.unity.mcp.animation",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-Animation.git",
+      "tools": [
+        { "name": "animation-create", "description": "Create AnimationClip assets with keyframes" },
+        { "name": "animation-get-data", "description": "Inspect clip curves, events, and properties" },
+        { "name": "animation-modify", "description": "Edit curves, events, and settings on a clip" },
+        { "name": "animator-create", "description": "Create AnimatorController assets" },
+        { "name": "animator-get-data", "description": "Inspect controller layers, states, and parameters" },
+        { "name": "animator-modify", "description": "Edit parameters, states, and transitions" }
+      ]
+    },
+    {
+      "name": "Cinemachine",
+      "description": "AI-assisted Cinemachine camera setup and configuration tools.",
+      "packageId": "com.ivanmurzak.unity.mcp.cinemachine",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-Cinemachine.git",
+      "tools": [
+        { "name": "cinemachine-camera-create", "description": "Create a CinemachineCamera in the scene" },
+        { "name": "cinemachine-set-targets", "description": "Set the Follow and LookAt targets" },
+        { "name": "cinemachine-set-lens", "description": "Configure FOV, clip planes, and dutch" },
+        { "name": "cinemachine-set-body", "description": "Set the position-control component (Follow/Orbital/...)" },
+        { "name": "cinemachine-set-noise", "description": "Add camera shake via Perlin noise" }
+      ]
+    },
+    {
+      "name": "InputSystem",
+      "description": "AI-assisted Unity Input System authoring: InputActionAssets, maps, actions, bindings, and control schemes.",
+      "packageId": "com.ivanmurzak.unity.mcp.inputsystem",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-InputSystem.git",
+      "tools": [
+        { "name": "inputsystem-asset-create", "description": "Create a new .inputactions InputActionAsset" },
+        { "name": "inputsystem-actionmap-add", "description": "Add an ActionMap to the asset" },
+        { "name": "inputsystem-action-add", "description": "Add an Action (type + expectedControlType)" },
+        { "name": "inputsystem-binding-add", "description": "Add a binding path to an Action" },
+        { "name": "inputsystem-binding-composite-add", "description": "Add a composite binding (2DVector/1DAxis)" },
+        { "name": "inputsystem-controlscheme-add", "description": "Add a control scheme with device requirements" },
+        { "name": "inputsystem-get", "description": "Read the asset's maps, actions, and bindings" }
+      ]
+    },
+    {
+      "name": "Navigation",
+      "description": "AI-driven NavMesh navigation: surfaces, baking, agents, and links.",
+      "packageId": "com.ivanmurzak.unity.mcp.navigation",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-Navigation.git",
+      "tools": [
+        { "name": "navigation-surface-add", "description": "Add and configure a NavMeshSurface" },
+        { "name": "navigation-set-bake-settings", "description": "Set agent radius/height/slope/step and voxel size" },
+        { "name": "navigation-surface-bake", "description": "Bake or clear a NavMeshSurface" },
+        { "name": "navigation-modifier-add", "description": "Add a NavMeshModifier (override area / ignore)" },
+        { "name": "navigation-modifier-volume-add", "description": "Add a NavMeshModifierVolume" },
+        { "name": "navigation-link-add", "description": "Add a NavMeshLink between two points" },
+        { "name": "navigation-agent-add", "description": "Add and configure a NavMeshAgent" },
+        { "name": "navigation-agent-set-destination", "description": "Set a NavMeshAgent's destination" },
+        { "name": "navigation-list", "description": "List NavMeshSurfaces and NavMeshAgents" },
+        { "name": "navigation-get", "description": "Serialize any NavMesh component" },
+        { "name": "navigation-modify", "description": "Modify any NavMesh component via ReflectorNet" }
+      ]
+    },
+    {
+      "name": "ParticleSystem",
+      "description": "AI-powered particle system creation and control tools.",
+      "packageId": "com.ivanmurzak.unity.mcp.particlesystem",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-ParticleSystem.git",
+      "tools": [
+        { "name": "particle-system-get", "description": "Inspect ParticleSystem modules and settings" },
+        { "name": "particle-system-modify", "description": "Modify emission, shape, color, noise, and more" }
+      ]
+    },
+    {
+      "name": "ProBuilder",
+      "description": "AI-assisted ProBuilder geometry modeling tools.",
+      "packageId": "com.ivanmurzak.unity.mcp.probuilder",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-ProBuilder.git",
+      "tools": [
+        { "name": "probuilder-create-shape", "description": "Create editable 3D primitives in the scene" },
+        { "name": "probuilder-get-mesh-info", "description": "Retrieve faces, vertices, and edges data" },
+        { "name": "probuilder-extrude", "description": "Extrude faces along their normals" },
+        { "name": "probuilder-delete-faces", "description": "Remove faces to create holes or trim geometry" },
+        { "name": "probuilder-set-face-material", "description": "Assign materials to individual faces" }
+      ]
+    },
+    {
+      "name": "Splines",
+      "description": "AI-assisted Spline authoring: containers, knots, tangents, and evaluation.",
+      "packageId": "com.ivanmurzak.unity.mcp.splines",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-Splines.git",
+      "tools": [
+        { "name": "splines-container-create", "description": "Create a SplineContainer in the scene" },
+        { "name": "splines-add-knot", "description": "Append a knot to a spline" },
+        { "name": "splines-set-knot", "description": "Set a knot's position, tangents, and rotation" },
+        { "name": "splines-set-tangent-mode", "description": "Set a knot's tangent mode" },
+        { "name": "splines-evaluate", "description": "Evaluate position/tangent/up along a spline" },
+        { "name": "splines-modify", "description": "Modify any Splines component via ReflectorNet" }
+      ]
+    },
+    {
+      "name": "Terrain",
+      "description": "AI-powered Unity Terrain authoring tools.",
+      "packageId": "com.ivanmurzak.unity.mcp.terrain",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-Terrain.git",
+      "tools": [
+        { "name": "terrain-create", "description": "Create a Terrain GameObject backed by new TerrainData" },
+        { "name": "terrain-set-heights", "description": "Sculpt heightmap values over a region or the whole terrain" },
+        { "name": "terrain-paint-layer", "description": "Paint a TerrainLayer onto the alphamap (splatmap)" },
+        { "name": "terrain-place-trees", "description": "Scatter or place trees from a tree prototype" },
+        { "name": "terrain-set-neighbors", "description": "Stitch neighbor Terrains so Unity blends seams" }
+      ]
+    },
+    {
+      "name": "Tilemap",
+      "description": "AI-assisted 2D Tilemap creation, painting, and tile/RuleTile asset tools.",
+      "packageId": "com.ivanmurzak.unity.mcp.tilemap",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-Tilemap.git",
+      "tools": [
+        { "name": "tilemap-create", "description": "Create a Grid + Tilemap + TilemapRenderer" },
+        { "name": "tilemap-set-tile", "description": "Paint a tile into a cell" },
+        { "name": "tilemap-box-fill", "description": "Fill a rectangular region with a tile" },
+        { "name": "tilemap-create-tile-asset", "description": "Create a Tile asset from a Sprite" },
+        { "name": "tilemap-create-rule-tile", "description": "Create a RuleTile asset (2D Tilemap Extras)" }
+      ]
+    },
+    {
+      "name": "Timeline",
+      "description": "AI-assisted Timeline cutscene and sequence authoring tools.",
+      "packageId": "com.ivanmurzak.unity.mcp.timeline",
+      "version": null,
+      "gitUrl": "https://github.com/IvanMurzak/Unity-AI-Timeline.git",
+      "tools": [
+        { "name": "timeline-create", "description": "Create a TimelineAsset (.playable)" },
+        { "name": "timeline-track-add", "description": "Add Animation/Activation/Audio/Signal/Control tracks" },
+        { "name": "timeline-clip-add", "description": "Add clips to a track with start and duration" },
+        { "name": "timeline-director-bind", "description": "Bind a TimelineAsset to a scene PlayableDirector" },
+        { "name": "timeline-modify", "description": "Modify any Timeline object via ReflectorNet" }
+      ]
+    }
+  ]
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fe5fec897fab429eaa2bc503d98bc27b
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.md
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.md
@@ -1,0 +1,63 @@
+# `extensions.catalog.json` — the shared extension catalogue
+
+`extensions.catalog.json` (this file's sibling) is the **single source of truth** for the ten shipped
+Unity-MCP extensions. It ships **inside this UPM package**, so it reaches every Unity user through
+OpenUPM, and it is mirrored into the `unity-mcp-cli` npm package so that CLI stays self-contained.
+
+## Why a JSON file when the editor already had a C# array
+
+The editor's Extensions section has always been driven by a **hardcoded C# array** —
+`MainWindowEditor._extensions` in
+`Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs`. That array is load-bearing: it builds the
+`ExtensionPanel` list in the *AI Game Developer* window and feeds
+`ExtensionPanel.AddToManifest`, the real installer that writes the OpenUPM scoped registry and the
+package dependency into a consumer's `Packages/manifest.json`.
+
+When `unity-mcp-cli` gained `installExtension`, a **second** independent list of the same ten
+extensions came into existence on the TypeScript side. Two hand-maintained lists of the same data
+drift silently — so this JSON was introduced as the shared spec both sides must match, and two
+build-failing parity tests were added to enforce it.
+
+## The three artifacts and who consumes them
+
+| Artifact | Path | Consumer | Ships via |
+|---|---|---|---|
+| **JSON source of truth** | `extensions.catalog.json` | the spec both code artifacts are tested against | this UPM package (OpenUPM) |
+| **C# array** | `Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs` § `_extensions` | the editor Extensions UI + `ExtensionPanel.AddToManifest` | this UPM package (OpenUPM) |
+| **TypeScript mirror** | `cli/src/utils/extensions-catalog.ts` § `EXTENSIONS_CATALOG` | `unity-mcp-cli`'s `installExtension` (library + `install-extension` command) | npm |
+
+The C# array is **deliberately not refactored to read this JSON at editor runtime.** Doing so would
+put a new file-load path in front of the extension list for every existing Unity user, and a failure
+there degrades silently to an empty list. The parity tests below give the same anti-drift guarantee
+with none of that risk. If a future change *does* move the C# side onto the JSON, the
+`json ↔ C#` parity test becomes redundant rather than wrong.
+
+## The parity tests (both build-failing)
+
+Both live in the CLI's vitest suite — they need no Unity licence and run on every PR via
+`test_cli.yml`, and again inside the publish job (`deploy.yml`), which is what makes them a release
+gate rather than a nicety.
+
+- **`cli/tests/extensions-catalog-parity.test.ts`** — `json ↔ TypeScript mirror`. Deep-equals the
+  normalised JSON against `EXTENSIONS_CATALOG`, all six fields including `version`.
+- **`cli/tests/extensions-catalog-csharp-parity.test.ts`** — `json ↔ C# array`. Parses the
+  `_extensions` initialiser out of the C# source and deep-equals it against the JSON on the five
+  fields the C# `ExtensionData` struct carries (`name`, `description`, `packageId`, `gitUrl`,
+  `tools[]`).
+
+Adding, removing, or editing an extension therefore means editing **the JSON and both code
+artifacts**; either test fails until all three agree.
+
+## `version` is `null` on every entry, on purpose
+
+No entry pins an extension version. Every extension resolves OpenUPM's `dist-tags.latest` **live at
+install time** — the CLI via `resolveLatestPackageVersion` in `cli/src/utils/manifest.ts`, the editor
+via `ExtensionPanel.FetchLatestOpenUpmVersionAsync`. A catalogue that pinned versions would go stale
+on the very next extension release, and this catalogue ships inside a package whose release cadence is
+independent of the ten extensions'.
+
+`version` has no counterpart in the C# `ExtensionData` struct, which is why the `json ↔ C#` test
+compares five fields rather than six. That is not a gap: the editor has no version field *because* it
+always resolves latest live, which is exactly what `version: null` encodes on the CLI side. A stray
+pin in the JSON is still caught — by the `json ↔ TypeScript` test, and by a dedicated assertion in
+the parity suite that every entry's `version` is `null`.

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.md.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4ad331ec48f4d55a09f232a9afa288a
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/cli/README.md
+++ b/cli/README.md
@@ -93,6 +93,7 @@ npx unity-mcp-cli install-plugin /path/to/unity/project
 - [Commands](#commands)
   - [`configure`](#configure)
   - [`create-project`](#create-project)
+  - [`install-extension`](#install-extension)
   - [`install-plugin`](#install-plugin)
   - [`install-unity`](#install-unity)
   - [`login`](#login)
@@ -178,6 +179,55 @@ unity-mcp-cli create-project /path/to/new/project
 ```bash
 unity-mcp-cli create-project ./MyGame --unity 2022.3.62f1
 ```
+
+![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
+
+## `install-extension`
+
+Install one of the Unity-MCP extensions — the optional tool packs that add MCP tools for Animation, Cinemachine, Input System, Navigation, Particle System, ProBuilder, Splines, Terrain, Tilemap, and Timeline — into a Unity project's `Packages/manifest.json`. This is the command-line equivalent of the **Extensions** section in the *AI Game Developer* editor window, and it installs from the same shared catalogue.
+
+```bash
+# See what is installable (no project and no network required)
+unity-mcp-cli install-extension --list
+
+# Run from inside the Unity project folder — the path is optional
+cd ./MyGame && unity-mcp-cli install-extension Tilemap
+```
+
+| Argument / Option | Required | Description |
+|---|---|---|
+| `[id]` | Yes (unless `--list`) | Extension to install — the OpenUPM package id (`com.ivanmurzak.unity.mcp.tilemap`) or the catalogue name (`Tilemap`). Matched case-insensitively. An unknown id lists every installable extension so you can self-correct. |
+| `[path]` | No | Path to the Unity project (positional or `--path`). Defaults to the current directory, verified the same way as `install-plugin`. |
+| `--extension-version <version>` | No | Extension version to install (defaults to latest from OpenUPM). **Not `--version`** — that is the CLI's own global version flag. |
+| `--list` | No | List the installable extensions and exit. |
+
+This command:
+1. Adds the **OpenUPM scoped registry** with all required scopes (the `com.ivanmurzak` scope is what makes the extension resolvable at all)
+2. Adds the extension's package id to `dependencies`, resolving OpenUPM's `latest` at install time
+3. **Never downgrades** on an auto-resolved version — if a higher version is already installed, it is preserved and a warning is printed. Pass `--extension-version` to force a specific value, including a downgrade.
+4. Is **idempotent** — a re-run that finds the extension already up to date reports so and writes nothing
+
+**Example — install a specific extension version:**
+
+```bash
+unity-mcp-cli install-extension Cinemachine ./MyGame --extension-version 1.0.17
+```
+
+**Example — in-process, from the library:**
+
+```ts
+import { installExtension, EXTENSIONS_CATALOG } from 'unity-mcp-cli';
+
+const result = await installExtension({
+  unityProjectPath: './MyGame',
+  extensionId: 'Tilemap',
+});
+if (result.kind === 'success') {
+  console.log(result.outcome, result.fromVersion, '->', result.toVersion);
+}
+```
+
+> After running this command, open (or focus) the Unity Editor so the Package Manager resolves the new dependency.
 
 ![AI Game Developer — Unity SKILLS and MCP](https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/hazzard-divider.svg?raw=true)
 

--- a/cli/src/commands/install-extension.ts
+++ b/cli/src/commands/install-extension.ts
@@ -1,0 +1,120 @@
+import { Command } from 'commander';
+import * as ui from '../utils/ui.js';
+import { verbose } from '../utils/ui.js';
+import { installExtension } from '../lib/install-extension.js';
+import { EXTENSIONS_CATALOG } from '../utils/extensions-catalog.js';
+import { resolveInstallTarget, unityAdapter } from '@baizor/gamedev-cli-core';
+
+interface InstallExtensionCliOptions {
+  path?: string;
+  extensionVersion?: string;
+  list?: boolean;
+}
+
+export const installExtensionCommand = new Command('install-extension')
+  .description(
+    'Install a Unity-MCP extension into a Unity project: resolve the extension <id> from the shared catalogue, add (or update) its dependency plus the OpenUPM scoped registry in Packages/manifest.json, then let Unity resolve it. Idempotent. The project path defaults to the current directory (like install-plugin).',
+  )
+  .argument('[id]', 'Extension to install (the OpenUPM package id, or the catalogue name e.g. "Tilemap")')
+  .argument('[path]', 'Path to the Unity project (defaults to the current directory)')
+  .option('--path <path>', 'Path to the Unity project')
+  // NOT `--version`: the root program registers `-V, --version` via `.version()`, which
+  // intercepts it before this subcommand sees it — `install-extension X --version 1.2.3`
+  // would print the CLI's own version and exit 0 without installing anything. This is the
+  // same reason `install-plugin` spells its flag `--plugin-version`.
+  .option('--extension-version <version>', 'Extension version to install (default: latest from OpenUPM)')
+  .option('--list', 'List the installable extensions and exit')
+  .action(async (id: string | undefined, positionalPath: string | undefined, options: InstallExtensionCliOptions) => {
+    // `--list` is a pure read: no project needed, no network, exit 0.
+    if (options.list) {
+      ui.heading('Installable Unity-MCP extensions');
+      for (const ext of EXTENSIONS_CATALOG) {
+        ui.label(ext.name, ext.packageId);
+      }
+      ui.info(
+        `${EXTENSIONS_CATALOG.length} extensions. Install one with: unity-mcp-cli install-extension <id> [path]`,
+      );
+      return;
+    }
+
+    if (!id || id.trim() === '') {
+      ui.error(
+        'Missing extension id. Pass one (e.g. `unity-mcp-cli install-extension Tilemap`), or run with --list to see what is installable.',
+      );
+      process.exit(1);
+    }
+
+    // Same path resolution as install-plugin: `path? → --path? → cwd`, then verify the
+    // directory really is a Unity project so the error names what was checked.
+    const target = resolveInstallTarget({
+      adapter: unityAdapter,
+      positional: positionalPath,
+      path: options.path,
+    });
+    if (target.kind === 'failure') {
+      ui.error(target.error.message);
+      process.exit(1);
+    }
+
+    const projectPath = target.projectRoot;
+
+    ui.heading('Installing Unity-MCP extension');
+    verbose(`Extension id: ${id}`);
+    verbose(`Project path: ${projectPath}`);
+    if (options.extensionVersion) verbose(`--extension-version: ${options.extensionVersion}`);
+
+    let spinner: ReturnType<typeof ui.startSpinner> | undefined;
+    if (!options.extensionVersion) {
+      spinner = ui.startSpinner('Resolving latest extension version...');
+    }
+
+    const result = await installExtension({
+      unityProjectPath: projectPath,
+      extensionId: id,
+      version: options.extensionVersion,
+      onProgress: (event) => {
+        if (event.phase === 'dependencies-resolved' && spinner) {
+          spinner.success(`Resolved extension version: ${event.version}`);
+          spinner = undefined;
+          return;
+        }
+        if (event.phase === 'manifest-patched') {
+          verbose(event.message);
+        }
+      },
+    });
+
+    if (result.kind === 'failure') {
+      if (spinner) {
+        spinner.error('Failed to resolve extension version');
+        spinner = undefined;
+      }
+      ui.error(result.error.message);
+      for (const warning of result.warnings) {
+        ui.warn(warning);
+      }
+      process.exit(1);
+    }
+
+    switch (result.outcome) {
+      case 'added':
+        ui.success(`Installed ${result.packageId} ${result.toVersion}`);
+        break;
+      case 'updated':
+        ui.success(`Updated ${result.packageId} ${result.fromVersion} → ${result.toVersion}`);
+        break;
+      case 'already-up-to-date':
+        ui.info(`${result.packageId} is already up to date (${result.toVersion})`);
+        break;
+    }
+
+    ui.label('Status', result.message);
+    ui.label('Manifest', result.manifestPath);
+
+    for (const warning of result.warnings) {
+      ui.warn(warning);
+    }
+    for (const step of result.nextSteps) {
+      ui.label('Next step', step);
+    }
+  });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,6 +5,7 @@ import { closeCommand } from './commands/close.js';
 import { createProjectCommand } from './commands/create-project.js';
 import { installUnityCommand } from './commands/install-unity.js';
 import { openCommand } from './commands/open.js';
+import { installExtensionCommand } from './commands/install-extension.js';
 import { installPluginCommand } from './commands/install-plugin.js';
 import { loginCommand } from './commands/login.js';
 import { configureCommand } from './commands/configure.js';
@@ -36,6 +37,7 @@ const subcommands = [
   closeCommand,
   configureCommand,
   createProjectCommand,
+  installExtensionCommand,
   installPluginCommand,
   installUnityCommand,
   loginCommand,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -17,12 +17,27 @@
 // this file via the `exports` field in package.json).
 
 export { installPlugin } from './lib/install-plugin.js';
+export { installExtension } from './lib/install-extension.js';
 export { removePlugin } from './lib/remove-plugin.js';
 export { configure } from './lib/configure.js';
 export { setupMcp, listAgentIds } from './lib/setup-mcp.js';
 export { openProject } from './lib/open.js';
 export { createProject } from './lib/create-project.js';
 export { runTool, runSystemTool } from './lib/run-tool.js';
+
+// The extension catalogue is part of the public library surface: a consumer that
+// renders an "install an extension" list (the desktop app) needs the same ten
+// entries the CLI installs from, and must not re-declare them.
+export {
+  EXTENSIONS_CATALOG,
+  findExtension,
+  hasVersion,
+} from './utils/extensions-catalog.js';
+
+export type {
+  ExtensionDescriptor,
+  ExtensionTool,
+} from './utils/extensions-catalog.js';
 
 export type {
   // Shared
@@ -34,6 +49,12 @@ export type {
   InstallResult,
   InstallSuccess,
   InstallFailure,
+  // install-extension
+  InstallExtensionOptions,
+  InstallExtensionResult,
+  InstallExtensionSuccess,
+  InstallExtensionFailure,
+  InstallExtensionOutcome,
   // remove-plugin
   RemovePluginOptions,
   RemoveResult,

--- a/cli/src/lib/install-extension.ts
+++ b/cli/src/lib/install-extension.ts
@@ -1,0 +1,230 @@
+import * as fs from 'fs';
+import {
+  EXTENSIONS_CATALOG,
+  findExtension,
+  hasVersion,
+  type ExtensionDescriptor,
+} from '../utils/extensions-catalog.js';
+import { addPackageToManifest, resolveLatestPackageVersion } from '../utils/manifest.js';
+import { silentLogger } from './logger.js';
+import { emitProgress } from './progress.js';
+import { requireUnityProject } from './validation.js';
+import type { InstallExtensionOptions, InstallExtensionResult } from './types.js';
+
+/**
+ * Install (or update) a Unity-MCP extension into a consumer Unity project, as a
+ * REAL installer that is behaviourally identical to the in-editor window's
+ * `ExtensionPanel`:
+ *
+ *  1. Resolve `extensionId` to a descriptor in the SHARED catalogue
+ *     (`Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json`,
+ *     mirrored here by `EXTENSIONS_CATALOG`).
+ *  2. Validate that the target path hosts a Unity project (`Packages/manifest.json`).
+ *  3. Resolve the version to install: the explicit `version` override, else the
+ *     catalogue pin, else OpenUPM's `dist-tags.latest` fetched live. Every shipped
+ *     catalogue entry is unpinned, so the live fetch is the normal path.
+ *  4. Read-modify-write `Packages/manifest.json`: ensure the OpenUPM scoped registry
+ *     and its required scopes, then add or version-bump the package dependency.
+ *  5. Tell the caller Unity must resolve packages (the CLI cannot call
+ *     `UnityEditor.PackageManager.Client.Resolve()` — only the editor can).
+ *
+ * Library-safe: no stdout noise, no `process.exit`, no throws past the public
+ * boundary; returns a `{ kind: 'success' | 'failure' }` union. Idempotent: a re-run
+ * that finds the dependency at an equal-or-newer version reports
+ * `already-up-to-date` and makes no write. Mirrors `installPlugin`'s shape exactly
+ * so the app can adopt it the same way.
+ */
+export async function installExtension(
+  opts: InstallExtensionOptions,
+): Promise<InstallExtensionResult> {
+  const warnings: string[] = [];
+  const nextSteps: string[] = [];
+  const extensionId = opts?.extensionId ?? '';
+
+  try {
+    const catalog = opts.catalog ?? EXTENSIONS_CATALOG;
+    const resolved = findExtension(extensionId, catalog);
+    if (resolved === null) {
+      return {
+        kind: 'failure',
+        success: false,
+        extensionId,
+        warnings,
+        nextSteps,
+        error: new Error(unknownExtensionMessage(extensionId, catalog)),
+      };
+    }
+
+    const validated = requireUnityProject(opts?.unityProjectPath);
+    if (!validated.ok) {
+      return {
+        kind: 'failure',
+        success: false,
+        extensionId,
+        packageId: resolved.packageId,
+        manifestPath: validated.manifestPath,
+        warnings,
+        nextSteps,
+        error: validated.error,
+      };
+    }
+    const { projectPath } = validated;
+
+    emitProgress(opts.onProgress, {
+      phase: 'start',
+      message: `Installing extension ${resolved.packageId} into ${projectPath}`,
+    });
+
+    // Apply the optional `version` override (drives both the pin written and, via
+    // `force`, whether a downgrade is permitted).
+    const descriptor = applyVersionOverride(resolved, opts.version, warnings);
+    const isExplicitVersion = (opts.version ?? '').trim() !== '';
+
+    let version: string;
+    if (hasVersion(descriptor)) {
+      // Non-null only for an explicit override or a (currently unused) catalogue pin.
+      version = descriptor.version as string;
+    } else {
+      version = await resolveLatestPackageVersion(
+        descriptor.packageId,
+        silentLogger,
+        '--extension-version',
+      );
+      emitProgress(opts.onProgress, {
+        phase: 'dependencies-resolved',
+        message: `Resolved latest ${descriptor.packageId} version: ${version}`,
+        version,
+      });
+    }
+
+    const before = readInstalledVersion(validated.manifestPath, descriptor.packageId);
+
+    const result = addPackageToManifest(
+      projectPath,
+      descriptor.packageId,
+      version,
+      isExplicitVersion,
+      silentLogger,
+    );
+
+    // `addPackageToManifest` refuses to downgrade unless `force`; surface that as a
+    // warning rather than silently reporting the requested version.
+    if (result.resolvedVersion !== version && !isExplicitVersion) {
+      warnings.push(
+        `${descriptor.packageId} is already at version ${result.resolvedVersion} (>= ${version}). ` +
+          'Skipping version update. Pass an explicit `version` to force a specific value.',
+      );
+    }
+
+    emitProgress(opts.onProgress, {
+      phase: 'manifest-patched',
+      message: result.modified
+        ? `Updated ${result.manifestPath}`
+        : 'manifest.json is already up to date.',
+      manifestPath: result.manifestPath,
+    });
+
+    // Derive the outcome from what was actually on disk before the write, NOT from
+    // `modified` alone: `modified` is also true when only the scoped registry had to
+    // be added, which is not an "added extension".
+    const outcome =
+      before === null
+        ? 'added'
+        : result.resolvedVersion === before
+          ? 'already-up-to-date'
+          : 'updated';
+
+    const message =
+      outcome === 'added'
+        ? `Added ${descriptor.packageId} ${result.resolvedVersion}. Unity will resolve the package on next focus.`
+        : outcome === 'updated'
+          ? `Updated ${descriptor.packageId} from ${before} to ${result.resolvedVersion}.`
+          : `${descriptor.name} is already installed and up to date (${result.resolvedVersion}).`;
+
+    if (outcome !== 'already-up-to-date') {
+      nextSteps.push(
+        'Open (or focus) the Unity Editor so the Package Manager resolves the new dependency.',
+      );
+    }
+
+    emitProgress(opts.onProgress, { phase: 'done', message: 'Extension install complete.' });
+
+    return {
+      kind: 'success',
+      success: true,
+      outcome,
+      changed: outcome !== 'already-up-to-date',
+      extensionId,
+      packageId: descriptor.packageId,
+      fromVersion: before,
+      toVersion: result.resolvedVersion,
+      manifestPath: result.manifestPath,
+      message,
+      warnings,
+      nextSteps,
+    };
+  } catch (err: unknown) {
+    return {
+      kind: 'failure',
+      success: false,
+      extensionId,
+      warnings,
+      nextSteps,
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}
+
+/**
+ * Read the version currently pinned for `packageId` in the project manifest, or
+ * `null` when the dependency is absent. Used to classify the outcome as
+ * added / updated / already-up-to-date, which `addPackageToManifest`'s
+ * `{ modified }` flag cannot express on its own.
+ *
+ * Deliberately forgiving: any read/parse problem yields `null` (treated as
+ * "not installed"). The subsequent `addPackageToManifest` call performs the
+ * authoritative read and throws a precise error if the manifest is unusable, so
+ * swallowing here cannot mask a real failure — it only avoids duplicating the
+ * error path.
+ */
+function readInstalledVersion(manifestPath: string, packageId: string): string | null {
+  try {
+    const raw = fs.readFileSync(manifestPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { dependencies?: Record<string, string> };
+    const current = parsed?.dependencies?.[packageId];
+    return typeof current === 'string' && current.trim() !== '' ? current : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Return a descriptor with the `version` override applied (empty/whitespace override is ignored). */
+function applyVersionOverride(
+  descriptor: ExtensionDescriptor,
+  version: string | undefined,
+  warnings: string[],
+): ExtensionDescriptor {
+  const v = (version ?? '').trim();
+  if (v === '') return descriptor;
+  if (descriptor.version !== null && descriptor.version !== v) {
+    warnings.push(
+      `version ${v} overrides the catalogue pin ${descriptor.packageId}@${descriptor.version} for this install.`,
+    );
+  }
+  return { ...descriptor, version: v };
+}
+
+/** A clear "unknown extension" error that lists what IS installable (or says the catalogue is empty). */
+function unknownExtensionMessage(
+  id: string,
+  catalog: readonly ExtensionDescriptor[],
+): string {
+  if (catalog.length === 0) {
+    return (
+      `Unknown extension "${id}". The Unity-MCP extension catalogue is currently empty, ` +
+      'so there is nothing to install.'
+    );
+  }
+  const available = catalog.map((d) => d.packageId).join(', ');
+  return `Unknown extension "${id}". Available extensions: ${available}.`;
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -5,6 +5,11 @@
 //
 // No top-level side effects, no runtime deps beyond TypeScript types.
 
+// Type-only import: erased at compile time, so this adds no runtime dependency
+// and cannot introduce a side effect. `ExtensionDescriptor` is the catalogue entry
+// shape, needed by `InstallExtensionOptions.catalog`.
+import type { ExtensionDescriptor } from '../utils/extensions-catalog.js';
+
 // ---------------------------------------------------------------------------
 // Progress events
 // ---------------------------------------------------------------------------
@@ -125,6 +130,93 @@ export interface InstallFailure {
 }
 
 export type InstallResult = InstallSuccess | InstallFailure;
+
+// ---------------------------------------------------------------------------
+// install-extension
+// ---------------------------------------------------------------------------
+
+/**
+ * What `installExtension` actually did. Distinguished from `changed` because a
+ * caller usually wants to say "installed" vs "updated" vs "nothing to do" in its
+ * UI, and `changed` alone cannot tell the first two apart.
+ */
+export type InstallExtensionOutcome = 'added' | 'updated' | 'already-up-to-date';
+
+export interface InstallExtensionOptions {
+  /** Absolute or relative path to the Unity project's root. */
+  unityProjectPath: string;
+  /**
+   * Extension to install — either the OpenUPM package id
+   * (`com.ivanmurzak.unity.mcp.tilemap`) or the catalogue display name
+   * (`Tilemap`). Matched case-insensitively, package id first.
+   */
+  extensionId: string;
+  /**
+   * Version to install. When omitted, OpenUPM's `dist-tags.latest` is resolved
+   * live at install time — which is the normal path, because every catalogue
+   * entry is unpinned (`version: null`). Supplying a value also permits a
+   * downgrade, mirroring `installPlugin`'s explicit-version semantics.
+   */
+  version?: string;
+  /**
+   * Catalogue override, for tests and for callers that carry their own list.
+   * Defaults to the built-in `EXTENSIONS_CATALOG`.
+   */
+  catalog?: readonly ExtensionDescriptor[];
+  /**
+   * Optional progress callback — fires for `start`, `dependencies-resolved`
+   * (when the version was auto-resolved), `manifest-patched`, and `done`.
+   */
+  onProgress?: ProgressCallback;
+}
+
+/** Successful `installExtension` outcome. Narrow with `kind === 'success'`. */
+export interface InstallExtensionSuccess {
+  kind: 'success';
+  /** Always `true` for the success variant. */
+  success: true;
+  /** What happened — see {@link InstallExtensionOutcome}. */
+  outcome: InstallExtensionOutcome;
+  /** `true` when `manifest.json` was written. `false` for `already-up-to-date`. */
+  changed: boolean;
+  /** The `extensionId` as supplied by the caller. */
+  extensionId: string;
+  /** The resolved OpenUPM package id that was written to the manifest. */
+  packageId: string;
+  /** Version present before the call, or `null` when the extension was absent. */
+  fromVersion: string | null;
+  /** Version present after the call. */
+  toVersion: string;
+  /** Absolute path to the `Packages/manifest.json` that was inspected / written. */
+  manifestPath: string;
+  /** Human-readable summary the caller may surface directly. */
+  message: string;
+  /** Non-fatal warnings collected during the run. */
+  warnings: string[];
+  /** Suggested next steps for the caller to surface to a human user. */
+  nextSteps: string[];
+}
+
+/** Failed `installExtension` outcome. Narrow with `kind === 'failure'`. */
+export interface InstallExtensionFailure {
+  kind: 'failure';
+  /** Always `false` for the failure variant. */
+  success: false;
+  /** The `extensionId` as supplied by the caller. */
+  extensionId: string;
+  /** Resolved package id, when catalogue lookup succeeded before the failure. */
+  packageId?: string;
+  /** Manifest path may be known even on failure (e.g. a validation failure that reached it). */
+  manifestPath?: string;
+  /** Non-fatal warnings collected before the failure. */
+  warnings: string[];
+  /** Suggested next steps the caller may surface to a human user. */
+  nextSteps: string[];
+  /** The captured error. Never thrown past this boundary. */
+  error: Error;
+}
+
+export type InstallExtensionResult = InstallExtensionSuccess | InstallExtensionFailure;
 
 // ---------------------------------------------------------------------------
 // remove-plugin

--- a/cli/src/utils/extensions-catalog.ts
+++ b/cli/src/utils/extensions-catalog.ts
@@ -1,0 +1,228 @@
+// The CLI's typed mirror of the SHARED extension catalogue — the single source of
+// truth `Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json`
+// (see that file's sibling `extensions.catalog.md`).
+//
+// There are THREE artifacts holding this same list, and all three are kept in
+// lockstep by build-failing parity tests:
+//
+//   1. `extensions.catalog.json`        — the JSON source of truth, shipped in the UPM package.
+//   2. `MainWindowEditor._extensions`   — the C# array that drives the editor's Extensions
+//                                         section and `ExtensionPanel.AddToManifest`.
+//   3. `EXTENSIONS_CATALOG` (this file) — drives `installExtension` in this CLI.
+//
+// SINGLE SOURCE OF TRUTH: this constant MUST stay equivalent to the JSON. The parity
+// test `cli/tests/extensions-catalog-parity.test.ts` reads the JSON and FAILS the build
+// if this mirror drifts; `cli/tests/extensions-catalog-csharp-parity.test.ts` does the
+// same for the C# array. Adding an extension = appending an entry to the JSON, the C#
+// array, AND this array (both tests enforce it). This mirror exists so the published npm
+// package stays self-contained — no runtime `../Unity-MCP-Plugin` dependency.
+//
+// No top-level side effects; pure data + pure lookups only.
+
+/** One tool a catalogue extension contributes — mirrors the JSON `tools[]` entry. */
+export interface ExtensionTool {
+  readonly name: string;
+  readonly description: string;
+}
+
+/**
+ * One installable extension — the CLI analog of the C# `ExtensionPanel.ExtensionData`.
+ * `packageId` is the INSTALL IDENTITY (the `Packages/manifest.json` dependency key,
+ * resolved from the OpenUPM scoped registry).
+ * `version` is `null` for a floating (unpinned) reference — every catalogue entry is
+ * unpinned, so OpenUPM's `dist-tags.latest` is resolved live at install time.
+ *
+ * `tools` is the same CURATED highlight list the editor renders in an extension's
+ * tooltip (`ExtensionPanel.BuildTooltip`) — it is deliberately NOT an exhaustive
+ * inventory of the extension's MCP tools, and must not be consumed as one.
+ */
+export interface ExtensionDescriptor {
+  readonly name: string;
+  readonly description: string;
+  readonly packageId: string;
+  readonly version: string | null;
+  readonly gitUrl: string | null;
+  readonly tools: readonly ExtensionTool[];
+}
+
+/**
+ * The extension catalogue, single-sourced from
+ * `Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json`.
+ * Ten shipped extensions; `Unity-AI-Tools-Template` is a template and is excluded.
+ */
+export const EXTENSIONS_CATALOG: readonly ExtensionDescriptor[] = [
+  {
+    name: 'Animation',
+    description: 'AI-driven animation control and playback tools.',
+    packageId: 'com.ivanmurzak.unity.mcp.animation',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-Animation.git',
+    tools: [
+      { name: 'animation-create', description: 'Create AnimationClip assets with keyframes' },
+      { name: 'animation-get-data', description: 'Inspect clip curves, events, and properties' },
+      { name: 'animation-modify', description: 'Edit curves, events, and settings on a clip' },
+      { name: 'animator-create', description: 'Create AnimatorController assets' },
+      { name: 'animator-get-data', description: 'Inspect controller layers, states, and parameters' },
+      { name: 'animator-modify', description: 'Edit parameters, states, and transitions' },
+    ],
+  },
+  {
+    name: 'Cinemachine',
+    description: 'AI-assisted Cinemachine camera setup and configuration tools.',
+    packageId: 'com.ivanmurzak.unity.mcp.cinemachine',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-Cinemachine.git',
+    tools: [
+      { name: 'cinemachine-camera-create', description: 'Create a CinemachineCamera in the scene' },
+      { name: 'cinemachine-set-targets', description: 'Set the Follow and LookAt targets' },
+      { name: 'cinemachine-set-lens', description: 'Configure FOV, clip planes, and dutch' },
+      { name: 'cinemachine-set-body', description: 'Set the position-control component (Follow/Orbital/...)' },
+      { name: 'cinemachine-set-noise', description: 'Add camera shake via Perlin noise' },
+    ],
+  },
+  {
+    name: 'InputSystem',
+    description:
+      'AI-assisted Unity Input System authoring: InputActionAssets, maps, actions, bindings, and control schemes.',
+    packageId: 'com.ivanmurzak.unity.mcp.inputsystem',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-InputSystem.git',
+    tools: [
+      { name: 'inputsystem-asset-create', description: 'Create a new .inputactions InputActionAsset' },
+      { name: 'inputsystem-actionmap-add', description: 'Add an ActionMap to the asset' },
+      { name: 'inputsystem-action-add', description: 'Add an Action (type + expectedControlType)' },
+      { name: 'inputsystem-binding-add', description: 'Add a binding path to an Action' },
+      { name: 'inputsystem-binding-composite-add', description: 'Add a composite binding (2DVector/1DAxis)' },
+      { name: 'inputsystem-controlscheme-add', description: 'Add a control scheme with device requirements' },
+      { name: 'inputsystem-get', description: "Read the asset's maps, actions, and bindings" },
+    ],
+  },
+  {
+    name: 'Navigation',
+    description: 'AI-driven NavMesh navigation: surfaces, baking, agents, and links.',
+    packageId: 'com.ivanmurzak.unity.mcp.navigation',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-Navigation.git',
+    tools: [
+      { name: 'navigation-surface-add', description: 'Add and configure a NavMeshSurface' },
+      { name: 'navigation-set-bake-settings', description: 'Set agent radius/height/slope/step and voxel size' },
+      { name: 'navigation-surface-bake', description: 'Bake or clear a NavMeshSurface' },
+      { name: 'navigation-modifier-add', description: 'Add a NavMeshModifier (override area / ignore)' },
+      { name: 'navigation-modifier-volume-add', description: 'Add a NavMeshModifierVolume' },
+      { name: 'navigation-link-add', description: 'Add a NavMeshLink between two points' },
+      { name: 'navigation-agent-add', description: 'Add and configure a NavMeshAgent' },
+      { name: 'navigation-agent-set-destination', description: "Set a NavMeshAgent's destination" },
+      { name: 'navigation-list', description: 'List NavMeshSurfaces and NavMeshAgents' },
+      { name: 'navigation-get', description: 'Serialize any NavMesh component' },
+      { name: 'navigation-modify', description: 'Modify any NavMesh component via ReflectorNet' },
+    ],
+  },
+  {
+    name: 'ParticleSystem',
+    description: 'AI-powered particle system creation and control tools.',
+    packageId: 'com.ivanmurzak.unity.mcp.particlesystem',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-ParticleSystem.git',
+    tools: [
+      { name: 'particle-system-get', description: 'Inspect ParticleSystem modules and settings' },
+      { name: 'particle-system-modify', description: 'Modify emission, shape, color, noise, and more' },
+    ],
+  },
+  {
+    name: 'ProBuilder',
+    description: 'AI-assisted ProBuilder geometry modeling tools.',
+    packageId: 'com.ivanmurzak.unity.mcp.probuilder',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-ProBuilder.git',
+    tools: [
+      { name: 'probuilder-create-shape', description: 'Create editable 3D primitives in the scene' },
+      { name: 'probuilder-get-mesh-info', description: 'Retrieve faces, vertices, and edges data' },
+      { name: 'probuilder-extrude', description: 'Extrude faces along their normals' },
+      { name: 'probuilder-delete-faces', description: 'Remove faces to create holes or trim geometry' },
+      { name: 'probuilder-set-face-material', description: 'Assign materials to individual faces' },
+    ],
+  },
+  {
+    name: 'Splines',
+    description: 'AI-assisted Spline authoring: containers, knots, tangents, and evaluation.',
+    packageId: 'com.ivanmurzak.unity.mcp.splines',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-Splines.git',
+    tools: [
+      { name: 'splines-container-create', description: 'Create a SplineContainer in the scene' },
+      { name: 'splines-add-knot', description: 'Append a knot to a spline' },
+      { name: 'splines-set-knot', description: "Set a knot's position, tangents, and rotation" },
+      { name: 'splines-set-tangent-mode', description: "Set a knot's tangent mode" },
+      { name: 'splines-evaluate', description: 'Evaluate position/tangent/up along a spline' },
+      { name: 'splines-modify', description: 'Modify any Splines component via ReflectorNet' },
+    ],
+  },
+  {
+    name: 'Terrain',
+    description: 'AI-powered Unity Terrain authoring tools.',
+    packageId: 'com.ivanmurzak.unity.mcp.terrain',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-Terrain.git',
+    tools: [
+      { name: 'terrain-create', description: 'Create a Terrain GameObject backed by new TerrainData' },
+      { name: 'terrain-set-heights', description: 'Sculpt heightmap values over a region or the whole terrain' },
+      { name: 'terrain-paint-layer', description: 'Paint a TerrainLayer onto the alphamap (splatmap)' },
+      { name: 'terrain-place-trees', description: 'Scatter or place trees from a tree prototype' },
+      { name: 'terrain-set-neighbors', description: 'Stitch neighbor Terrains so Unity blends seams' },
+    ],
+  },
+  {
+    name: 'Tilemap',
+    description: 'AI-assisted 2D Tilemap creation, painting, and tile/RuleTile asset tools.',
+    packageId: 'com.ivanmurzak.unity.mcp.tilemap',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-Tilemap.git',
+    tools: [
+      { name: 'tilemap-create', description: 'Create a Grid + Tilemap + TilemapRenderer' },
+      { name: 'tilemap-set-tile', description: 'Paint a tile into a cell' },
+      { name: 'tilemap-box-fill', description: 'Fill a rectangular region with a tile' },
+      { name: 'tilemap-create-tile-asset', description: 'Create a Tile asset from a Sprite' },
+      { name: 'tilemap-create-rule-tile', description: 'Create a RuleTile asset (2D Tilemap Extras)' },
+    ],
+  },
+  {
+    name: 'Timeline',
+    description: 'AI-assisted Timeline cutscene and sequence authoring tools.',
+    packageId: 'com.ivanmurzak.unity.mcp.timeline',
+    version: null,
+    gitUrl: 'https://github.com/IvanMurzak/Unity-AI-Timeline.git',
+    tools: [
+      { name: 'timeline-create', description: 'Create a TimelineAsset (.playable)' },
+      { name: 'timeline-track-add', description: 'Add Animation/Activation/Audio/Signal/Control tracks' },
+      { name: 'timeline-clip-add', description: 'Add clips to a track with start and duration' },
+      { name: 'timeline-director-bind', description: 'Bind a TimelineAsset to a scene PlayableDirector' },
+      { name: 'timeline-modify', description: 'Modify any Timeline object via ReflectorNet' },
+    ],
+  },
+] as const;
+
+/** True when a descriptor carries a concrete version pin (drives the up-to-date / update decision). */
+export function hasVersion(descriptor: ExtensionDescriptor): boolean {
+  return descriptor.version !== null && descriptor.version.trim() !== '';
+}
+
+/**
+ * Resolve a user-supplied `<id>` to a catalogue descriptor. Matches by `packageId`
+ * first (case-insensitively — UPM package names are lowercase by convention, and
+ * this is the install identity), then falls back to an exact case-insensitive `name`
+ * match for convenience (`unity-mcp-cli install-extension Tilemap`). Returns `null`
+ * when absent or `id` is empty.
+ */
+export function findExtension(
+  id: string | undefined | null,
+  catalog: readonly ExtensionDescriptor[] = EXTENSIONS_CATALOG,
+): ExtensionDescriptor | null {
+  if (id === undefined || id === null) return null;
+  const needle = id.trim();
+  if (needle === '') return null;
+
+  const byPackageId = catalog.find((d) => d.packageId.toLowerCase() === needle.toLowerCase());
+  if (byPackageId) return byPackageId;
+
+  return catalog.find((d) => d.name.toLowerCase() === needle.toLowerCase()) ?? null;
+}

--- a/cli/src/utils/manifest.ts
+++ b/cli/src/utils/manifest.ts
@@ -32,11 +32,35 @@ interface Manifest {
  *   styled logger adapter explicitly to preserve the historical output.
  */
 export async function resolveLatestVersion(logger: LibLogger = silentLogger): Promise<string> {
+  return resolveLatestPackageVersion(PACKAGE_ID, logger);
+}
+
+/**
+ * Resolve the latest version of ANY OpenUPM-hosted package (the plugin itself, or
+ * one of the catalogue extensions) from the OpenUPM registry. Throws an error with
+ * actionable suggestions if the network request fails.
+ *
+ * This is the generalisation of {@link resolveLatestVersion}: same 5000 ms
+ * `AbortController` abort, same "no cached fallback" behaviour, same actionable
+ * error — the only difference is that the package id is a parameter and the
+ * suggested escape-hatch flag is caller-supplied, because `install-plugin` offers
+ * `--plugin-version` where `install-extension` offers `--version`.
+ *
+ * @param packageId OpenUPM package id to resolve (e.g. `com.ivanmurzak.unity.mcp.tilemap`).
+ * @param logger Optional logger. Defaults to `silentLogger` so library callers stay
+ *   side-effect-free.
+ * @param versionFlag Name of the CLI flag suggested in the failure message.
+ */
+export async function resolveLatestPackageVersion(
+  packageId: string,
+  logger: LibLogger = silentLogger,
+  versionFlag = '--plugin-version',
+): Promise<string> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5000);
 
   try {
-    const res = await fetch(`https://package.openupm.com/${PACKAGE_ID}`, {
+    const res = await fetch(`https://package.openupm.com/${packageId}`, {
       signal: controller.signal,
       headers: { Accept: 'application/json' },
     });
@@ -52,15 +76,15 @@ export async function resolveLatestVersion(logger: LibLogger = silentLogger): Pr
 
     throw new Error(
       `OpenUPM returned status ${res.status}. ` +
-      'Check your network connection and retry, or specify a version manually with --plugin-version <version>'
+      `Check your network connection and retry, or specify a version manually with ${versionFlag} <version>`
     );
   } catch (err) {
-    if (err instanceof Error && err.message.includes('--plugin-version')) {
+    if (err instanceof Error && err.message.includes(versionFlag)) {
       throw err;
     }
     throw new Error(
-      'Failed to resolve latest plugin version from OpenUPM. ' +
-      'Check your network connection and retry, or specify a version manually with --plugin-version <version>'
+      `Failed to resolve the latest version of ${packageId} from OpenUPM. ` +
+      `Check your network connection and retry, or specify a version manually with ${versionFlag} <version>`
     );
   } finally {
     clearTimeout(timeout);
@@ -117,6 +141,36 @@ export function addPluginToManifest(
   force = false,
   logger: LibLogger = silentLogger,
 ): AddPluginResult {
+  return addPackageToManifest(projectPath, PACKAGE_ID, version, force, logger);
+}
+
+/**
+ * Add ANY OpenUPM-hosted package to a Unity project's `Packages/manifest.json` —
+ * the plugin itself, or one of the catalogue extensions.
+ *
+ * This is the generalisation of {@link addPluginToManifest}, which now delegates
+ * here with `PACKAGE_ID`. Keeping ONE implementation matters because the
+ * scoped-registry rules (registry name, URL, and the `REQUIRED_SCOPES` pair
+ * `com.ivanmurzak` / `extensions.unity`) must be identical for the plugin and for
+ * every extension — the extensions live under the `com.ivanmurzak` scope, so an
+ * extension installed without that scope resolves against Unity's default registry
+ * and fails. It also mirrors the C# editor installer
+ * (`ExtensionPanel.AddToManifest` / `EnsureScopedRegistry`), which single-sources
+ * the same three constants on the Unity side.
+ *
+ * Behaviour (unchanged from the plugin-only version):
+ * - Adds the OpenUPM scoped registry with the required scopes when missing.
+ * - Adds/updates the package dependency.
+ * - When `force` is false (auto-resolved version): never downgrades.
+ * - When `force` is true (user-specified version): allows downgrade.
+ */
+export function addPackageToManifest(
+  projectPath: string,
+  packageId: string,
+  version: string,
+  force = false,
+  logger: LibLogger = silentLogger,
+): AddPluginResult {
   const manifestPath = path.join(projectPath, 'Packages', 'manifest.json');
 
   if (!fs.existsSync(manifestPath)) {
@@ -167,15 +221,15 @@ export function addPluginToManifest(
     modified = true;
   }
 
-  const currentVersion = manifest.dependencies[PACKAGE_ID];
+  const currentVersion = manifest.dependencies[packageId];
   let resolvedVersion = version;
   if (!currentVersion || force || shouldUpdateVersion(currentVersion, version)) {
-    manifest.dependencies[PACKAGE_ID] = version;
+    manifest.dependencies[packageId] = version;
     modified = true;
   } else {
     resolvedVersion = currentVersion;
     logger.info(
-      `Plugin already at version ${currentVersion} (>= ${version}). Skipping version update. Use --plugin-version to force a specific version.`
+      `${packageId} already at version ${currentVersion} (>= ${version}). Skipping version update. Pass an explicit version to force a specific version.`
     );
   }
 

--- a/cli/tests/extensions-catalog-csharp-parity.test.ts
+++ b/cli/tests/extensions-catalog-csharp-parity.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// The SECOND half of the catalogue drift tripwire.
+//
+// `extensions-catalog-parity.test.ts` locks the JSON source of truth against the CLI's
+// TypeScript mirror. This file locks the SAME JSON against the THIRD artifact: the C#
+// array `MainWindowEditor._extensions`, which drives the editor window's Extensions
+// section and feeds `ExtensionPanel.AddToManifest` — the in-editor installer. That array
+// is load-bearing and independently maintained, which is exactly what makes this
+// comparison meaningful rather than a tautology.
+//
+// It lives in the CLI's vitest suite on purpose: no Unity licence, no editor, runs on
+// every PR via test_cli.yml AND again inside the publish job (deploy.yml), which is what
+// makes it a release gate. Precedent for a TS test parsing the engine-side source to
+// enforce parity: Godot-MCP's `cli/tests/skills-addon-parity.test.ts`.
+//
+// `version` is intentionally NOT compared: the C# `ExtensionData` struct has no version
+// field, because the editor always resolves OpenUPM `dist-tags.latest` live
+// (`ExtensionPanel.FetchLatestOpenUpmVersionAsync`). That is the same policy the JSON
+// encodes as `version: null`, and the JSON↔TS test asserts the null on both its sides.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PLUGIN_PACKAGE = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'Unity-MCP-Plugin',
+  'Packages',
+  'com.ivanmurzak.unity.mcp',
+);
+const CATALOG_JSON = path.join(PLUGIN_PACKAGE, 'extensions.catalog.json');
+const CSHARP_SOURCE = path.join(
+  PLUGIN_PACKAGE,
+  'Editor',
+  'Scripts',
+  'UI',
+  'Window',
+  'MainWindowEditor.Extensions.cs',
+);
+
+interface CatalogEntry {
+  name: string;
+  description: string;
+  packageId: string;
+  gitUrl: string | null;
+  tools: { name: string; description: string }[];
+}
+
+/**
+ * Isolate the `_extensions = { ... }` initialiser, so nothing elsewhere in the file
+ * (`SetupExtensionsSection`'s body, comments) can be mistaken for a catalogue entry.
+ * Brace-scans rather than regexing the whole file, because the entries nest
+ * `tools: new[] { ... }` blocks. String literals are skipped so a `{` or `}` inside a
+ * description cannot unbalance the scan.
+ */
+function extractExtensionsBlock(source: string): string {
+  const anchor = source.indexOf('_extensions');
+  if (anchor === -1) throw new Error(`'_extensions' not found in ${CSHARP_SOURCE}`);
+
+  const open = source.indexOf('{', anchor);
+  if (open === -1) throw new Error(`no '{' after '_extensions' in ${CSHARP_SOURCE}`);
+
+  let depth = 0;
+  let inString = false;
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i];
+
+    if (inString) {
+      if (ch === '\\') {
+        i++; // skip the escaped character
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unbalanced braces in the '_extensions' initialiser of ${CSHARP_SOURCE}`);
+}
+
+const ENTRY_RE =
+  /new\(\s*name:\s*"((?:[^"\\]|\\.)*)"\s*,\s*description:\s*"((?:[^"\\]|\\.)*)"\s*,\s*packageId:\s*"((?:[^"\\]|\\.)*)"\s*,\s*gitUrl:\s*"((?:[^"\\]|\\.)*)"\s*,\s*tools:\s*new\[\]\s*\{([\s\S]*?)\}\s*\)/g;
+const TOOL_RE = /\(\s*"((?:[^"\\]|\\.)*)"\s*,\s*"((?:[^"\\]|\\.)*)"\s*\)/g;
+
+/** Unescape the C# string escapes actually reachable in this file's literals. */
+function unescapeCSharp(s: string): string {
+  return s.replace(/\\(["\\nrt])/g, (_m, c: string) => {
+    if (c === 'n') return '\n';
+    if (c === 'r') return '\r';
+    if (c === 't') return '\t';
+    return c;
+  });
+}
+
+function parseCSharpCatalog(): { entries: CatalogEntry[]; newCount: number } {
+  const block = extractExtensionsBlock(fs.readFileSync(CSHARP_SOURCE, 'utf-8'));
+
+  // How many entries the file CLAIMS to have, counted independently of the entry regex.
+  // Compared against the parse result below so a regex that silently matches a subset
+  // fails loudly as a parser bug instead of masquerading as catalogue drift.
+  const newCount = (block.match(/\bnew\(/g) ?? []).length;
+
+  const entries: CatalogEntry[] = [];
+  ENTRY_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ENTRY_RE.exec(block)) !== null) {
+    const toolsBlock = m[5];
+    const tools: { name: string; description: string }[] = [];
+    TOOL_RE.lastIndex = 0;
+    let t: RegExpExecArray | null;
+    while ((t = TOOL_RE.exec(toolsBlock)) !== null) {
+      tools.push({ name: unescapeCSharp(t[1]), description: unescapeCSharp(t[2]) });
+    }
+    entries.push({
+      name: unescapeCSharp(m[1]),
+      description: unescapeCSharp(m[2]),
+      packageId: unescapeCSharp(m[3]),
+      gitUrl: unescapeCSharp(m[4]),
+      tools,
+    });
+  }
+  return { entries, newCount };
+}
+
+function readJsonCatalog(): CatalogEntry[] {
+  const raw = JSON.parse(fs.readFileSync(CATALOG_JSON, 'utf-8')) as {
+    extensions?: {
+      name?: string;
+      description?: string;
+      packageId?: string;
+      gitUrl?: string | null;
+      tools?: { name?: string; description?: string }[];
+    }[];
+  };
+  return (raw.extensions ?? []).map((e) => ({
+    name: (e.name ?? '').trim(),
+    description: (e.description ?? '').trim(),
+    packageId: (e.packageId ?? '').trim(),
+    gitUrl: e.gitUrl === undefined || e.gitUrl === null || e.gitUrl.trim() === '' ? null : e.gitUrl.trim(),
+    tools: (e.tools ?? []).map((t) => ({
+      name: (t.name ?? '').trim(),
+      description: (t.description ?? '').trim(),
+    })),
+  }));
+}
+
+describe('extensions.catalog.json parity with the C# MainWindowEditor._extensions array', () => {
+  it('both artifacts are reachable from the test (relative layout sanity)', () => {
+    expect(fs.existsSync(CATALOG_JSON), `missing ${CATALOG_JSON}`).toBe(true);
+    expect(fs.existsSync(CSHARP_SOURCE), `missing ${CSHARP_SOURCE}`).toBe(true);
+  });
+
+  // Anti-vacuity guards. Without these, a parser that matched nothing would produce `[]`
+  // and the deep-equal below would only report "drift" — hiding a broken test behind a
+  // plausible-looking failure. Worse, if the JSON were ever empty too, `[] === []` would
+  // pass with the whole tripwire dead. These assert POSITIVE artifacts.
+  it('the C# parser extracts every entry the source declares', () => {
+    const { entries, newCount } = parseCSharpCatalog();
+    expect(newCount, 'no `new(` entries found in the _extensions block').toBeGreaterThanOrEqual(10);
+    expect(
+      entries.length,
+      `the entry regex matched ${entries.length} of ${newCount} \`new(\` entries — the parser, ` +
+        'not the catalogue, is out of date with the C# formatting',
+    ).toBe(newCount);
+  });
+
+  it('the C# parser extracts a non-trivial tool set', () => {
+    const { entries } = parseCSharpCatalog();
+    const toolCount = entries.reduce((n, e) => n + e.tools.length, 0);
+    expect(toolCount, 'parsed zero/too few tools — the tools regex is broken').toBeGreaterThanOrEqual(50);
+    for (const e of entries) {
+      expect(e.tools.length, `${e.packageId} parsed with no tools`).toBeGreaterThan(0);
+    }
+  });
+
+  it('the C# array matches the JSON source of truth exactly', () => {
+    const { entries } = parseCSharpCatalog();
+    expect(
+      entries,
+      'Unity-MCP-Plugin/.../Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs drifted from ' +
+        'Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json. ' +
+        'Update BOTH the C# array and cli/src/utils/extensions-catalog.ts to match the JSON.',
+    ).toEqual(readJsonCatalog());
+  });
+});

--- a/cli/tests/extensions-catalog-parity.test.ts
+++ b/cli/tests/extensions-catalog-parity.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { EXTENSIONS_CATALOG, type ExtensionDescriptor } from '../src/utils/extensions-catalog.js';
+
+// The CLI's EXTENSIONS_CATALOG mirror MUST stay equivalent to the SHARED source of truth
+// `Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json` (shipped in
+// the UPM package). If the catalogue gains/changes/loses an entry, this test fails until
+// the mirror is updated — the drift tripwire that keeps the editor window, the CLI, and the
+// app from diverging. Its sibling `extensions-catalog-csharp-parity.test.ts` enforces the
+// same JSON against the C# array.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CATALOG_JSON = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'Unity-MCP-Plugin',
+  'Packages',
+  'com.ivanmurzak.unity.mcp',
+  'extensions.catalog.json',
+);
+
+interface CatalogJsonEntry {
+  name?: string;
+  description?: string;
+  packageId?: string;
+  version?: string | null;
+  gitUrl?: string | null;
+  tools?: { name?: string; description?: string }[];
+}
+
+/** Trim to a non-empty string, else null (so `""` and a missing field normalise alike). */
+function trimOrNull(v: string | null | undefined): string | null {
+  if (v === undefined || v === null) return null;
+  const s = String(v).trim();
+  return s === '' ? null : s;
+}
+
+/** Normalise a raw JSON entry to the canonical ExtensionDescriptor shape. */
+function normalizeJsonEntry(e: CatalogJsonEntry): ExtensionDescriptor {
+  return {
+    name: (e.name ?? '').trim(),
+    description: (e.description ?? '').trim(),
+    packageId: (e.packageId ?? '').trim(),
+    version: trimOrNull(e.version),
+    gitUrl: trimOrNull(e.gitUrl),
+    tools: (e.tools ?? [])
+      .filter((t) => t.name && t.name.trim() !== '')
+      .map((t) => ({ name: (t.name ?? '').trim(), description: (t.description ?? '').trim() })),
+  };
+}
+
+function readCatalogJson(): CatalogJsonEntry[] {
+  const raw = JSON.parse(fs.readFileSync(CATALOG_JSON, 'utf-8')) as {
+    extensions?: CatalogJsonEntry[];
+  };
+  return (raw.extensions ?? []).filter(
+    (e) => e.name && e.name.trim() !== '' && e.packageId && e.packageId.trim() !== '',
+  );
+}
+
+describe('extensions-catalog parity with Unity-MCP-Plugin/.../extensions.catalog.json', () => {
+  it('the catalogue JSON is reachable from the test (relative layout sanity)', () => {
+    expect(fs.existsSync(CATALOG_JSON)).toBe(true);
+  });
+
+  // Anti-vacuity floor. Every assertion below compares the mirror against the JSON, so a
+  // JSON that failed to load as an empty array would make those comparisons pass against
+  // an empty mirror. These two assert a POSITIVE artifact instead: real content was read.
+  it('the JSON carries the ten shipped extensions and a non-trivial tool set', () => {
+    const entries = readCatalogJson();
+    expect(entries.length).toBeGreaterThanOrEqual(10);
+    const toolCount = entries.reduce((n, e) => n + (e.tools?.length ?? 0), 0);
+    expect(toolCount).toBeGreaterThanOrEqual(50);
+  });
+
+  it('the TS mirror EXTENSIONS_CATALOG matches the JSON source of truth exactly', () => {
+    const expected = readCatalogJson().map(normalizeJsonEntry);
+
+    // Compare as plain objects (EXTENSIONS_CATALOG is readonly; spread to mutable for deep-equal).
+    const actual = EXTENSIONS_CATALOG.map((d) => ({
+      name: d.name,
+      description: d.description,
+      packageId: d.packageId,
+      version: d.version,
+      gitUrl: d.gitUrl,
+      tools: d.tools.map((t) => ({ name: t.name, description: t.description })),
+    }));
+
+    expect(
+      actual,
+      'cli/src/utils/extensions-catalog.ts drifted from ' +
+        'Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json. ' +
+        'Update EXTENSIONS_CATALOG to match the JSON source of truth.',
+    ).toEqual(expected);
+  });
+
+  it('no catalogue entry pins a version (OpenUPM latest is resolved at install time)', () => {
+    // A pin here goes stale on the very next extension release — see extensions.catalog.md.
+    // Asserted on BOTH artifacts: a pin added to only one of them is a drift the deep-equal
+    // above catches, and a pin added to both would slip past it.
+    for (const e of readCatalogJson()) {
+      expect(trimOrNull(e.version), `${e.packageId} pins a version in the JSON`).toBeNull();
+    }
+    for (const d of EXTENSIONS_CATALOG) {
+      expect(d.version, `${d.packageId} pins a version in the TS mirror`).toBeNull();
+    }
+  });
+
+  it('every packageId is unique and lowercase (the UPM dependency key is the install identity)', () => {
+    const ids = EXTENSIONS_CATALOG.map((d) => d.packageId);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(id, `${id} must be lowercase — UPM package names are case-sensitive`).toBe(
+        id.toLowerCase(),
+      );
+    }
+  });
+});

--- a/cli/tests/install-extension-cli.test.ts
+++ b/cli/tests/install-extension-cli.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+
+// The CLI-surface half of `installExtension`'s coverage: the library tests drive the
+// function in-process, these drive the real `unity-mcp-cli install-extension` binary so
+// the commander wiring (registration, argument order, --path, --extension-version, --list,
+// exit codes) is exercised end to end. Mirrors tests/cli.test.ts's runner.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, '..', 'bin', 'unity-mcp-cli.js');
+const TILEMAP_ID = 'com.ivanmurzak.unity.mcp.tilemap';
+
+function runCli(args: string[], options?: { cwd?: string }): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      timeout: 20000,
+      cwd: options?.cwd,
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: (error.stdout ?? '') + (error.stderr ?? ''),
+      exitCode: error.status ?? 1,
+    };
+  }
+}
+
+const tmpDirs: string[] = [];
+function mkUnityProject(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-ext-cli-'));
+  tmpDirs.push(tmpDir);
+  fs.mkdirSync(path.join(tmpDir, 'Packages'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'Packages', 'manifest.json'),
+    JSON.stringify({ dependencies: {} }, null, 2),
+  );
+  return tmpDir;
+}
+
+function readManifest(projectPath: string): {
+  dependencies?: Record<string, string>;
+  scopedRegistries?: { name: string; url: string; scopes: string[] }[];
+} {
+  return JSON.parse(fs.readFileSync(path.join(projectPath, 'Packages', 'manifest.json'), 'utf-8'));
+}
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('install-extension CLI — registration and help', () => {
+  it('is registered on the root command', () => {
+    const { stdout, exitCode } = runCli(['--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('install-extension');
+  });
+
+  it('documents its arguments and options', () => {
+    const { stdout, exitCode } = runCli(['install-extension', '--help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('--extension-version');
+    expect(stdout).toContain('--path');
+    expect(stdout).toContain('--list');
+  });
+
+  // REGRESSION GUARD for a real bug found by these CLI tests and invisible to the
+  // in-process library tests: the flag was originally spelled `--version`, which the ROOT
+  // program's `.version()` option intercepts. `install-extension Tilemap --version 1.0.16`
+  // printed the CLI's own version ("0.88.0") and exited 0 — a silent no-op install on the
+  // primary documented flag. Pin the observable so a rename back cannot pass.
+  it('the version flag installs rather than printing the CLI version', () => {
+    const project = mkUnityProject();
+    const cliVersion = runCli(['--version']).stdout.trim();
+    expect(cliVersion).toMatch(/^\d+\.\d+\.\d+/);
+
+    const { stdout, exitCode } = runCli([
+      'install-extension',
+      'Tilemap',
+      project,
+      '--extension-version',
+      '1.0.16',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).not.toBe(cliVersion);
+    // The positive artifact: the dependency really landed. An assertion that stdout merely
+    // "is not the version string" could be satisfied by any other output, including a
+    // different no-op.
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+});
+
+describe('install-extension CLI — --list', () => {
+  it('lists the shipped extensions without needing a project or the network', () => {
+    // Run from a directory that is NOT a Unity project: --list must not require one.
+    const notAProject = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-ext-cli-none-'));
+    tmpDirs.push(notAProject);
+
+    const { stdout, exitCode } = runCli(['install-extension', '--list'], { cwd: notAProject });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(TILEMAP_ID);
+    expect(stdout).toContain('com.ivanmurzak.unity.mcp.cinemachine');
+    expect(stdout).toContain('Timeline');
+  });
+});
+
+describe('install-extension CLI — failure exit codes', () => {
+  it('exits 1 with a listing hint when no id is given', () => {
+    const project = mkUnityProject();
+    const { stdout, exitCode } = runCli(['install-extension'], { cwd: project });
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('--list');
+  });
+
+  it('exits 1 for an unknown extension id', () => {
+    const project = mkUnityProject();
+    const { stdout, exitCode } = runCli(['install-extension', 'com.example.nope', project]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain('Unknown extension');
+  });
+
+  it('exits 1 when the target directory is not a Unity project', () => {
+    const notAProject = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-ext-cli-none-'));
+    tmpDirs.push(notAProject);
+    const { exitCode } = runCli([
+      'install-extension',
+      'Tilemap',
+      notAProject,
+      '--extension-version',
+      '1.0.16',
+    ]);
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe('install-extension CLI — real installs', () => {
+  // An explicit --extension-version keeps these offline: the version-resolution path is
+  // covered in-process (with a stubbed fetch) by tests/install-extension.test.ts.
+  it('installs into the positional path and patches the manifest', () => {
+    const project = mkUnityProject();
+    const { stdout, exitCode } = runCli([
+      'install-extension',
+      'Tilemap',
+      project,
+      '--extension-version',
+      '1.0.16',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(TILEMAP_ID);
+
+    const manifest = readManifest(project);
+    expect(manifest.dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+    const registry = manifest.scopedRegistries?.find((r) => r.name === 'package.openupm.com');
+    expect(registry?.scopes).toContain('com.ivanmurzak');
+  });
+
+  it('accepts the project via --path', () => {
+    const project = mkUnityProject();
+    const { exitCode } = runCli([
+      'install-extension',
+      'Tilemap',
+      '--path',
+      project,
+      '--extension-version',
+      '1.0.16',
+    ]);
+    expect(exitCode).toBe(0);
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+
+  it('defaults the project to the current directory', () => {
+    const project = mkUnityProject();
+    const { exitCode } = runCli(['install-extension', 'Tilemap', '--extension-version', '1.0.16'], {
+      cwd: project,
+    });
+    expect(exitCode).toBe(0);
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+
+  it('accepts a full package id as well as the display name', () => {
+    const project = mkUnityProject();
+    const { exitCode } = runCli([
+      'install-extension',
+      TILEMAP_ID,
+      project,
+      '--extension-version',
+      '1.0.16',
+    ]);
+    expect(exitCode).toBe(0);
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+
+  it('is idempotent across process boundaries (exit 0, up-to-date on the second run)', () => {
+    const project = mkUnityProject();
+    const first = runCli(['install-extension', 'Tilemap', project, '--extension-version', '1.0.16']);
+    expect(first.exitCode).toBe(0);
+
+    const second = runCli(['install-extension', 'Tilemap', project, '--extension-version', '1.0.16']);
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toContain('already up to date');
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+});

--- a/cli/tests/install-extension.test.ts
+++ b/cli/tests/install-extension.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { installExtension } from '../src/lib.js';
+import { EXTENSIONS_CATALOG, findExtension } from '../src/utils/extensions-catalog.js';
+import type { ExtensionDescriptor, ProgressEvent } from '../src/lib.js';
+
+const TILEMAP_ID = 'com.ivanmurzak.unity.mcp.tilemap';
+const REGISTRY_NAME = 'package.openupm.com';
+
+function mkUnityProject(manifest: unknown = { dependencies: {} }): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-ext-test-'));
+  fs.mkdirSync(path.join(tmpDir, 'Packages'), { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'Packages', 'manifest.json'),
+    typeof manifest === 'string' ? manifest : JSON.stringify(manifest, null, 2),
+  );
+  return tmpDir;
+}
+
+function readManifest(projectPath: string): {
+  dependencies?: Record<string, string>;
+  scopedRegistries?: { name: string; url: string; scopes: string[] }[];
+} {
+  return JSON.parse(fs.readFileSync(path.join(projectPath, 'Packages', 'manifest.json'), 'utf-8'));
+}
+
+/** Stub OpenUPM's packument endpoint so no test touches the network. */
+function stubOpenUpm(latest: string): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ 'dist-tags': { latest } }),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+const tmpDirs: string[] = [];
+function track(dir: string): string {
+  tmpDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  while (tmpDirs.length) {
+    const dir = tmpDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Catalogue lookup
+// ---------------------------------------------------------------------------
+
+describe('findExtension', () => {
+  it('resolves by exact package id', () => {
+    expect(findExtension(TILEMAP_ID)?.name).toBe('Tilemap');
+  });
+
+  it('resolves by package id case-insensitively', () => {
+    expect(findExtension(TILEMAP_ID.toUpperCase())?.packageId).toBe(TILEMAP_ID);
+  });
+
+  it('resolves by display name case-insensitively', () => {
+    expect(findExtension('tilemap')?.packageId).toBe(TILEMAP_ID);
+    expect(findExtension('Cinemachine')?.packageId).toBe('com.ivanmurzak.unity.mcp.cinemachine');
+  });
+
+  it('returns null for an unknown id, an empty string, and nullish input', () => {
+    expect(findExtension('com.example.nope')).toBeNull();
+    expect(findExtension('')).toBeNull();
+    expect(findExtension('   ')).toBeNull();
+    expect(findExtension(undefined)).toBeNull();
+    expect(findExtension(null)).toBeNull();
+  });
+
+  it('the shipped catalogue lists the ten extensions, all unpinned', () => {
+    expect(EXTENSIONS_CATALOG.length).toBeGreaterThanOrEqual(10);
+    for (const d of EXTENSIONS_CATALOG) {
+      expect(d.version).toBeNull();
+      expect(d.packageId.startsWith('com.ivanmurzak.unity.mcp.')).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure paths — never throw past the public boundary
+// ---------------------------------------------------------------------------
+
+describe('installExtension — failures', () => {
+  it('fails with an actionable message for an unknown extension id', async () => {
+    const project = track(mkUnityProject());
+    const result = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'com.example.nope',
+    });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('unreachable');
+    expect(result.error.message).toContain('Unknown extension "com.example.nope"');
+    // The message must list what IS installable, so the user can self-correct.
+    expect(result.error.message).toContain(TILEMAP_ID);
+    expect(result.extensionId).toBe('com.example.nope');
+  });
+
+  it('fails when the path is not a Unity project, and names the missing manifest', async () => {
+    const empty = track(fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-ext-empty-')));
+    const result = await installExtension({ unityProjectPath: empty, extensionId: 'Tilemap' });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('unreachable');
+    expect(result.error.message).toContain('Packages/manifest.json');
+    expect(result.packageId).toBe(TILEMAP_ID);
+    expect(result.manifestPath).toContain('manifest.json');
+  });
+
+  it('resolves the catalogue BEFORE touching the filesystem', async () => {
+    // An unknown id in a non-project directory must report the unknown extension, not
+    // the missing manifest: the catalogue miss is the user's actual mistake.
+    const empty = track(fs.mkdtempSync(path.join(os.tmpdir(), 'unity-mcp-ext-empty-')));
+    const result = await installExtension({ unityProjectPath: empty, extensionId: 'nope' });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('unreachable');
+    expect(result.error.message).toContain('Unknown extension');
+  });
+
+  it('returns a failure (not a throw) when the manifest is unparseable', async () => {
+    const project = track(mkUnityProject('{ this is not json'));
+    const result = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.0',
+    });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('unreachable');
+    expect(result.error).toBeInstanceOf(Error);
+  });
+
+  it('surfaces an OpenUPM failure as a failure result suggesting --extension-version', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) })),
+    );
+    const project = track(mkUnityProject());
+    const result = await installExtension({ unityProjectPath: project, extensionId: 'Tilemap' });
+
+    expect(result.kind).toBe('failure');
+    if (result.kind !== 'failure') throw new Error('unreachable');
+    // The escape hatch named in the error must be the flag the CLI actually accepts.
+    expect(result.error.message).toContain('--extension-version');
+    // Nothing was written — a failed version resolution must not half-patch the manifest.
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The install itself
+// ---------------------------------------------------------------------------
+
+describe('installExtension — add', () => {
+  it('adds the dependency and the OpenUPM scoped registry with the required scopes', async () => {
+    const project = track(mkUnityProject());
+    const result = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.16',
+    });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('unreachable');
+    expect(result.outcome).toBe('added');
+    expect(result.changed).toBe(true);
+    expect(result.fromVersion).toBeNull();
+    expect(result.toVersion).toBe('1.0.16');
+    expect(result.packageId).toBe(TILEMAP_ID);
+    expect(result.nextSteps.length).toBeGreaterThan(0);
+
+    const manifest = readManifest(project);
+    expect(manifest.dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+
+    const registry = manifest.scopedRegistries?.find((r) => r.name === REGISTRY_NAME);
+    expect(registry).toBeDefined();
+    expect(registry?.url).toBe('https://package.openupm.com');
+    // `com.ivanmurzak` is the load-bearing scope: without it UPM resolves the extension
+    // against Unity's default registry and the install silently fails to restore.
+    expect(registry?.scopes).toContain('com.ivanmurzak');
+    expect(registry?.scopes).toContain('extensions.unity');
+  });
+
+  it('resolves OpenUPM dist-tags.latest when no version is supplied', async () => {
+    const fetchMock = stubOpenUpm('9.9.9');
+    const project = track(mkUnityProject());
+    const result = await installExtension({ unityProjectPath: project, extensionId: 'Tilemap' });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('unreachable');
+    expect(result.toVersion).toBe('9.9.9');
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('9.9.9');
+
+    // It must ask OpenUPM about the EXTENSION, not about the plugin.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(`https://package.openupm.com/${TILEMAP_ID}`);
+  });
+
+  it('does not hit the network when an explicit version is supplied', async () => {
+    const fetchMock = stubOpenUpm('9.9.9');
+    const project = track(mkUnityProject());
+    await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.0',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves unrelated dependencies and an existing scoped registry entry', async () => {
+    const project = track(
+      mkUnityProject({
+        dependencies: { 'com.unity.modules.tilemap': '1.0.0' },
+        scopedRegistries: [
+          { name: REGISTRY_NAME, url: 'https://package.openupm.com', scopes: ['com.someoneelse'] },
+        ],
+      }),
+    );
+    await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.16',
+    });
+
+    const manifest = readManifest(project);
+    expect(manifest.dependencies?.['com.unity.modules.tilemap']).toBe('1.0.0');
+    expect(manifest.scopedRegistries).toHaveLength(1);
+    const scopes = manifest.scopedRegistries?.[0].scopes ?? [];
+    expect(scopes).toContain('com.someoneelse');
+    expect(scopes).toContain('com.ivanmurzak');
+  });
+});
+
+describe('installExtension — update / idempotence', () => {
+  it('is idempotent: a second identical run reports already-up-to-date and rewrites nothing', async () => {
+    const project = track(mkUnityProject());
+    await installExtension({ unityProjectPath: project, extensionId: 'Tilemap', version: '1.0.16' });
+
+    const manifestPath = path.join(project, 'Packages', 'manifest.json');
+    const before = fs.readFileSync(manifestPath, 'utf-8');
+
+    const second = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.16',
+    });
+
+    expect(second.kind).toBe('success');
+    if (second.kind !== 'success') throw new Error('unreachable');
+    expect(second.outcome).toBe('already-up-to-date');
+    expect(second.changed).toBe(false);
+    expect(second.fromVersion).toBe('1.0.16');
+    expect(second.toVersion).toBe('1.0.16');
+    expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(before);
+  });
+
+  it('reports `updated` with both versions when a newer version is installed', async () => {
+    const project = track(mkUnityProject());
+    await installExtension({ unityProjectPath: project, extensionId: 'Tilemap', version: '1.0.10' });
+    const result = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.16',
+    });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('unreachable');
+    expect(result.outcome).toBe('updated');
+    expect(result.changed).toBe(true);
+    expect(result.fromVersion).toBe('1.0.10');
+    expect(result.toVersion).toBe('1.0.16');
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+
+  it('never downgrades on an auto-resolved version, and warns instead', async () => {
+    const project = track(mkUnityProject());
+    await installExtension({ unityProjectPath: project, extensionId: 'Tilemap', version: '2.0.0' });
+
+    stubOpenUpm('1.0.16');
+    const result = await installExtension({ unityProjectPath: project, extensionId: 'Tilemap' });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('unreachable');
+    expect(result.outcome).toBe('already-up-to-date');
+    expect(result.toVersion).toBe('2.0.0');
+    expect(result.warnings.join(' ')).toContain('2.0.0');
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('2.0.0');
+  });
+
+  it('allows a downgrade when the version is explicit', async () => {
+    const project = track(mkUnityProject());
+    await installExtension({ unityProjectPath: project, extensionId: 'Tilemap', version: '2.0.0' });
+    const result = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.16',
+    });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') throw new Error('unreachable');
+    expect(result.outcome).toBe('updated');
+    expect(result.fromVersion).toBe('2.0.0');
+    expect(result.toVersion).toBe('1.0.16');
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+
+  it('classifies as `added` even when the scoped registry also had to be created', async () => {
+    // `addPackageToManifest` reports `modified: true` for a registry-only change too, so
+    // the outcome must be derived from the dependency's prior presence, not from `modified`.
+    const project = track(mkUnityProject({ dependencies: {} }));
+    const result = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.16',
+    });
+    if (result.kind !== 'success') throw new Error('unreachable');
+    expect(result.outcome).toBe('added');
+    expect(result.fromVersion).toBeNull();
+  });
+});
+
+describe('installExtension — progress + catalogue override', () => {
+  it('emits start / dependencies-resolved / manifest-patched / done in order', async () => {
+    stubOpenUpm('1.2.3');
+    const project = track(mkUnityProject());
+    const events: ProgressEvent[] = [];
+    await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      onProgress: (e) => events.push(e),
+    });
+
+    expect(events.map((e) => e.phase)).toEqual([
+      'start',
+      'dependencies-resolved',
+      'manifest-patched',
+      'done',
+    ]);
+  });
+
+  it('a throwing onProgress callback cannot abort the install', async () => {
+    const project = track(mkUnityProject());
+    const result = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.16',
+      onProgress: () => {
+        throw new Error('consumer bug');
+      },
+    });
+
+    expect(result.kind).toBe('success');
+    expect(readManifest(project).dependencies?.[TILEMAP_ID]).toBe('1.0.16');
+  });
+
+  it('honours a catalogue override, including an empty catalogue', async () => {
+    const project = track(mkUnityProject());
+    const custom: ExtensionDescriptor[] = [
+      {
+        name: 'Custom',
+        description: 'A test-only extension.',
+        packageId: 'com.example.custom',
+        version: null,
+        gitUrl: null,
+        tools: [],
+      },
+    ];
+
+    const ok = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Custom',
+      version: '0.1.0',
+      catalog: custom,
+    });
+    expect(ok.kind).toBe('success');
+    expect(readManifest(project).dependencies?.['com.example.custom']).toBe('0.1.0');
+
+    // A shipped id must NOT resolve against an overridden catalogue.
+    const miss = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      version: '1.0.0',
+      catalog: custom,
+    });
+    expect(miss.kind).toBe('failure');
+
+    const empty = await installExtension({
+      unityProjectPath: project,
+      extensionId: 'Tilemap',
+      catalog: [],
+    });
+    expect(empty.kind).toBe('failure');
+    if (empty.kind !== 'failure') throw new Error('unreachable');
+    expect(empty.error.message).toContain('catalogue is currently empty');
+  });
+});

--- a/docs/openupm-signing.md
+++ b/docs/openupm-signing.md
@@ -89,40 +89,48 @@ gh secret set UPM_SERVICE_ACCOUNT_KEY_SECRET --repo IvanMurzak/Unity-MCP
 gh secret set UPM_ORG_ID                     --repo IvanMurzak/Unity-MCP
 ```
 
-### 3. File the OpenUPM listing change
+### 3. The OpenUPM listing change — ✅ ALREADY DONE
 
-OpenUPM's package listing for `com.ivanmurzak.unity.mcp` currently has
-`trackingMode: git`, which makes OpenUPM pack and serve unsigned tarballs from
-the repository's git tags. To make OpenUPM serve the signed tarball that the
-workflow now uploads, the listing must be flipped to `trackingMode: githubRelease`.
+> **This step is complete. Do not re-file it.** Read live from
+> `https://raw.githubusercontent.com/openupm/openupm/master/data/packages/com.ivanmurzak.unity.mcp.yml`
+> (HTTP 200) on **2026-08-17**, the listing already carries **both** required values:
+>
+> ```yaml
+> trackingMode: githubRelease
+> githubReleaseAssetName: 'com.ivanmurzak.unity.mcp-'
+> ```
+>
+> An earlier revision of this document stated the listing "currently has
+> `trackingMode: git`" and "must be flipped". **That was true when written and is now
+> stale.** It was corrected here after a live read, because acting on it would have meant
+> opening a redundant PR against `openupm/openupm` — or, worse, treating a satisfied
+> precondition as a release blocker.
 
 The listing lives in the [openupm/openupm](https://github.com/openupm/openupm)
-repository at `data/packages/com.ivanmurzak.unity.mcp.yml`. Open a PR there
-changing:
+repository at `data/packages/com.ivanmurzak.unity.mcp.yml`, and only a PR there can change
+it — the value is registry-side, so nothing in this repository controls it.
 
-```yaml
-trackingMode: git
-```
+**What `trackingMode: githubRelease` means for a release.** OpenUPM republishes the
+`.tgz` **release asset** instead of packing the git tag, so the signed tarball is what
+Unity users receive. Two consequences worth keeping in mind:
 
-to:
+- The `com.ivanmurzak.unity.mcp-<version>.tgz` asset is **on OpenUPM's critical path**. A
+  release whose signed tarball failed to upload publishes a tag OpenUPM cannot ingest.
+  (Under the old `trackingMode: git` the tag alone was sufficient — that is no longer the
+  shape to reason about.)
+- The `githubReleaseAssetName` prefix guard makes OpenUPM select the tarball by filename
+  rather than guessing from the asset list. This matters because a release also ships
+  `.unitypackage` and may add further `.tgz` assets later.
 
-```yaml
-trackingMode: githubRelease
-```
+**Verified against the live releases:** release `0.88.0` carries exactly two assets —
+`com.ivanmurzak.unity.mcp-0.88.0.tgz` (756,589 bytes) and
+`AI-Game-Dev-Installer.unitypackage` (27,304 bytes) — and `package.openupm.com` serves
+`dist-tags.latest = 0.88.0`, so the ingest path is demonstrably working end to end.
 
-Per the OpenUPM blog, switch `trackingMode` to `githubRelease` **before** the
-first signed release ships, so OpenUPM does not race-publish the unsigned git
-tag in parallel.
-
-Also set `githubReleaseAssetName` so OpenUPM picks the signed tarball by
-filename prefix rather than guessing from the asset list. The release already
-ships `.unitypackage` and multiple server `.zip` assets, and may add more
-`.tgz` assets later (e.g. signing a second package), so the prefix guard
-prevents a future-breaking failure mode:
-
-```yaml
-githubReleaseAssetName: 'com.ivanmurzak.unity.mcp-'
-```
+Note also that this repository's release tags are **bare** (`0.88.0`), with no `v` prefix:
+`release.yml`'s `check-version-tag` job passes `tag: ${{ steps.get_version.outputs.current-version }}`
+straight to `mukunku/tag-exists-action`. A pre-release check for `v<version>` would look at
+a tag namespace this repo has never used and would always report "absent".
 
 ## Verifying signing worked
 


### PR DESCRIPTION
## What this is

The Unity extension install rail: `installExtension` (library + `install-extension` command) plus a shared `extensions.catalog.json` listing the ten shipped extensions, mirroring the Godot pattern **including its build-failing catalogue parity test**.

**This PR is content only. It carries no version bump and cuts no release.** Content lands and goes green on `main` first; the release is a separate, later step. Nothing here publishes anything.

---

## The catalogue's canonical location and its second consumer — the decision this task had to make

Unity was described as having "no extensions catalogue of any kind today". That is true of a *file*, but **not** of the data: the editor already ships a hardcoded C# array, `MainWindowEditor._extensions` (`Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs`, 10 entries). It is load-bearing — it builds the *AI Game Developer* window's Extensions section and feeds `ExtensionPanel.AddToManifest`, the real in-editor installer.

So this PR makes the JSON the shared source of truth for **three** artifacts:

| Artifact | Path | Consumer | Ships via |
|---|---|---|---|
| **JSON source of truth** | `Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json` | the spec both code artifacts are tested against | UPM package (OpenUPM) |
| **C# array** | `…/Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs` § `_extensions` | editor Extensions UI + `ExtensionPanel.AddToManifest` | UPM package (OpenUPM) |
| **TypeScript mirror** | `cli/src/utils/extensions-catalog.ts` § `EXTENSIONS_CATALOG` | `installExtension` in this CLI | npm |

**The parity tests compare TWO independently maintained artifacts, twice over:**

- `cli/tests/extensions-catalog-parity.test.ts` — **json ↔ TypeScript mirror**, all six fields.
- `cli/tests/extensions-catalog-csharp-parity.test.ts` — **json ↔ C# array**, the five fields the C# `ExtensionData` struct carries.

Neither compares an artifact against itself. The C# side is unambiguously independently maintained *and* independently consumed, which is what gives the tripwire its power.

**Deliberate scope decision: the C# array is NOT refactored to read the JSON at editor runtime.** `git diff` against `main` for that file is **empty** — it is byte-identical. Making the editor load the JSON would put a new file-load path in front of the extension list for *every existing Unity user*, and its failure mode is a silently empty list. The parity tests deliver the same anti-drift guarantee with none of that risk. Rationale is recorded in-repo in `extensions.catalog.md`, not just here. If the C# side later moves onto the JSON, the json↔C# test becomes redundant rather than wrong.

Both tests live in the CLI vitest suite on purpose: no Unity licence, no editor, and they gate **every PR** via `test_cli.yml` *and* the publish job via `deploy.yml:66-69`. Precedent for a TS test parsing engine-side source to enforce parity: Godot-MCP's `cli/tests/skills-addon-parity.test.ts`.

### `version: null` on all ten

No entry pins a version; OpenUPM's `dist-tags.latest` is resolved live at install time (CLI: `resolveLatestPackageVersion`; editor: `ExtensionPanel.FetchLatestOpenUpmVersionAsync`). A pin would go stale on the very next extension release. `version` has no C# counterpart *because* the editor always resolves latest — so the json↔C# test compares five fields, and the no-pin claim is asserted separately on both JSON and mirror.

---

## The parity tests are proven build-failing, in both directions

Four plants, each mutating **exactly one** artifact, each RED attributed from its own run rather than from a suite count. Command: `npx vitest run tests/extensions-catalog-parity.test.ts tests/extensions-catalog-csharp-parity.test.ts --testTimeout=30000`. Every plant was reverted from a pristine byte-for-byte backup and the tree verified clean afterwards.

### Plant 1 — mutate the TypeScript mirror only → json↔TS RED, json↔C# GREEN

`tilemap-set-tile` description changed to `'PLANT1 mutated tool description'` in `extensions-catalog.ts` only.

```
FAIL tests/extensions-catalog-parity.test.ts > the TS mirror EXTENSIONS_CATALOG matches the JSON source of truth exactly
AssertionError: cli/src/utils/extensions-catalog.ts drifted from Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json. Update EXTENSIONS_CATALOG to match the JSON source of truth.: expected [ { name: 'Animation', …(5) }, …(9) ] to deeply equal [ { name: 'Animation', …(5) }, …(9) ]

 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 8 passed (9)
```

### Plant 2 — mutate the C# array only → json↔C# RED, json↔TS GREEN

`tilemap-set-tile` description changed to `"PLANT2 mutated in C# only"` in the C# array only.

```
FAIL tests/extensions-catalog-csharp-parity.test.ts > the C# array matches the JSON source of truth exactly
AssertionError: Unity-MCP-Plugin/.../Editor/Scripts/UI/Window/MainWindowEditor.Extensions.cs drifted from Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/extensions.catalog.json. Update BOTH the C# array and cli/src/utils/extensions-catalog.ts to match the JSON.: expected [ { name: 'Animation', …(4) }, …(9) ] to deeply equal [ { name: 'Animation', …(4) }, …(9) ]

 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 8 passed (9)
```

Plants 1 and 2 are mirror images, which proves more than "the test can fail": each pairing fails on **its own** artifact and correctly ignores the other's. A single plant could not distinguish that from one test failing on everything.

### Plant 3 — mutate the JSON only → BOTH RED

Tilemap `packageId` changed to `com.ivanmurzak.unity.mcp.plant3` in the JSON only.

```
FAIL tests/extensions-catalog-csharp-parity.test.ts > the C# array matches the JSON source of truth exactly
FAIL tests/extensions-catalog-parity.test.ts > the TS mirror EXTENSIONS_CATALOG matches the JSON source of truth exactly

 Test Files  2 failed (2)
      Tests  2 failed | 7 passed (9)
```

### Plant 4 — a claim the deep-equal *cannot* catch

Tilemap pinned to `1.0.16` in **both** the JSON and the mirror, so they still agree and both deep-equals pass. Only the dedicated no-pin assertion fires:

```
× no catalogue entry pins a version (OpenUPM latest is resolved at install time)
AssertionError: com.ivanmurzak.unity.mcp.tilemap pins a version in the JSON: expected '1.0.16' to be null

 Test Files  1 failed | 1 passed (2)
      Tests  1 failed | 8 passed (9)
```

This is why the plant count is four and not one: "no entry pins a version" is a **separate claim** from "the artifacts agree", and a consistent pin slips past the deep-equal entirely.

### Anti-vacuity guards inside the tests

An empty parse or an unreadable JSON would make a deep-equal pass against an empty mirror. Both suites therefore assert **positive artifacts**: ≥10 entries read, ≥50 tools parsed, every entry non-empty, and — in the C# suite — that the entry regex matched **the same count** as an independent `\bnew\(` tally, so a parser that silently matched a subset fails as a parser bug instead of masquerading as catalogue drift.

### Positive control (the unmutated pair is GREEN)

```
 Test Files  38 passed (38)
      Tests  585 passed | 2 skipped (587)
```
`npm test` exit status **0** (captured unpiped). New tests: 43 across four files — `install-extension-cli` (12), `install-extension` (22), `extensions-catalog-csharp-parity` (4), `extensions-catalog-parity` (5).

---

## ⚠️ Local suite flakiness — pre-existing, environmental, and NOT caused by this PR

Early full-suite runs on the dev machine failed with `Test timed out in 5000ms` in files this PR does not touch (`open-lib.test.ts`, then `cli.test.ts` + `unity-editor.test.ts` — a **different** set each run). Each passed in isolation.

I baselined it rather than assume: with **all four new test files moved out of `tests/`**, the suite still failed the same way (`unity-editor.test.ts`, 5000 ms timeout). So the flake is pre-existing and load-induced on a shared machine, not introduced here. With parallelism constrained (`--maxWorkers=2`), the full suite including the new tests is green, exit 0.

**Worth flagging for a future PR (out of scope here):** several tests rely on the default 5 s vitest timeout and are load-sensitive. `deploy.yml:66-69` re-runs `npm test` *inside the publish job*, where a timeout flake fails the publish **after** the plugin release has already happened. CI is the authoritative signal for this PR.

---

## Registry-side reads — both performed, recorded verbatim

Both were read **live** today; neither is an assumption.

### (i) The OpenUPM listing's `trackingMode` for `com.ivanmurzak.unity.mcp`

- **What:** `trackingMode: githubRelease`, and `githubReleaseAssetName: 'com.ivanmurzak.unity.mcp-'`
- **From:** `https://raw.githubusercontent.com/openupm/openupm/master/data/packages/com.ivanmurzak.unity.mcp.yml` — **HTTP 200**
- **When:** 2026-08-17T14:45:23Z

```yaml
name: com.ivanmurzak.unity.mcp
repoUrl: https://github.com/IvanMurzak/Unity-MCP
trackingMode: githubRelease
githubReleaseAssetName: 'com.ivanmurzak.unity.mcp-'
gitTagPrefix: ''
licenseSpdxId: Apache-2.0
```

**This corrects stale in-repo documentation.** `docs/openupm-signing.md` stated the listing "currently has `trackingMode: git`" and "must be flipped", filed under *One-time setup (repository owner)*. It is already flipped, and **both** required values are present. Acting on the doc would have meant filing a redundant PR against `openupm/openupm`, or treating a satisfied precondition as a release blocker. **This PR corrects that doc.**

Consequence: OpenUPM republishes the **release asset**, so `com.ivanmurzak.unity.mcp-<version>.tgz` is **on OpenUPM's critical path** — the tag alone is no longer sufficient.

### (ii) The npm trusted-publisher configuration for `unity-mcp-cli`

- **What:** a **GitHub OIDC trusted publisher** is configured and in active use.
- **From:** the npm registry packument, `https://registry.npmjs.org/unity-mcp-cli`, field `versions['0.88.0']._npmUser`:

```json
{"name":"GitHub Actions","email":"npm-oidc-no-reply@github.com",
 "trustedPublisher":{"id":"github","oidcConfigId":"oidc:2134457d-bbbc-4d65-9947-4d3608c4886a"}}
```

- **Which workflow file it is bound to** — from the SLSA provenance attestation, `https://registry.npmjs.org/-/npm/v1/attestations/unity-mcp-cli@0.88.0` (HTTP 200), `predicate.buildDefinition.externalParameters.workflow`:

```json
{"ref":"refs/heads/main",
 "repository":"https://github.com/IvanMurzak/Unity-MCP",
 "path":".github/workflows/release.yml"}
```
with `internalParameters.github.event_name = "push"`, builder `github-hosted`, run `31948179026`, source commit `d9a733a0146353778fdbf9e43ed1a6ffda75945a`.

- **Stability, not a one-off:** the **same** `oidcConfigId` published **twelve consecutive versions**, 0.84.0 → 0.88.0. Zero token publishes in that range. Latest: 0.88.0 at 2026-08-16T13:12:35Z.
- **When:** 2026-08-17, ~14:45–14:50Z.

**What this settles, and what it does not.** The taskflow's open question was whether npm matches the binding against the reusable workflow (`workflow_ref`) or its caller (`job_workflow_ref`). The recorded publisher is **`release.yml`** — the caller — which is the `workflow_ref` view; the reusable `deploy.yml` does not appear. The decision-relevant fact is stronger than the abstract question: **the exact route DoD 8 mandates (`release.yml` on a push to `main` → `deploy.yml` via `workflow_call`) is empirically proven to satisfy the trusted publisher, twelve times, most recently one day ago.**

**Still genuinely unknown, and deliberately left so:** whether a *direct* `deploy.yml` `workflow_dispatch` would satisfy the binding. That path is forbidden by DoD 8 anyway, so the answer is not needed — and finding out costs an irreversible version number. Not tested. npm does not expose the configured workflow *filename* string publicly (`www.npmjs.com` returns **HTTP 403** to a scripted fetch), so the provenance record is the strongest available registry-side evidence; it is observational (what npm accepted) rather than a read of the config form.

---

## Version headroom — proof nothing is already taken

Next version would be **0.89.0** (a feature addition). **This PR does not bump it.**

| Check | Result |
|---|---|
| npm `unity-mcp-cli` | 77 versions, `dist-tags.latest = 0.88.0`; **0.89.0 absent** |
| OpenUPM `com.ivanmurzak.unity.mcp` | 186 versions, `dist-tags.latest = 0.88.0`; **0.89.0 absent** (`'0.89.0' in versions → False`) |
| git tag `0.89.0` | absent (`git rev-parse --verify refs/tags/0.89.0` → exit 1) |
| git tag `v0.89.0` | absent — **and so is every `v*` tag** |

⚠️ **Spec/doc correction:** this repository's tags are **bare** (`0.88.0`), not `v`-prefixed. `git tag -l "v0.8*"` returns nothing while `git tag -l` returns 186 tags ending `0.87.0`, `0.88.0`. `release.yml`'s `check-version-tag` passes `tag: ${{ steps.get_version.outputs.current-version }}` — the bare version — to `mukunku/tag-exists-action`, and the OpenUPM listing confirms `gitTagPrefix: ''`. **A pre-release check for a `v<version>` tag would inspect a namespace this repo has never used and would always report "absent" — i.e. it would never protect anything.** Check the bare tag.

---

## What the release cascade would do on merge — so the owner can gate it with full information

Merging to `main` fires `release.yml` (`on: push: branches: [main]`), gated by `check-version-tag`: **if the tag for the current `package.json` version already exists, the release jobs are skipped.** Since this PR does **not** bump the version, tag `0.88.0` already exists ⇒ **merging this PR publishes nothing.** The publish only happens on the later, separate version-bump merge.

When that bump does merge, the cascade publishes:

| Artifact | Registry / channel | Irreversible? |
|---|---|---|
| Unity plugin `com.ivanmurzak.unity.mcp` | GitHub Release + **OpenUPM** (every existing Unity user) | **yes** |
| `com.ivanmurzak.unity.mcp-<v>.tgz` (signed UPM tarball) | GitHub Release asset — **on OpenUPM's critical path** under `trackingMode: githubRelease` | **yes** |
| `AI-Game-Dev-Installer.unitypackage` | GitHub Release asset | yes |
| `unity-mcp-cli` | **npm**, `--access public --provenance`, OIDC | **yes** |
| git tag `<v>` (bare) | this repo | effectively yes — the gate refuses a re-cut |
| Discord announcement | webhook | n/a (failure reddens the run without undoing the release) |

**The ten `Unity-AI-*` extensions are NOT published by this repository's workflows.** Verified: zero `repository_dispatch` and zero extension references in `release.yml` (jobs: `test-cli`, `check-version-tag`, `prepare-release-notes`, `build-unity-installer`, `build-signed-upm-package`, `release-unity-plugin`, `deploy`, `cleanup-artifacts`). The extension cascade is a **pipeline-target behaviour** run separately, not something a merge triggers.

**Expected GitHub Release assets** (pattern from `0.88.0`, published 2026-08-16T13:11:57Z): `com.ivanmurzak.unity.mcp-<v>.tgz` (~757 KB) and `AI-Game-Dev-Installer.unitypackage` (~27 KB). Under the confirmed `trackingMode: githubRelease`, the `.tgz` is what OpenUPM ingests — **not** the tag.

### Forward-only recovery — do not attempt a re-publish

**A bad publish cannot be withdrawn.** Published npm and OpenUPM versions cannot be replaced or unpublished. Recovery is **forward-only, via a fresh patch bump**. Specifically, and for whoever reads this later:

- **Never** re-dispatch `deploy.yml` for the same version.
- **Never** delete and re-cut a tag — `check-version-tag` requires that no tag for the version exists yet, and re-cutting defeats the gate that exists to protect you.
- **Never** hand-run `npm publish`.
- The fix for any bad release is the next version number.

### The `unity-ai-*` standalone release leaf targets were deliberately NOT run

They were not run, and must not be run after the release: their resolve-version step patch-bumps from the current version and would **double-bump** all ten extensions.

---

## Hand-off to `w3-4-plugin-probe-install`

**Not yet publishable facts** — no release has been cut by this PR, so the published versions do not exist yet. What is fixed now is the **API shape**:

```ts
import { installExtension, EXTENSIONS_CATALOG, findExtension } from 'unity-mcp-cli';
import type {
  InstallExtensionOptions, InstallExtensionResult,
  InstallExtensionOutcome, ExtensionDescriptor, ExtensionTool,
} from 'unity-mcp-cli';

function installExtension(opts: {
  unityProjectPath: string;
  extensionId: string;                          // package id OR display name, case-insensitive
  version?: string;                             // omit → OpenUPM dist-tags.latest, live
  catalog?: readonly ExtensionDescriptor[];     // test/override seam
  onProgress?: (e: ProgressEvent) => void;      // start | dependencies-resolved | manifest-patched | done
}): Promise<InstallExtensionResult>;            // { kind: 'success' | 'failure' }, never throws
```

On success: `outcome: 'added' | 'updated' | 'already-up-to-date'`, `changed`, `extensionId`, `packageId`, `fromVersion: string | null`, `toVersion`, `manifestPath`, `message`, `warnings`, `nextSteps`. On failure: `extensionId`, optional `packageId` / `manifestPath`, `warnings`, `nextSteps`, `error`.

- **CLI:** `unity-mcp-cli install-extension <id> [path] [--path <p>] [--extension-version <v>] [--list]`
- **Progress phases reuse the existing `ProgressEvent` union** — no new phase names, so the app's forwarder needs no new cases.
- **The ten package ids are `com.ivanmurzak.unity.mcp.<name>`** — `animation`, `cinemachine`, `inputsystem`, `navigation`, `particlesystem`, `probuilder`, `splines`, `terrain`, `tilemap`, `timeline`. All ten verified live on OpenUPM (HTTP 200, published versions). ⚠️ **Not** `com.ivanmurzak.unity.ai.*`, which appears nowhere in this repository.
- Version numbers to be filled in once the release is cut: `unity-mcp-cli@<v>` and plugin `<v>`, which are **the same number** by construction.

---

## Reviewer notes / findings

1. **The `--extension-version` flag name is load-bearing, not cosmetic.** It was first written as `--version`, which the root program's `.version()` intercepts: `install-extension Tilemap --version 1.0.16` printed `0.88.0` and exited **0** without installing — a silent no-op on the primary documented flag. Caught by the CLI-surface tests and **invisible to the in-process library tests**; a regression guard now pins it. (This is why `install-plugin` spells its own flag `--plugin-version`.)
2. **The catalogue's `tools[]` is a curated highlight list, not a tool inventory.** It matches what the editor renders in the tooltip (`ExtensionPanel.BuildTooltip`). Several extensions ship many more tools than the catalogue lists — e.g. Cinemachine ships 14 vs 5 listed, Terrain 16 vs 5, Timeline 13 vs 5. Faithfully mirroring the C# array is what makes the parity test meaningful; **`w3-4` must not treat `tools[]` as exhaustive.**
3. **`ExtensionData.GitUrl` is write-only in the C# side** — 13 occurrences across exactly 2 files, none of them a read. Installation is 100% OpenUPM-registry based. It is mirrored into the catalogue for parity and metadata value, not because anything installs from it.
4. **No `unityPackageRequired` field was added, deliberately.** Seven of the ten wrap a Unity package a user must also have (Cinemachine, InputSystem, Navigation, ProBuilder, Splines, Tilemap→`com.unity.2d.tilemap.extras`, Timeline), and three wrap built-in modules (Animation, ParticleSystem, Terrain) — the analog of Godot's Class-B `addonRequired`. The C# `ExtensionData` struct has no such field, so adding one would create an asymmetry the parity test cannot check. Worth a follow-up that adds it to **both** sides.
5. **The extension repos pin two different plugin versions** — `0.88.0` (Animation, Cinemachine, Navigation, ParticleSystem, Splines, Terrain, Tilemap) and `0.86.3` (InputSystem, ProBuilder, Timeline). Not touched here; flagged for whoever owns the cascade.
6. `resolveLatestVersion`'s failure message changed (it now names the package id and takes a caller-supplied flag name). No test asserted the old wording; grepped to confirm.

## What I could not verify

- **The release itself** — DoD 8, 9, 10, and the published-version half of 13 are post-merge facts that cannot exist until the version bump is merged. No release was cut, no workflow dispatched, nothing published. The OpenUPM `dist-tags.latest` poll (DoD 9) is unstartable for the same reason; **no duration estimate for that window appears anywhere in this PR**, and none may be invented — poll the observable.
- **CI** — not yet observed for this branch at the time of writing.
- **The editor UI was not exercised.** No Unity editor was launched; the C# array is byte-identical to `main`, so the extensions UI is unchanged by construction, but that is an argument from the diff, not an observation.
- **No real extension was installed into a real Unity project.** Manifest patching is verified against temp-directory fixtures and by the CLI subprocess tests; UPM actually *resolving* the dependency requires an editor.
- **`npm publish` behaviour of the direct `deploy.yml` route** — untested on purpose (see above).
