### PR TITLE
feat(auth): assisted re-auth on a dead machine credential — D4 ladder against pinned McpPlugin 8.1.0 (c2)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AccountCredentialService.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AccountCredentialService.cs
@@ -171,6 +171,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Services
                 var provider = _provider ??= CreateDefaultProvider();
                 if (provider.IsSignedIn)
                     _coordinator = new ConnectionCredentialCoordinator(plugin, provider, _logger);
+
+                // D4 assisted re-auth trigger (oauth-client-error-hygiene 02 §C4): the service-level
+                // dead-credential subscription outlives any editor window — re-attached here on every
+                // plugin (re)build so a provider rebuilt by Reload() is always covered.
+                AssistedReauthService.Attach(provider);
             }
         }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthGate.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthGate.cs
@@ -1,0 +1,171 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using UnityEditor;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Services
+{
+    /// <summary>
+    /// What the once-gate + carousel guard decided for a dead-credential verdict
+    /// (oauth-client-error-hygiene 02 §C4, D4 recovery ladder).
+    /// </summary>
+    internal enum AssistedReauthDecision
+    {
+        /// <summary>Auto-open the browser and run the assisted device flow (D4 ladder step 2).</summary>
+        AutoRun,
+
+        /// <summary>This verdict already auto-ran once this editor session — no second auto-open.</summary>
+        OnceGated,
+
+        /// <summary>
+        /// The D4 ladder step 3 guard: assisted recovery already succeeded once this session and the
+        /// credential died again, or the device code expired unattended twice — stop auto-opening;
+        /// persistent status + the manual Authorize button take over.
+        /// </summary>
+        CarouselStopped,
+    }
+
+    /// <summary>
+    /// Session-scoped key-value store seam. Production is <see cref="EditorSessionKeyValueStore"/>
+    /// (Unity's <see cref="SessionState"/>: survives domain reloads, dies with the editor session);
+    /// tests inject a dictionary store so a "domain reload" is a new gate over the same store and a
+    /// "fresh editor session" is a new store.
+    /// </summary>
+    internal interface ISessionKeyValueStore
+    {
+        string GetString(string key, string defaultValue);
+        void SetString(string key, string value);
+        int GetInt(string key, int defaultValue);
+        void SetInt(string key, int value);
+    }
+
+    /// <summary>The production <see cref="ISessionKeyValueStore"/> over <see cref="SessionState"/>. Main thread only.</summary>
+    internal sealed class EditorSessionKeyValueStore : ISessionKeyValueStore
+    {
+        public string GetString(string key, string defaultValue) => SessionState.GetString(key, defaultValue);
+        public void SetString(string key, string value) => SessionState.SetString(key, value);
+        public int GetInt(string key, int defaultValue) => SessionState.GetInt(key, defaultValue);
+        public void SetInt(string key, int value) => SessionState.SetInt(key, value);
+    }
+
+    /// <summary>
+    /// The assisted re-auth once-gate + carousel guard (oauth-client-error-hygiene 02 §C4).
+    /// Anchored in <see cref="SessionState"/> — NOT <c>EditorPrefs</c> (too durable): the gate
+    /// survives domain reloads but a full editor restart deliberately re-fires the assisted flow
+    /// (D4 wants the user involved until authorization succeeds). Keys are hashes of the dead
+    /// refresh token — raw token material NEVER lands in <see cref="SessionState"/>.
+    /// </summary>
+    internal sealed class AssistedReauthGate
+    {
+        internal const string HandledVerdictHashKey = "com.IvanMurzak.Unity.MCP.AssistedReauth.HandledVerdictHash";
+        internal const string AssistedSuccessKey = "com.IvanMurzak.Unity.MCP.AssistedReauth.AssistedSuccess";
+        internal const string UnattendedExpiryCountKey = "com.IvanMurzak.Unity.MCP.AssistedReauth.UnattendedExpiryCount";
+        internal const string CarouselStoppedKey = "com.IvanMurzak.Unity.MCP.AssistedReauth.CarouselStopped";
+
+        /// <summary>
+        /// The persistent D4 status shown when the assisted flow will not auto-open (once-gated,
+        /// carousel-stopped, expired unattended, or nothing to re-authorize) — the manual Authorize
+        /// button stays the way forward.
+        /// r2: the pinned McpPlugin 8.1.0 does not expose the verdict reason
+        /// (<c>PluginCredentialProvider.SignInRequiredReason</c> arrives with the r2 pin bump), so
+        /// every terminal verdict renders this generic status; r2 adds the distinct
+        /// "server configuration error" rendering for <c>invalid_target</c> verdicts.
+        /// </summary>
+        internal const string StatusSignInRequired =
+            "Sign in required — your session expired. Use the Authorize button to sign in.";
+
+        readonly ISessionKeyValueStore _session;
+
+        public AssistedReauthGate(ISessionKeyValueStore session)
+            => _session = session ?? throw new ArgumentNullException(nameof(session));
+
+        /// <summary>True when the D4 ladder step 3 guard tripped this editor session: no more auto-opens.</summary>
+        public bool CarouselStopped => _session.GetInt(CarouselStoppedKey, 0) != 0;
+
+        /// <summary>
+        /// Decide what a dead-credential verdict keyed by <paramref name="deadTokenHash"/>
+        /// (<see cref="HashToken"/> of the dead refresh token) may do this editor session.
+        /// </summary>
+        public AssistedReauthDecision Decide(string deadTokenHash)
+        {
+            if (deadTokenHash == null)
+                throw new ArgumentNullException(nameof(deadTokenHash));
+
+            if (CarouselStopped)
+                return AssistedReauthDecision.CarouselStopped;
+
+            // D4 ladder step 3: assisted re-auth already succeeded once this editor session and the
+            // machine credential is dead AGAIN — auto-opening the browser again would be a sign-in
+            // carousel; trip the guard instead.
+            // r2: key this on the verdict's reason class (invalid_grant vs invalid_target) once the
+            // pinned McpPlugin exposes PluginCredentialProvider.SignInRequiredReason.
+            if (_session.GetInt(AssistedSuccessKey, 0) != 0)
+            {
+                StopCarousel();
+                return AssistedReauthDecision.CarouselStopped;
+            }
+
+            // Once per editor session per verdict: SessionState survives domain reloads, so the
+            // browser opens exactly once for one dead token no matter how many reloads happen in
+            // between; a DIFFERENT family dying later is a new verdict and auto-runs again; a full
+            // editor restart clears SessionState and deliberately re-fires (D4).
+            if (string.Equals(_session.GetString(HandledVerdictHashKey, string.Empty), deadTokenHash, StringComparison.Ordinal))
+                return AssistedReauthDecision.OnceGated;
+
+            _session.SetString(HandledVerdictHashKey, deadTokenHash);
+            return AssistedReauthDecision.AutoRun;
+        }
+
+        /// <summary>
+        /// An assisted flow (triggered by, or recovering from, a dead-credential verdict) committed
+        /// successfully. If the freshly authorized credential dies again this session, the next
+        /// <see cref="Decide"/> trips the carousel guard.
+        /// </summary>
+        public void RecordAssistedSuccess()
+        {
+            _session.SetInt(AssistedSuccessKey, 1);
+            _session.SetInt(UnattendedExpiryCountKey, 0); // the user was present — restart the unattended count
+        }
+
+        /// <summary>
+        /// An auto-opened device-code request expired with nobody approving it. The flow is NEVER
+        /// re-initiated unattended (D4); the second unattended expiry trips the carousel guard.
+        /// </summary>
+        public void RecordUnattendedExpiry()
+        {
+            var count = _session.GetInt(UnattendedExpiryCountKey, 0) + 1;
+            _session.SetInt(UnattendedExpiryCountKey, count);
+            if (count >= 2)
+                StopCarousel();
+        }
+
+        void StopCarousel() => _session.SetInt(CarouselStoppedKey, 1);
+
+        /// <summary>
+        /// SHA-256 hex of a refresh token — the <see cref="SessionState"/> once-gate key. The raw
+        /// token never lands in <see cref="SessionState"/> (07 rule 2: no token material outside the
+        /// protected machine store).
+        /// </summary>
+        public static string HashToken(string refreshToken)
+        {
+            if (refreshToken == null)
+                throw new ArgumentNullException(nameof(refreshToken));
+
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            var bytes = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(refreshToken));
+            var builder = new System.Text.StringBuilder(bytes.Length * 2);
+            foreach (var b in bytes)
+                builder.Append(b.ToString("x2"));
+            return builder.ToString();
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthGate.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthGate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dbd6e8914f834228897134e5e013422b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthService.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthService.cs
@@ -1,0 +1,512 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.McpPlugin;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.ReflectorNet.Utils;
+using com.IvanMurzak.Unity.MCP.Runtime.Utils;
+using com.IvanMurzak.Unity.MCP.Utils;
+using Microsoft.Extensions.Logging;
+using R3;
+using UnityEditor;
+using UnityEngine;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Services
+{
+    /// <summary>Terminal result of one assisted sign-in run (<see cref="AssistedReauthService"/>).</summary>
+    public enum AssistedReauthOutcome
+    {
+        /// <summary>Device grant approved AND the F1 login commit fully landed in the machine store.</summary>
+        Committed,
+
+        /// <summary>Device grant approved but the login commit did not fully land (busy lock, exchange failure, declined account switch, ...).</summary>
+        CommitFailed,
+
+        /// <summary>The device code expired before anybody approved it. Never re-initiated unattended (D4).</summary>
+        Expired,
+
+        /// <summary>The flow was cancelled (user click, disposal, or a cancellation token).</summary>
+        Cancelled,
+
+        /// <summary>The flow failed (denied, transport error, or an unexpected exception).</summary>
+        Failed,
+
+        /// <summary>Another assisted sign-in run is already in flight; nothing was started.</summary>
+        AlreadyRunning,
+    }
+
+    /// <summary>
+    /// The service-level assisted re-auth entry (oauth-client-error-hygiene 02 §C4, D4 recovery
+    /// ladder) — the extraction of the Authorize flow that used to live inline in
+    /// <c>MainWindowEditor.Connection.cs</c> and existed only while the window was open. It runs the
+    /// whole D4 ladder step 2 with or without any window:
+    /// <list type="bullet">
+    ///   <item><b>Trigger:</b> subscribes <see cref="PluginCredentialProvider.OnSignInRequired"/> /
+    ///   <see cref="PluginCredentialProvider.State"/> (re-attached on every plugin (re)build via
+    ///   <see cref="AccountCredentialService.AttachTo"/>). A dead-credential verdict in Cloud mode
+    ///   auto-opens the default browser on the device-flow verification URL and polls the token
+    ///   endpoint until the user approves — bounded by the server's device-code expiry, never
+    ///   re-initiated unattended.</item>
+    ///   <item><b>Once-gate + carousel guard:</b> <see cref="AssistedReauthGate"/> over
+    ///   <see cref="SessionState"/> — one auto-open per dead token per editor session (surviving
+    ///   domain reloads), and the D4 step-3 guard stops auto-opening entirely after a repeat death
+    ///   or two unattended expiries; the manual Authorize button stays.</item>
+    ///   <item><b>Manual entry:</b> the window's Authorize button delegates to
+    ///   <see cref="AuthorizeAsync"/> — no duplicated flow.</item>
+    ///   <item><b>On success:</b> the F1 login commit (<see cref="AccountCredentialService.CommitLoginAsync"/>),
+    ///   then the existing reload flow — <see cref="AccountCredentialService.Reload"/> + plugin
+    ///   rebuild + <c>ConnectIfNeeded</c> (KeepConnected intent respected).
+    ///   r2: once the McpPlugin pin carries the a3 coordinator stop/resume, the provider's
+    ///   SignInRequired→SignedIn edge resumes a stopped loop by itself.</item>
+    /// </list>
+    /// No method here ever logs or surfaces token material.
+    /// </summary>
+    public static class AssistedReauthService
+    {
+        static readonly ILogger _logger = UnityLoggerFactory.LoggerFactory.CreateLogger(nameof(AssistedReauthService));
+        static readonly object _gate = new object();
+
+        static AssistedReauthGate? _sessionGate;
+        static IDisposable? _providerSubscription;
+        static Task<AssistedReauthOutcome>? _activeTask;
+        static volatile DeviceAuthFlow? _activeFlow;
+        static volatile string? _statusMessage;
+
+        /// <summary>
+        /// Raised on any observable change (flow state, status message, auth state). May fire on ANY
+        /// thread — UI subscribers must marshal to the editor main thread themselves.
+        /// </summary>
+        public static event Action? Changed;
+
+        /// <summary>The live (or most recent) flow's state; <see cref="DeviceAuthFlowState.Idle"/> when none ran yet.</summary>
+        public static DeviceAuthFlowState FlowState => _activeFlow?.State ?? DeviceAuthFlowState.Idle;
+
+        /// <summary>The live (or most recent) flow's user code, for the "Code: XXXX" status line.</summary>
+        public static string? UserCode => _activeFlow?.UserCode;
+
+        /// <summary>The live (or most recent) flow's error message, if any.</summary>
+        public static string? FlowErrorMessage => _activeFlow?.ErrorMessage;
+
+        /// <summary>
+        /// The persistent status line (D4 ladder step 3 / commit progress), or null when the flow
+        /// state alone tells the story. Never contains token material.
+        /// </summary>
+        public static string? StatusMessage => _statusMessage;
+
+        /// <summary>True while a device-authorization flow is in flight (initiating / waiting / polling).</summary>
+        public static bool IsFlowRunning => IsRunningState(FlowState);
+
+        static bool IsRunningState(DeviceAuthFlowState state)
+            => state == DeviceAuthFlowState.Initiating
+            || state == DeviceAuthFlowState.WaitingForUser
+            || state == DeviceAuthFlowState.Polling;
+
+        internal static AssistedReauthGate SessionGate
+        {
+            get
+            {
+                lock (_gate)
+                    return _sessionGate ??= new AssistedReauthGate(new EditorSessionKeyValueStore());
+            }
+        }
+
+        /// <summary>
+        /// Subscribe the dead-credential trigger to <paramref name="provider"/> (02 §C4: the
+        /// provider's <c>OnSignInRequired</c>/<c>State</c> had zero Unity readers — this is the
+        /// reader). Called by <see cref="AccountCredentialService.AttachTo"/> on every plugin
+        /// (re)build, replacing any previous subscription so a provider rebuilt by
+        /// <see cref="AccountCredentialService.Reload"/> is always covered.
+        /// </summary>
+        internal static void Attach(PluginCredentialProvider provider)
+        {
+            if (provider == null)
+                throw new ArgumentNullException(nameof(provider));
+
+            lock (_gate)
+            {
+                _providerSubscription?.Dispose();
+                var subscriptions = new CompositeDisposable();
+                provider.OnSignInRequired
+                    .Subscribe(_ => OnSignInRequiredVerdict())
+                    .AddTo(subscriptions);
+                provider.State
+                    .Subscribe(state => OnAuthStateChanged(state))
+                    .AddTo(subscriptions);
+                _providerSubscription = subscriptions;
+            }
+        }
+
+        /// <summary>
+        /// The manual, service-level Authorize entry — the window's Authorize button (and the auth
+        /// alert panel) delegate here, and the automatic dead-credential trigger runs the same flow.
+        /// Single-flight: a second call while a flow is in flight returns
+        /// <see cref="AssistedReauthOutcome.AlreadyRunning"/> without starting anything.
+        /// </summary>
+        public static Task<AssistedReauthOutcome> AuthorizeAsync() => RunAsync(auto: false);
+
+        /// <summary>Cancel the in-flight device-authorization flow, if any.</summary>
+        public static void CancelFlow() => _activeFlow?.Cancel();
+
+        // ── The dead-credential trigger (02 §C4 step 2) ──────────────────────────────────────────
+
+        static void OnSignInRequiredVerdict()
+        {
+            // Fires from the provider's refresh path — possibly on a thread-pool thread and while
+            // the provider's internal gate is held. Never call back into the provider synchronously
+            // here; SessionState and the editor APIs are main-thread-only anyway.
+            MainThread.Instance.RunAsync(() => HandleVerdictOnMainThread());
+        }
+
+        static void OnAuthStateChanged(AuthState state)
+        {
+            // A signed-in (or signed-out) provider clears the persistent sign-in-required status;
+            // either way the UI re-reads everything it renders.
+            if (state == AuthState.SignedIn || state == AuthState.SignedOut)
+                SetStatus(null);
+            else
+                RaiseChanged();
+        }
+
+        static void HandleVerdictOnMainThread()
+        {
+            try
+            {
+                HandleVerdictCore(
+                    isCloudMode: UnityMcpPluginEditor.ConnectionMode == ConnectionMode.Cloud,
+                    deadRefreshToken: ReadPluginPlaneRefreshToken(),
+                    gate: SessionGate,
+                    runFlow: () =>
+                    {
+                        if (IsFlowRunning)
+                            return;
+                        Debug.LogWarning("[AI Game Developer] The saved sign-in for this machine is no longer valid. " +
+                            "Opening your browser to re-authorize — approve the request there to reconnect.");
+                        _ = RunAsync(auto: true);
+                    },
+                    setStatus: status => SetStatus(status));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Assisted re-auth trigger failed: {message}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// The verdict trigger's decision core (02 §C4), pure for tests: returns true when the
+        /// assisted flow auto-runs for this dead-credential verdict. LocalServer (Custom) mode never
+        /// auto-runs (no behavior change); a machine with no stored plugin-plane refresh token has
+        /// nothing to re-authorize automatically (the manual prompt path stays); otherwise the
+        /// <see cref="AssistedReauthGate"/> once-gate + carousel guard decide.
+        /// </summary>
+        internal static bool HandleVerdictCore(
+            bool isCloudMode,
+            string? deadRefreshToken,
+            AssistedReauthGate gate,
+            Action runFlow,
+            Action<string> setStatus)
+        {
+            if (gate == null) throw new ArgumentNullException(nameof(gate));
+            if (runFlow == null) throw new ArgumentNullException(nameof(runFlow));
+            if (setStatus == null) throw new ArgumentNullException(nameof(setStatus));
+
+            if (!isCloudMode)
+                return false; // LocalServer mode keeps its existing behavior (02 §C4)
+
+            if (string.IsNullOrEmpty(deadRefreshToken))
+            {
+                // Signed out / store missing: nothing to re-authorize automatically — the manual
+                // prompt path (auth alert + Authorize button) stays the way in.
+                setStatus(AssistedReauthGate.StatusSignInRequired);
+                return false;
+            }
+
+            var decision = gate.Decide(AssistedReauthGate.HashToken(deadRefreshToken!));
+            if (decision != AssistedReauthDecision.AutoRun)
+            {
+                // Once-gated this editor session, or the D4 step-3 carousel guard tripped: no
+                // auto-open — persistent status + the manual Authorize button.
+                setStatus(AssistedReauthGate.StatusSignInRequired);
+                return false;
+            }
+
+            runFlow();
+            return true;
+        }
+
+        /// <summary>
+        /// The dead refresh token, read from the shared machine store: a failed refresh never
+        /// deletes the store (unified-machine-auth 03:52), so on a dead-family verdict the store
+        /// still holds the declared-dead token and its hash is the once-gate key. Null when the
+        /// store is missing/unreadable or holds no plugin-plane refresh token. The store's read
+        /// path adopts v1 token material into families, so the plugin plane is
+        /// <c>families.plugin</c> with <c>families.legacy</c> as the v1-adopted fallback (04 §1).
+        /// </summary>
+        internal static string? ReadPluginPlaneRefreshToken()
+        {
+            try
+            {
+                var read = new MachineCredentialStore().TryRead();
+                if (read.Status != MachineCredentialStoreStatus.Ok || read.Credentials?.Families == null)
+                    return null;
+                var family = read.Credentials.Families.Plugin ?? read.Credentials.Families.Legacy;
+                return family?.RefreshToken;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Reading the machine credential store failed: {message}", ex.Message);
+                return null;
+            }
+        }
+
+        // ── The flow runner ──────────────────────────────────────────────────────────────────────
+
+        static Task<AssistedReauthOutcome> RunAsync(bool auto)
+        {
+            lock (_gate)
+            {
+                if (_activeTask != null && !_activeTask.IsCompleted)
+                    return Task.FromResult(AssistedReauthOutcome.AlreadyRunning);
+                _activeTask = RunFlowAndRecordAsync(auto);
+                return _activeTask;
+            }
+        }
+
+        static async Task<AssistedReauthOutcome> RunFlowAndRecordAsync(bool auto)
+        {
+            await Task.Yield(); // escape the starter's lock scope before touching other services
+
+            // A run that started while sign-in was required is a RECOVERY run — its success feeds
+            // the carousel guard (a fresh manual sign-in from a signed-out machine does not).
+            bool recovery;
+            try
+            {
+                recovery = auto || AccountCredentialService.Provider.State.CurrentValue == AuthState.SignInRequired;
+            }
+            catch (Exception)
+            {
+                recovery = auto;
+            }
+
+            SetStatus(null); // the flow's own state drives the status line while it runs
+
+            AssistedReauthOutcome outcome;
+            try
+            {
+                var cloudBaseUrl = UnityMcpPlugin.UnityConnectionConfig.CloudServerBaseUrl;
+                outcome = await RunSignInCoreAsync(
+                    client: new DeviceAuthService(cloudBaseUrl), // requests scope=mcp:agent (03 F1.2)
+                    serverTarget: cloudBaseUrl,
+                    // null ⇒ DeviceAuthFlow's default opener, Application.OpenURL — the ONE
+                    // browser-open seam (D4); tests inject a fake so CI never opens a browser.
+                    openBrowser: null,
+                    delay: null,
+                    commit: CommitAndReloadAsync,
+                    onFlow: RegisterActiveFlow);
+            }
+            catch (OperationCanceledException)
+            {
+                outcome = AssistedReauthOutcome.Cancelled;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Assisted sign-in failed: {message}", ex.Message); // never token material
+                outcome = AssistedReauthOutcome.Failed;
+            }
+
+            RecordOutcome(auto, recovery, outcome);
+            RaiseChanged();
+            return outcome;
+        }
+
+        /// <summary>
+        /// One assisted sign-in run, injectable for tests: drive the RFC 8628
+        /// <see cref="DeviceAuthFlow"/> (device code → browser open → poll), then hand an approved
+        /// grant to <paramref name="commit"/>. Polling is strictly bounded — the flow returns on
+        /// approval, denial, the device-code expiry deadline, or cancellation/disposal — and is
+        /// NEVER re-initiated here: an expired request surfaces the persistent sign-in-required
+        /// status instead (D4).
+        /// </summary>
+        internal static async Task<AssistedReauthOutcome> RunSignInCoreAsync(
+            IDeviceAuthClient client,
+            string? serverTarget,
+            Action<string>? openBrowser,
+            Func<TimeSpan, CancellationToken, Task>? delay,
+            Func<DeviceAuthLoginResult, CancellationToken, Task<AssistedReauthOutcome>> commit,
+            Action<DeviceAuthFlow>? onFlow = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (client == null) throw new ArgumentNullException(nameof(client));
+            if (commit == null) throw new ArgumentNullException(nameof(commit));
+
+            if (cancellationToken.IsCancellationRequested)
+                return AssistedReauthOutcome.Cancelled;
+
+            DeviceAuthLoginResult? login = null;
+            var flow = new DeviceAuthFlow(client, result => login = result, serverTarget, openBrowser, delay);
+            onFlow?.Invoke(flow);
+
+            // Start FIRST, register the external cancellation after: StartAsync assigns its
+            // CancellationTokenSource synchronously before its first await, so a Cancel arriving
+            // through the registration always reaches the live token source (registering earlier
+            // could fire against the not-yet-created source and be lost).
+            var startTask = flow.StartAsync();
+            using var cancelFlowOnToken = cancellationToken.Register(flow.Cancel);
+            await startTask;
+
+            switch (flow.State)
+            {
+                case DeviceAuthFlowState.Authorized when login != null:
+                    return await commit(login, cancellationToken);
+                case DeviceAuthFlowState.Expired:
+                    return AssistedReauthOutcome.Expired;
+                case DeviceAuthFlowState.Cancelled:
+                    return AssistedReauthOutcome.Cancelled;
+                default:
+                    return AssistedReauthOutcome.Failed;
+            }
+        }
+
+        static void RegisterActiveFlow(DeviceAuthFlow flow)
+        {
+            _activeFlow = flow;
+            flow.OnStateChanged += _ => RaiseChanged();
+            RaiseChanged();
+        }
+
+        /// <summary>
+        /// Production commit for an approved device grant: the F1 login commit into the shared
+        /// machine store (agent family → RFC 8693 exchange → plugin family + v1 mirror), then the
+        /// existing reload flow — <see cref="AccountCredentialService.Reload"/> + plugin rebuild +
+        /// <c>ConnectIfNeeded</c> — so the next (re)connect presents the fresh credential and the
+        /// on-401 coordinator re-attaches, reconnecting only when the user's KeepConnected intent
+        /// is on (a deliberately stopped connection is never resurrected).
+        /// r2: when the McpPlugin pin carries a3's coordinator stop/resume, the provider's
+        /// SignInRequired→SignedIn edge resumes a stopped loop by itself and this rebuild becomes
+        /// the fresh-sign-in path only.
+        /// </summary>
+        static async Task<AssistedReauthOutcome> CommitAndReloadAsync(DeviceAuthLoginResult login, CancellationToken cancellationToken)
+        {
+            LoginCommitResult commit;
+            try
+            {
+                commit = await AccountCredentialService.CommitLoginAsync(
+                    login.AgentFamily,
+                    login.Subject,
+                    login.ServerTarget,
+                    onStatus: status => SetStatus(status), // plain field + event — no marshalling needed
+                    // The commit runs ConfigureAwait(false), so this callback may fire on a
+                    // background thread — the modal dialog must run on the editor main thread.
+                    confirmAccountSwitch: displaced => MainThread.Instance.Run(() => EditorUtility.DisplayDialog(
+                        "Switch account on this machine?",
+                        "This machine is already signed in to a different AI Game Dev account.\n\n"
+                        + "Continuing signs the other account out of every tool on this machine (engine plugins, CLIs, and the desktop app) and replaces it with the account you just authorized.",
+                        "Replace Account",
+                        "Cancel")),
+                    cancellationToken: cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return AssistedReauthOutcome.Cancelled;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Login commit failed: {message}", ex.Message); // never token material
+                SetStatus("Sign-in failed — see the Console for details.");
+                return AssistedReauthOutcome.CommitFailed;
+            }
+
+            // Reflect the (possibly) rewritten store in this editor domain — a rebuild through the
+            // provider's auto-adopt read, never an echo-write (G-SEC-2).
+            AccountCredentialService.Reload();
+
+            if (commit.Status != LoginCommitStatus.FullyCommitted)
+                return AssistedReauthOutcome.CommitFailed;
+
+            await MainThread.Instance.RunAsync(() =>
+            {
+                if (UnityMcpPluginEditor.ConnectionMode != ConnectionMode.Cloud)
+                    return;
+                UnityMcpPluginEditor.Instance.DisposeMcpPluginInstance();
+                UnityMcpPluginEditor.Instance.BuildMcpPluginIfNeeded();
+                UnityMcpPluginEditor.Instance.AddUnityLogCollectorIfNeeded(() => new BufferedFileLogStorage());
+                UnityMcpPluginEditor.ConnectIfNeeded();
+            });
+
+            return AssistedReauthOutcome.Committed;
+        }
+
+        static void RecordOutcome(bool auto, bool recovery, AssistedReauthOutcome outcome)
+        {
+            try
+            {
+                switch (outcome)
+                {
+                    case AssistedReauthOutcome.Committed:
+                        if (recovery)
+                            // Carousel input (D4 ladder step 3): assisted recovery succeeded once
+                            // this session — if the machine credential dies AGAIN, the trigger stops
+                            // auto-opening (a browser carousel would be worse than a red status).
+                            SessionGate.RecordAssistedSuccess();
+                        _logger.LogInformation("Signed in — the machine credential was renewed.");
+                        break;
+
+                    case AssistedReauthOutcome.Expired when auto:
+                        // The browser was opened but nobody approved before the device code expired.
+                        // NEVER re-initiate unattended (D4) — count it; the second unattended expiry
+                        // trips the carousel guard.
+                        SessionGate.RecordUnattendedExpiry();
+                        SetStatusIfEmpty(AssistedReauthGate.StatusSignInRequired);
+                        break;
+
+                    case AssistedReauthOutcome.Failed when auto:
+                    case AssistedReauthOutcome.CommitFailed when auto:
+                        SetStatusIfEmpty(AssistedReauthGate.StatusSignInRequired);
+                        break;
+
+                        // Manual outcomes and Cancelled: the flow's own terminal state (rendered by
+                        // the window) says enough; no persistent status.
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Recording the assisted sign-in outcome failed: {message}", ex.Message);
+            }
+        }
+
+        static void SetStatus(string? message)
+        {
+            _statusMessage = message;
+            RaiseChanged();
+        }
+
+        static void SetStatusIfEmpty(string message)
+        {
+            if (string.IsNullOrEmpty(_statusMessage))
+                SetStatus(message);
+        }
+
+        static void RaiseChanged()
+        {
+            try
+            {
+                Changed?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("An AssistedReauthService.Changed subscriber threw: {message}", ex.Message);
+            }
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthService.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/Services/AssistedReauthService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bced6e745694dd1bd0278f742f5f5fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.Connection.cs
@@ -89,23 +89,31 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
 
         private void OnAuthorizationRejected()
         {
-            if (UnityMcpPluginEditor.ConnectionMode != ConnectionMode.Cloud)
+            if (!ShouldPromptOnAuthorizationRejected(UnityMcpPluginEditor.ConnectionMode, AccountCredentialService.IsSignedIn))
                 return;
 
-            // When signed in via the shared machine credential store, the ConnectionCredentialCoordinator
-            // (wired in AccountCredentialService.AttachTo) already handles the 3-strike rejection by
-            // refreshing the token and reconnecting — do not disturb the session here (design 06).
-            if (AccountCredentialService.IsSignedIn)
-                return;
-
-            // Not signed in: the machine store is the only Cloud credential source (T9 — the cloudToken
-            // UserSettings mirror was removed), so there is no persisted token to clear. Prompt a fresh sign-in.
+            // The machine store is the only Cloud credential source (T9 — the cloudToken
+            // UserSettings mirror was removed). A rejection here means the presented credential is
+            // not usable right now — surface the prompt path instead of staying silently red
+            // (oauth-client-error-hygiene 02 §C4). On a dead-family verdict the
+            // AssistedReauthService additionally auto-opens the browser (D4), once-gated.
             Debug.LogWarning("[AI Game Developer] The server rejected the authorization. " +
                 "Please click 'Authorize' to sign in again.");
 
             UpdateCloudAuthState();
             RefreshConnectionUI();
         }
+
+        /// <summary>
+        /// Whether a server authorization rejection surfaces the sign-in prompt path. Cloud mode
+        /// ALWAYS prompts (oauth-client-error-hygiene 02 §C4): the old signed-in early-return
+        /// assumed the coordinator's silent refresh+reconnect would recover, but a DEAD credential
+        /// family can never be refreshed — the early-return left a signed-in editor silently red
+        /// while the authorization server was hit every 60 s. <paramref name="isSignedIn"/> stays an
+        /// explicit input so tests pin the removal (restoring the early-return reddens them).
+        /// </summary>
+        internal static bool ShouldPromptOnAuthorizationRejected(ConnectionMode mode, bool isSignedIn)
+            => mode == ConnectionMode.Cloud;
 
         private void UpdateConnectionUI(HubConnectionState state, bool keepConnected)
         {
@@ -385,122 +393,80 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
                 _ = SignOutMachineWideThenRefreshUiAsync();
             });
 
-            void SetCommitStatus(string message)
+            // The Authorize flow lives in the service now (oauth-client-error-hygiene 02 §C4:
+            // extraction, not reuse) — it runs the whole D4 ladder (device code → default-browser
+            // open → poll until approval → F1 login commit → reload + reconnect) with or without
+            // this window; the window only renders its state and delegates the button.
+            void RefreshAuthFlowUi()
             {
+                // Service events may fire on any thread. Use RunAsync (EditorApplication.update-
+                // based) instead of delayCall so the UI updates even when the Unity Editor window is
+                // not focused — delayCall is throttled/paused when Unity loses application focus.
                 MainThread.Instance.RunAsync(() =>
                 {
                     if (statusLabel != null)
                     {
-                        statusLabel.text = message;
-                        statusLabel.style.display = string.IsNullOrEmpty(message)
+                        // The persistent status (D4 ladder step 3 / commit progress) wins over the
+                        // flow-state line; both come from the service.
+                        statusLabel.text = AssistedReauthService.StatusMessage
+                            ?? GetAuthFlowStatusMessage(
+                                AssistedReauthService.FlowState,
+                                AssistedReauthService.UserCode,
+                                AssistedReauthService.FlowErrorMessage);
+                        statusLabel.style.display = string.IsNullOrEmpty(statusLabel.text)
                             ? DisplayStyle.None
                             : DisplayStyle.Flex;
                     }
+                    if (btnAuthorize != null)
+                    {
+                        btnAuthorize.text = AssistedReauthService.IsFlowRunning ? "Cancel" : "Authorize";
+                    }
+                    UpdateTokenDisplay();
+                    UpdateRevokeButtonVisibility();
+                    UpdateCloudAuthState();
                     Repaint();
                 });
             }
 
-            async Task CommitLoginThenRefreshUiAsync(DeviceAuthLoginResult result)
-            {
-                LoginCommitResult commit;
-                try
-                {
-                    commit = await AccountCredentialService.CommitLoginAsync(
-                        result.AgentFamily,
-                        result.Subject,
-                        result.ServerTarget,
-                        onStatus: SetCommitStatus, // marshals to the main thread itself
-                        // The commit runs ConfigureAwait(false), so this callback may fire on a
-                        // background thread — the modal dialog must run on the editor main thread.
-                        confirmAccountSwitch: displaced => MainThread.Instance.Run(() => EditorUtility.DisplayDialog(
-                            "Switch account on this machine?",
-                            "This machine is already signed in to a different AI Game Dev account.\n\n"
-                            + "Continuing signs the other account out of every tool on this machine (engine plugins, CLIs, and the desktop app) and replaces it with the account you just authorized.",
-                            "Replace Account",
-                            "Cancel")));
-                }
-                catch (Exception ex)
-                {
-                    Debug.LogWarning($"[AI Game Developer] Login commit failed: {ex.Message}");
-                    SetCommitStatus("Sign-in failed — see the Console for details.");
-                    return;
-                }
+            // Replace any previous handler (CreateGUI reruns on Invalidate) and keep a reference so
+            // OnDisable can detach — a static event must never retain a closed window.
+            if (_assistedReauthChangedHandler != null)
+                AssistedReauthService.Changed -= _assistedReauthChangedHandler;
+            _assistedReauthChangedHandler = RefreshAuthFlowUi;
+            AssistedReauthService.Changed += _assistedReauthChangedHandler;
+            RefreshAuthFlowUi(); // render pre-window state (e.g. an auto flow already in flight, or the carousel status)
 
-                // Reflect the (possibly) rewritten store in this editor domain — a rebuild through the
-                // provider's auto-adopt read, never an echo-write (G-SEC-2).
-                AccountCredentialService.Reload();
+            async Task AuthorizeThenRefreshUiAsync()
+            {
+                // NOTE (d1): DeviceAuthFlowState.Authorized means the DEVICE GRANT was approved —
+                // the service completes the F1 login commit (agent family → exchange → plugin
+                // family), reloads the provider, and reconnects (KeepConnected intent respected)
+                // before this await returns Committed.
+                var outcome = await AssistedReauthService.AuthorizeAsync();
 
                 await MainThread.Instance.RunAsync(() =>
                 {
                     UpdateTokenDisplay();
                     UpdateRevokeButtonVisibility();
                     UpdateCloudAuthState();
-                    if (commit.Status == LoginCommitStatus.FullyCommitted)
+                    if (outcome == AssistedReauthOutcome.Committed)
                     {
                         // Invalidate cached AI agent configs so they pick up the new credential
                         InvalidateAndReloadAgentUI();
-
-                        // Reconnect to cloud server with the new token (only if still in Cloud mode)
-                        if (UnityMcpPluginEditor.ConnectionMode == ConnectionMode.Cloud)
-                            ReconnectAfterModeSwitch();
                     }
                     Repaint();
                 });
             }
 
-            _startAuthorizeAction = async () =>
+            _startAuthorizeAction = () =>
             {
-                // If currently running, cancel
-                if (_deviceAuthFlow != null && IsAuthFlowRunning(_deviceAuthFlow.State))
+                // Click while the flow is running = cancel (unchanged UX).
+                if (AssistedReauthService.IsFlowRunning)
                 {
-                    _deviceAuthFlow.Cancel();
+                    AssistedReauthService.CancelFlow();
                     return;
                 }
-
-                _deviceAuthFlow?.Cancel();
-                var cloudBaseUrl = UnityMcpPlugin.UnityConnectionConfig.CloudServerBaseUrl;
-                _deviceAuthFlow = new DeviceAuthFlow(
-                    new DeviceAuthService(cloudBaseUrl), // requests scope=mcp:agent (03 F1.2)
-                    onAuthorized: result =>
-                    {
-                        // F1.3–F1.5: commit the minted agent family into the shared machine store under
-                        // the cross-process lock, derive the plugin family via RFC 8693 token exchange,
-                        // and stamp the v1 mirror — never a bare lock-free Adopt (G-SEC-2).
-                        _ = CommitLoginThenRefreshUiAsync(result);
-                    },
-                    serverTarget: cloudBaseUrl);
-                var capturedFlow = _deviceAuthFlow; // Capture to avoid stale field reference in async callbacks
-
-                capturedFlow.OnStateChanged += state =>
-                {
-                    // Use RunAsync (EditorApplication.update-based) instead of delayCall so that
-                    // the UI updates even when the Unity Editor window is not focused — delayCall
-                    // is throttled/paused when Unity loses application focus.
-                    MainThread.Instance.RunAsync(() =>
-                    {
-                        // Ignore stale events from a previous auth flow
-                        if (_deviceAuthFlow != capturedFlow) return;
-
-                        if (statusLabel != null)
-                        {
-                            statusLabel.text = GetAuthFlowStatusMessage(state, capturedFlow.UserCode, capturedFlow.ErrorMessage);
-                            statusLabel.style.display = string.IsNullOrEmpty(statusLabel.text)
-                                ? DisplayStyle.None
-                                : DisplayStyle.Flex;
-                        }
-                        // NOTE (d1): DeviceAuthFlowState.Authorized means the DEVICE GRANT was approved —
-                        // the credential is not yet committed to the machine store. The signed-in UI
-                        // refresh + reconnect happen in CommitLoginThenRefreshUiAsync once the F1 login
-                        // commit (agent family → exchange → plugin family) actually lands.
-                        if (btnAuthorize != null)
-                        {
-                            btnAuthorize.text = IsAuthFlowRunning(state) ? "Cancel" : "Authorize";
-                        }
-                        Repaint();
-                    });
-                };
-
-                await capturedFlow.StartAsync();
+                _ = AuthorizeThenRefreshUiAsync();
             };
 
             btnAuthorize.RegisterCallback<ClickEvent>(_ => _startAuthorizeAction?.Invoke());

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.CreateGUI.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.CreateGUI.cs
@@ -219,8 +219,6 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         private VisualElement? _aiAgentLabelsContainer;
         private VisualElement? _aiAgentStatusCircle;
 
-        private DeviceAuthFlow? _deviceAuthFlow;
-
         private long _mcpServerDataVersion;
         private long _aiAgentDataVersion;
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/UI/Window/MainWindowEditor.cs
@@ -26,6 +26,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         Button? _btnConnect;
         Button? _btnAuthorize;
         Action? _startAuthorizeAction;
+        Action? _assistedReauthChangedHandler;
         VisualElement? _timelinePointUnity;
         AlertPanel? _connectionAuthAlert;
         AlertPanel? _connectionConnectAlert;
@@ -73,6 +74,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.UI
         {
             _disposables.Clear();
             _authRejectedSubscription.Dispose();
+            if (_assistedReauthChangedHandler != null)
+            {
+                AssistedReauthService.Changed -= _assistedReauthChangedHandler;
+                _assistedReauthChangedHandler = null;
+            }
         }
 
         internal static (bool needsAuth, bool hasToken, bool isCloud) ComputeCloudAuthState(ConnectionMode mode, bool hasCredential)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthGateTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthGateTests.cs
@@ -1,0 +1,168 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.Collections.Generic;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// The assisted re-auth once-gate + carousel guard (oauth-client-error-hygiene 02 §C4, D4
+    /// recovery ladder), driven through the same decision core the production verdict trigger uses
+    /// (<see cref="AssistedReauthService.HandleVerdictCore"/>). The session store is faked so a
+    /// "domain reload" is a NEW gate over the SAME store (SessionState survives reloads) and a
+    /// "fresh editor session" is a new store (SessionState dies with the editor).
+    /// </summary>
+    public class AssistedReauthGateTests
+    {
+        sealed class FakeSessionStore : ISessionKeyValueStore
+        {
+            readonly Dictionary<string, string> _strings = new Dictionary<string, string>();
+            readonly Dictionary<string, int> _ints = new Dictionary<string, int>();
+
+            public string GetString(string key, string defaultValue) => _strings.TryGetValue(key, out var value) ? value : defaultValue;
+            public void SetString(string key, string value) => _strings[key] = value;
+            public int GetInt(string key, int defaultValue) => _ints.TryGetValue(key, out var value) ? value : defaultValue;
+            public void SetInt(string key, int value) => _ints[key] = value;
+        }
+
+        /// <summary>One verdict arriving at the production decision core; counts flow invocations.</summary>
+        static bool Verdict(FakeSessionStore session, string? deadToken, ref int invoked, out string? status, bool isCloudMode = true)
+        {
+            string? captured = null;
+            var invokedLocal = 0;
+            var ran = AssistedReauthService.HandleVerdictCore(
+                isCloudMode: isCloudMode,
+                deadRefreshToken: deadToken,
+                gate: new AssistedReauthGate(session), // a fresh gate instance per verdict — statics never carry the state
+                runFlow: () => invokedLocal++,
+                setStatus: s => captured = s);
+            invoked += invokedLocal;
+            status = captured;
+            return ran;
+        }
+
+        [Test]
+        public void DeadFamilyVerdict_AutoRunsExactlyOnce_AcrossSimulatedDomainReload_AndAgainInFreshSession()
+        {
+            var session = new FakeSessionStore(); // one editor session
+            var invoked = 0;
+
+            // First verdict: the assisted flow auto-runs.
+            Assert.IsTrue(Verdict(session, "rt-dead", ref invoked, out _));
+            Assert.AreEqual(1, invoked);
+
+            // The same verdict repeated in the same domain: once-gated, no second auto-run.
+            Assert.IsFalse(Verdict(session, "rt-dead", ref invoked, out var status));
+            Assert.AreEqual(1, invoked);
+            Assert.IsNotNull(status); // persistent "sign in required" status instead of a re-open
+
+            // Simulated domain reload: in-memory state dies, SessionState survives — a NEW gate
+            // over the SAME session store still refuses to re-run for the same dead token.
+            Assert.IsFalse(Verdict(session, "rt-dead", ref invoked, out _));
+            Assert.AreEqual(1, invoked);
+
+            // Fresh editor session: SessionState is cleared — the verdict fires again (deliberate,
+            // D4 wants the user involved until authorization succeeds).
+            Assert.IsTrue(Verdict(new FakeSessionStore(), "rt-dead", ref invoked, out _));
+            Assert.AreEqual(2, invoked);
+        }
+
+        [Test]
+        public void DifferentDeadToken_IsANewVerdict_AndAutoRunsAgain()
+        {
+            var session = new FakeSessionStore();
+            var invoked = 0;
+
+            Assert.IsTrue(Verdict(session, "rt-dead-1", ref invoked, out _));
+            // A different family died later (e.g. a peer surface re-logged-in and THAT credential
+            // died too): a new verdict — auto-runs again in the same session.
+            Assert.IsTrue(Verdict(session, "rt-dead-2", ref invoked, out _));
+            Assert.AreEqual(2, invoked);
+        }
+
+        [Test]
+        public void CarouselGuard_VerdictAfterAssistedSuccess_DoesNotAutoOpen_AndSetsStatus()
+        {
+            var session = new FakeSessionStore();
+            var invoked = 0;
+
+            // The assisted flow ran and committed successfully...
+            Assert.IsTrue(Verdict(session, "rt-dead-1", ref invoked, out _));
+            new AssistedReauthGate(session).RecordAssistedSuccess();
+
+            // ...and the freshly authorized credential died AGAIN (new token, new verdict): the D4
+            // ladder step-3 guard stops the auto-open — persistent status + manual Authorize only.
+            Assert.IsFalse(Verdict(session, "rt-dead-2", ref invoked, out var status));
+            Assert.AreEqual(1, invoked);
+            Assert.IsNotNull(status);
+            StringAssert.Contains("Sign in required", status);
+
+            // The guard survives a domain reload (SessionState anchor).
+            Assert.IsTrue(new AssistedReauthGate(session).CarouselStopped);
+            Assert.IsFalse(Verdict(session, "rt-dead-3", ref invoked, out _));
+            Assert.AreEqual(1, invoked);
+        }
+
+        [Test]
+        public void CarouselGuard_TwoUnattendedExpiries_StopAutoOpening()
+        {
+            var session = new FakeSessionStore();
+            var gate = new AssistedReauthGate(session);
+
+            Assert.AreEqual(AssistedReauthDecision.AutoRun, gate.Decide(AssistedReauthGate.HashToken("rt-1")));
+            gate.RecordUnattendedExpiry();
+            Assert.IsFalse(gate.CarouselStopped); // one unattended expiry: a NEW verdict may still auto-run
+
+            Assert.AreEqual(AssistedReauthDecision.AutoRun, gate.Decide(AssistedReauthGate.HashToken("rt-2")));
+            gate.RecordUnattendedExpiry();
+            Assert.IsTrue(gate.CarouselStopped); // twice unattended — D4 ladder step 3
+
+            // Any further verdict, any token, even after a domain reload: no auto-open.
+            Assert.AreEqual(AssistedReauthDecision.CarouselStopped, new AssistedReauthGate(session).Decide(AssistedReauthGate.HashToken("rt-3")));
+        }
+
+        [Test]
+        public void LocalServerMode_NeverAutoRuns_AndSetsNoStatus()
+        {
+            var session = new FakeSessionStore();
+            var invoked = 0;
+
+            Assert.IsFalse(Verdict(session, "rt-dead", ref invoked, out var status, isCloudMode: false));
+            Assert.AreEqual(0, invoked);
+            Assert.IsNull(status); // no behavior change for LocalServer (Custom) mode
+        }
+
+        [Test]
+        public void MissingStoredToken_DoesNotAutoRun_ButSetsStatus()
+        {
+            var session = new FakeSessionStore();
+            var invoked = 0;
+
+            // Signed out / store missing: nothing to re-authorize automatically — the manual
+            // prompt path stays, with the persistent status set.
+            Assert.IsFalse(Verdict(session, deadToken: null, ref invoked, out var status));
+            Assert.AreEqual(0, invoked);
+            Assert.IsNotNull(status);
+        }
+
+        [Test]
+        public void HashToken_IsDeterministic_AndNeverTheRawToken()
+        {
+            var hash = AssistedReauthGate.HashToken("rt-secret");
+            Assert.AreEqual(64, hash.Length); // SHA-256 hex
+            Assert.AreEqual(hash, AssistedReauthGate.HashToken("rt-secret"));
+            Assert.AreNotEqual(hash, AssistedReauthGate.HashToken("rt-other"));
+            StringAssert.DoesNotContain("rt-secret", hash); // raw token material never lands in SessionState
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthGateTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthGateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d412e62e2ba4279af130795c6ab0026
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthServiceTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthServiceTests.cs
@@ -1,0 +1,224 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.Unity.MCP.Editor.Services;
+using NUnit.Framework;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// The service-level assisted sign-in runner (<see cref="AssistedReauthService.RunSignInCoreAsync"/>,
+    /// oauth-client-error-hygiene 02 §C4 / D4): browser-open stays behind the injected seam (no real
+    /// browser in CI), polling stops on expiry and on cancellation/disposal, and is NEVER
+    /// re-initiated unattended. Runs against a mocked authorization server; pending awaits run on
+    /// the thread pool (via <see cref="Task.Run(Func{Task})"/>) so the flow's continuations never
+    /// deadlock against the blocked Unity main thread.
+    /// </summary>
+    public class AssistedReauthServiceTests
+    {
+        sealed class FakeDeviceAuthClient : IDeviceAuthClient
+        {
+            readonly DeviceAuthorizeResponse _authorize;
+            readonly Queue<DeviceTokenResponse> _tokens;
+            int _requestCount;
+            int _pollCount;
+
+            public string ClientId => "unity-mcp-plugin";
+            public int RequestCount => Volatile.Read(ref _requestCount);
+            public int PollCount => Volatile.Read(ref _pollCount);
+
+            public FakeDeviceAuthClient(DeviceAuthorizeResponse authorize, IEnumerable<DeviceTokenResponse> tokens)
+            {
+                _authorize = authorize;
+                _tokens = new Queue<DeviceTokenResponse>(tokens);
+            }
+
+            public Task<DeviceAuthorizeResponse> RequestDeviceCodeAsync(CancellationToken ct = default)
+            {
+                Interlocked.Increment(ref _requestCount);
+                return Task.FromResult(_authorize);
+            }
+
+            public Task<DeviceTokenResponse> PollTokenAsync(string deviceCode, CancellationToken ct = default)
+            {
+                Interlocked.Increment(ref _pollCount);
+                lock (_tokens)
+                    return Task.FromResult(_tokens.Count > 0 ? _tokens.Dequeue() : Pending());
+            }
+        }
+
+        static DeviceAuthorizeResponse Authorize(int expiresIn = 600) => new DeviceAuthorizeResponse
+        {
+            DeviceCode = "DC-1",
+            UserCode = "WXYZ-1234",
+            VerificationUri = "https://ai-game.dev/device",
+            VerificationUriComplete = "https://ai-game.dev/device?code=WXYZ-1234",
+            ExpiresIn = expiresIn,
+            Interval = 5,
+        };
+
+        static DeviceTokenResponse Pending() => new DeviceTokenResponse { Error = "authorization_pending" };
+        static DeviceTokenResponse ServerExpired() => new DeviceTokenResponse { Error = "expired_token" };
+
+        /// <summary>A structurally valid (unverified) JWT whose payload carries the given JSON.</summary>
+        static string Jwt(string payloadJson)
+        {
+            static string B64Url(string s) => Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(s))
+                .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            return $"{B64Url(@"{""alg"":""ES256"",""typ"":""JWT""}")}.{B64Url(payloadJson)}.sig";
+        }
+
+        static DeviceTokenResponse Success() => new DeviceTokenResponse
+        {
+            AccessToken = Jwt(@"{""sub"":""usr_42"",""aud"":""urn:agd:hub""}"),
+            RefreshToken = "rt-1",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            Scope = "mcp:agent",
+        };
+
+        /// <summary>Run the core off the Unity main thread so pending awaits resume on the pool.</summary>
+        static AssistedReauthOutcome Run(Func<Task<AssistedReauthOutcome>> flow)
+            => Task.Run(flow).GetAwaiter().GetResult();
+
+        [Test]
+        public void Approval_OpensBrowserThroughTheInjectedSeam_AndCommitsExactlyOnce()
+        {
+            string? opened = null;
+            var commits = 0;
+            var client = new FakeDeviceAuthClient(Authorize(), new[] { Pending(), Success() });
+
+            var outcome = Run(() => AssistedReauthService.RunSignInCoreAsync(
+                client,
+                serverTarget: "https://ai-game.dev",
+                openBrowser: url => opened = url, // the D4 browser-open seam — no real browser in CI
+                delay: (_, __) => Task.CompletedTask,
+                commit: (login, ct) =>
+                {
+                    Interlocked.Increment(ref commits);
+                    Assert.AreEqual("rt-1", login.AgentFamily.RefreshToken);
+                    return Task.FromResult(AssistedReauthOutcome.Committed);
+                }));
+
+            Assert.AreEqual(AssistedReauthOutcome.Committed, outcome);
+            Assert.AreEqual("https://ai-game.dev/device?code=WXYZ-1234", opened);
+            Assert.AreEqual(1, commits);
+        }
+
+        [Test]
+        public void ServerExpiry_StopsThePoll_NoReinitiation_NoCommit()
+        {
+            var commits = 0;
+            var client = new FakeDeviceAuthClient(Authorize(), new[] { Pending(), ServerExpired() });
+
+            var outcome = Run(() => AssistedReauthService.RunSignInCoreAsync(
+                client,
+                serverTarget: "https://ai-game.dev",
+                openBrowser: _ => { },
+                delay: (_, __) => Task.CompletedTask,
+                commit: (login, ct) => { Interlocked.Increment(ref commits); return Task.FromResult(AssistedReauthOutcome.Committed); }));
+
+            Assert.AreEqual(AssistedReauthOutcome.Expired, outcome);
+            Assert.AreEqual(0, commits);
+            // Never re-initiated unattended (D4): exactly ONE device-code request went out, and the
+            // poll stopped at the server's expired_token verdict.
+            Assert.AreEqual(1, client.RequestCount);
+            Assert.AreEqual(2, client.PollCount);
+        }
+
+        [Test]
+        public void DeadlineExpiry_ShortFixtureExpiry_StopsThePoll_AndNeverReinitiates()
+        {
+            var commits = 0;
+            // 1-second device-code lifetime (the short fixture expiry), pending forever, a real but
+            // tiny poll delay: the RFC 8628 deadline is what ends the flow.
+            var client = new FakeDeviceAuthClient(Authorize(expiresIn: 1), Array.Empty<DeviceTokenResponse>());
+
+            var outcome = Run(() => AssistedReauthService.RunSignInCoreAsync(
+                client,
+                serverTarget: "https://ai-game.dev",
+                openBrowser: _ => { },
+                delay: (_, ct) => Task.Delay(TimeSpan.FromMilliseconds(25), ct),
+                commit: (login, ct) => { Interlocked.Increment(ref commits); return Task.FromResult(AssistedReauthOutcome.Committed); }));
+
+            Assert.AreEqual(AssistedReauthOutcome.Expired, outcome);
+            Assert.AreEqual(0, commits);
+            Assert.AreEqual(1, client.RequestCount); // no unattended re-initiation
+
+            // The poll loop is dead after the deadline: no further polls arrive.
+            var pollsAtCompletion = client.PollCount;
+            Thread.Sleep(200);
+            Assert.AreEqual(pollsAtCompletion, client.PollCount);
+        }
+
+        [Test]
+        public void Cancellation_StopsThePoll_NoCommit_NoReinitiation()
+        {
+            var commits = 0;
+            using var cts = new CancellationTokenSource();
+            // Pending forever + a delay that parks until cancelled: only disposal/cancellation can
+            // end this flow (within the device-code lifetime).
+            var client = new FakeDeviceAuthClient(Authorize(), Array.Empty<DeviceTokenResponse>());
+
+            var task = Task.Run(() => AssistedReauthService.RunSignInCoreAsync(
+                client,
+                serverTarget: "https://ai-game.dev",
+                openBrowser: _ => { },
+                delay: (_, ct) => Task.Delay(Timeout.InfiniteTimeSpan, ct),
+                commit: (login, ct) => { Interlocked.Increment(ref commits); return Task.FromResult(AssistedReauthOutcome.Committed); },
+                onFlow: null,
+                cancellationToken: cts.Token));
+
+            // Wait for the flow to actually start (the device-code request is its first step),
+            // then cancel while it is parked in the poll delay.
+            var deadline = DateTime.UtcNow.AddSeconds(10);
+            while (client.RequestCount == 0 && DateTime.UtcNow < deadline)
+                Thread.Sleep(10);
+            Assert.AreEqual(1, client.RequestCount, "flow never started");
+
+            cts.Cancel();
+            var outcome = task.GetAwaiter().GetResult();
+
+            Assert.AreEqual(AssistedReauthOutcome.Cancelled, outcome);
+            Assert.AreEqual(0, commits);
+            Assert.AreEqual(1, client.RequestCount); // cancellation never re-initiates
+
+            // The poll loop is dead after cancellation: no further polls arrive.
+            var pollsAtCompletion = client.PollCount;
+            Thread.Sleep(200);
+            Assert.AreEqual(pollsAtCompletion, client.PollCount);
+        }
+
+        [Test]
+        public void CancelledBeforeStart_DoesNothing()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var client = new FakeDeviceAuthClient(Authorize(), Array.Empty<DeviceTokenResponse>());
+
+            var outcome = Run(() => AssistedReauthService.RunSignInCoreAsync(
+                client,
+                serverTarget: "https://ai-game.dev",
+                openBrowser: _ => { },
+                delay: (_, __) => Task.CompletedTask,
+                commit: (login, ct) => Task.FromResult(AssistedReauthOutcome.Committed),
+                onFlow: null,
+                cancellationToken: cts.Token));
+
+            Assert.AreEqual(AssistedReauthOutcome.Cancelled, outcome);
+            Assert.AreEqual(0, client.RequestCount); // nothing went out on the wire
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthServiceTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Auth/AssistedReauthServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1884439971274649ac571bf076d722d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/MainWindowEditor.StatusLogicTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/UI/MainWindowEditor.StatusLogicTests.cs
@@ -354,5 +354,29 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         }
 
         #endregion
+
+        #region ShouldPromptOnAuthorizationRejected (oauth-client-error-hygiene 02 §C4)
+
+        // The silent-red early-return is GONE: a Cloud-mode authorization rejection surfaces the
+        // prompt path even while the provider still reads as signed in. A dead credential family
+        // can never be refreshed, so "signed in ⇒ the coordinator will recover" was false — the
+        // early-return left the editor silently red while the AS was hit every 60 s. Restoring
+        // `if (isSignedIn) return false;` reddens the signed-in case below.
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CloudMode_AlwaysReachesThePromptPath(bool isSignedIn)
+        {
+            Assert.IsTrue(MainWindowEditor.ShouldPromptOnAuthorizationRejected(ConnectionMode.Cloud, isSignedIn));
+        }
+
+        // LocalServer (Custom) mode keeps its behavior: no cloud sign-in prompt.
+        [TestCase(true)]
+        [TestCase(false)]
+        public void CustomMode_NeverPrompts(bool isSignedIn)
+        {
+            Assert.IsFalse(MainWindowEditor.ShouldPromptOnAuthorizationRejected(ConnectionMode.Custom, isSignedIn));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## What this is

`oauth-client-error-hygiene` task **c2-unity-assisted-reauth-against-810** (supersedes c1, whose guard condition was confirmed true: this repo consumes McpPlugin via the NuGetForUnity **8.1.0 version pin** — `NuGetConfig.cs:113` / `.nuget-installed.json` — so no pin or DLL is touched here; pin bumps belong to r2).

Implements the **D4 recovery ladder** in the Unity editor against the pinned McpPlugin 8.1.0: when the machine credential is dead, the user is involved — the default browser opens on the device-flow authorization request and the editor waits (polls) for approval — instead of the silently-red editor the old signed-in early-return produced.

## Changes

- **Service-level device-flow entry (extraction, 02 §C4)** — new `AssistedReauthService`: the Authorize flow no longer lives inline in `MainWindowEditor.Connection.cs` and no longer dies with the window. The window's Authorize button delegates to `AssistedReauthService.AuthorizeAsync()` (no duplicated flow); the dev-bridge `authorize` target keeps working through the same `_startAuthorizeAction`.
- **Trigger (02 §C4 step 2)** — the service subscribes `PluginCredentialProvider.OnSignInRequired` / `State` (both public in 8.1.0, previously zero Unity readers), re-attached on every plugin (re)build via `AccountCredentialService.AttachTo`. Cloud mode only; LocalServer (Custom) mode behavior is unchanged.
- **Silent-red early-return removed** — `OnAuthorizationRejected` no longer early-returns for signed-in users; the decision is pinned by `MainWindowEditor.ShouldPromptOnAuthorizationRejected` + tests (restoring the early-return reddens them).
- **D4 assisted flow** — default browser opened at `verification_uri_complete` (else `verification_uri`, with the user code shown in the window/log), token endpoint polled until approval, bounded by the server's device-code expiry (RFC 8628). Polling stops on approval, expiry, or disposal/cancellation — NEVER re-initiates unattended.
- **Once-gate** — `SessionState` keyed by a SHA-256 hash of the dead refresh token (raw token material never lands in SessionState): fires once per editor session per verdict, survives domain reload, deliberately re-fires after a full editor restart. NOT EditorPrefs.
- **Carousel guard (D4 ladder step 3)** — after an assisted success, a repeat dead-credential verdict stops auto-opening; two unattended device-code expiries also stop it. Persistent "Sign in required" status + the manual Authorize button remain.
- **On success** — F1 login commit (`CommitLoginAsync`), then the existing reload flow: `AccountCredentialService.Reload()` + plugin rebuild + `ConnectIfNeeded` (KeepConnected intent respected — a deliberately stopped connection is never resurrected).

## Deferred to r2

Compiled against the pinned McpPlugin **8.1.0**, so the following c1 items are deferred to **r2** (which bumps the pin to the McpPlugin build carrying a1–a3):

- **a2/a3 interplay evidence** — memo-blocked refresh + connection-loop-settles behavior, and the a3 coordinator's auto-resume on the SignInRequired→SignedIn edge. Until r2, the resume path is the in-process reload flow above (the 8.1.0 connect loop keeps the KeepConnected intent and picks up the fresh credential).
- **Reason-class rendering** — `PluginCredentialProvider.SignInRequiredReason` does not exist in 8.1.0: all terminal verdicts render the generic "Sign in required — your session expired" status, and the carousel guard keys on **verdict recurrence**, not reason class. `// r2:` markers are placed where the `invalid_target` → "server configuration error" rendering and reason-class carousel keying slot in.
- **No pin/version bumps in this diff** (r2 owns them).

## Verification (local, Unity 2022.3.62f3 — the project's pinned editor)

- Full EditMode suite `com.IvanMurzak.Unity.MCP.Editor.Tests`: **1082/1082 passed** (existing suite + 15 new tests) against the pinned 8.1.0 DLLs.
- **Plant round** (each DoD claim reddened by reverting its mechanism, then restored):
  - restore the signed-in early-return ⇒ `CloudMode_AlwaysReachesThePromptPath(True)` RED (DoD c)
  - remove the once-gate ⇒ `DeadFamilyVerdict_AutoRunsExactlyOnce_AcrossSimulatedDomainReload_AndAgainInFreshSession` RED (DoD a)
  - remove the carousel success check ⇒ `CarouselGuard_VerdictAfterAssistedSuccess_DoesNotAutoOpen_AndSetsStatus` RED (DoD b)
  - disconnect the browser-open seam ⇒ `Approval_OpensBrowserThroughTheInjectedSeam_AndCommitsExactlyOnce` RED (DoD d)
  - re-initiate once on expiry ⇒ both `ServerExpiry_…` and `DeadlineExpiry_…` no-reinitiation tests RED (polling lifecycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVipj7Xi4HouAmmdCYSdmz
