### PR TITLE
fix(logs): skip log collection in Asset Import Workers, allow shared-handle Clear (#855)

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Unity/Logs/FileLogStorage.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Unity/Logs/FileLogStorage.cs
@@ -113,7 +113,10 @@ namespace com.IvanMurzak.Unity.MCP
 
                     _logger.LogDebug("Creating log file stream: {file}", filePath);
 
-                    var stream = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite, bufferSize: _fileBufferSize, useAsync: false)
+                    // FileShare.Delete is required, not cosmetic: Windows refuses DeleteFile while ANY
+                    // open handle omits FILE_SHARE_DELETE. Without it a second Editor process holding
+                    // this file makes Clear() throw "used by another process" (#855).
+                    var stream = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete, bufferSize: _fileBufferSize, useAsync: false)
                         ?? throw new Exception("Failed to create file stream for log storage.");
 
                     resultFileName = currentFileName;
@@ -320,7 +323,7 @@ namespace com.IvanMurzak.Unity.MCP
             if (!File.Exists(filePath))
                 return Array.Empty<LogEntry>();
 
-            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
             {
                 var cutoffTime = lastMinutes > 0
                     ? DateTime.Now.AddMinutes(-lastMinutes)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/UnityMcpPlugin.cs
@@ -103,6 +103,13 @@ namespace com.IvanMurzak.Unity.MCP
             if (LogCollector != null)
                 return;
 
+            // Asset Import Workers are headless Editor processes launched with the SAME -projectPath,
+            // so each one resolves the same log file and holds a write handle on it for its whole
+            // lifetime. They serve no MCP client, so collecting their logs only adds import noise to
+            // the cache — and their handles are what makes Console/ClearLogs fail (#855).
+            if (Runtime.Utils.EnvironmentUtils.IsAssetImportWorker())
+                return;
+
             AddUnityLogCollector(logStorageProvider());
         }
 

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
@@ -116,7 +116,10 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
         public const string AssetImportWorkerNamePrefix = "AssetImportWorker";
 
         /// <summary>
-        /// Checks whether the current process is a Unity Asset Import Worker.
+        /// Checks whether the CURRENT PROCESS is a Unity Asset Import Worker, by reading the
+        /// <c>-name</c> argument Unity itself launches the worker with. The project's location on
+        /// disk plays no part: no path is inspected, compared, or hardcoded anywhere here, so this
+        /// behaves identically on every machine and for every project folder.
         ///
         /// A worker is a headless Editor process Unity launches with the SAME <c>-projectPath</c>
         /// as the main Editor, so every project-relative path it computes — including the MCP log
@@ -127,10 +130,14 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
             => IsAssetImportWorker(Environment.GetCommandLineArgs());
 
         /// <summary>
-        /// Test-friendly overload. Matches only a <c>-name</c> / <c>--name</c> flag whose VALUE starts
-        /// with <see cref="AssetImportWorkerNamePrefix"/>. Deliberately not a substring scan of the whole
-        /// command line: a project living under a folder called <c>AssetImportWorkerRepro</c> would
-        /// otherwise disable log collection in the main Editor.
+        /// Test-friendly overload taking the command line explicitly.
+        ///
+        /// Matches a <c>-name</c> / <c>--name</c> flag whose VALUE starts with
+        /// <see cref="AssetImportWorkerNamePrefix"/>. Reading the flag's value, rather than scanning
+        /// the whole command line for the word, is what keeps the project's location out of it: the
+        /// command line also carries <c>-projectPath</c>, so a substring scan would report "worker"
+        /// for any project whose folder happened to contain that word and switch off log collection
+        /// in its main Editor.
         /// </summary>
         public static bool IsAssetImportWorker(IReadOnlyList<string>? commandLineArgs)
         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Runtime/Utils/EnvironmentUtils.cs
@@ -110,6 +110,50 @@ namespace com.IvanMurzak.Unity.MCP.Runtime.Utils
         }
 
         /// <summary>
+        /// The value Unity gives an Asset Import Worker via its <c>-name</c> command-line argument,
+        /// e.g. <c>-name AssetImportWorker0</c>. Workers are numbered, so this is a prefix.
+        /// </summary>
+        public const string AssetImportWorkerNamePrefix = "AssetImportWorker";
+
+        /// <summary>
+        /// Checks whether the current process is a Unity Asset Import Worker.
+        ///
+        /// A worker is a headless Editor process Unity launches with the SAME <c>-projectPath</c>
+        /// as the main Editor, so every project-relative path it computes — including the MCP log
+        /// file — collides with the main Editor's. Workers serve no MCP client, so anything scoped
+        /// to a client session should be skipped in them.
+        /// </summary>
+        public static bool IsAssetImportWorker()
+            => IsAssetImportWorker(Environment.GetCommandLineArgs());
+
+        /// <summary>
+        /// Test-friendly overload. Matches only a <c>-name</c> / <c>--name</c> flag whose VALUE starts
+        /// with <see cref="AssetImportWorkerNamePrefix"/>. Deliberately not a substring scan of the whole
+        /// command line: a project living under a folder called <c>AssetImportWorkerRepro</c> would
+        /// otherwise disable log collection in the main Editor.
+        /// </summary>
+        public static bool IsAssetImportWorker(IReadOnlyList<string>? commandLineArgs)
+        {
+            if (commandLineArgs == null)
+                return false;
+
+            // Stop at Count - 1: a trailing "-name" has no value to inspect.
+            for (var i = 0; i < commandLineArgs.Count - 1; i++)
+            {
+                var flag = commandLineArgs[i];
+                if (!string.Equals(flag, "-name", StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(flag, "--name", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var value = commandLineArgs[i + 1];
+                if (value != null && value.StartsWith(AssetImportWorkerNamePrefix, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Applies environment-variable and command-line-argument overrides to the given config.
         /// Args (highest priority) override env vars, env vars override the disk-baseline values
         /// already present on <paramref name="config"/>. Returns an <see cref="OverrideRecord"/>

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
@@ -301,6 +301,66 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.AreEqual("QUOTED_TOKEN", config.LocalToken);
         }
 
+        // --- Asset Import Worker detection (#855) ---
+
+        [Test]
+        public void IsAssetImportWorker_TrueForWorkerCommandLine()
+        {
+            // Verbatim shape of a Unity 6 Asset Import Worker command line.
+            var args = new[]
+            {
+                "D:/UnityEditor/6000.3.21f1/Editor/Unity.exe",
+                "-adb2", "-batchMode", "-noUpm",
+                "-name", "AssetImportWorker0",
+                "-projectPath", "D:/Coding/Game",
+                "-logFile", "Logs/AssetImportWorker0.log",
+                "-parentPid", "44868"
+            };
+
+            Assert.IsTrue(EnvironmentUtils.IsAssetImportWorker(args));
+        }
+
+        [Test]
+        public void IsAssetImportWorker_FalseForMainEditorCommandLine()
+        {
+            var args = new[]
+            {
+                "D:/UnityEditor/6000.3.21f1/Editor/Unity.exe",
+                "-projectPath", "D:/Coding/Game"
+            };
+
+            Assert.IsFalse(EnvironmentUtils.IsAssetImportWorker(args));
+        }
+
+        [Test]
+        public void IsAssetImportWorker_FalseWhenOnlyThePathContainsTheWord()
+        {
+            // A substring scan of the whole command line would disable log collection in the MAIN
+            // Editor of any project stored under a folder with this name.
+            var args = new[]
+            {
+                "D:/UnityEditor/6000.3.21f1/Editor/Unity.exe",
+                "-projectPath", "D:/Repro/AssetImportWorkerRepro"
+            };
+
+            Assert.IsFalse(EnvironmentUtils.IsAssetImportWorker(args));
+        }
+
+        [Test]
+        public void IsAssetImportWorker_FalseForTrailingNameFlagWithNoValue()
+        {
+            var args = new[] { "Unity.exe", "-name" };
+
+            Assert.IsFalse(EnvironmentUtils.IsAssetImportWorker(args));
+        }
+
+        [Test]
+        public void IsAssetImportWorker_FalseForNullOrEmptyArgs()
+        {
+            Assert.IsFalse(EnvironmentUtils.IsAssetImportWorker(null));
+            Assert.IsFalse(EnvironmentUtils.IsAssetImportWorker(Array.Empty<string>()));
+        }
+
         // --- Helpers ---
 
         static string SerializeForDisk(UnityMcpPlugin.UnityConnectionConfig config)

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Environment/EnvironmentUtilsTests.cs
@@ -306,13 +306,15 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         [Test]
         public void IsAssetImportWorker_TrueForWorkerCommandLine()
         {
-            // Verbatim shape of a Unity 6 Asset Import Worker command line.
+            // The ARGUMENT SHAPE is what a Unity 6 Asset Import Worker is launched with. The path
+            // values are generic fixtures: IsAssetImportWorker only reads the value of -name, and
+            // nothing in this fixture is resolved against a filesystem.
             var args = new[]
             {
-                "D:/UnityEditor/6000.3.21f1/Editor/Unity.exe",
+                "/home/user/unity/Editor/Unity",
                 "-adb2", "-batchMode", "-noUpm",
                 "-name", "AssetImportWorker0",
-                "-projectPath", "D:/Coding/Game",
+                "-projectPath", "/home/user/my-game",
                 "-logFile", "Logs/AssetImportWorker0.log",
                 "-parentPid", "44868"
             };
@@ -325,8 +327,8 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         {
             var args = new[]
             {
-                "D:/UnityEditor/6000.3.21f1/Editor/Unity.exe",
-                "-projectPath", "D:/Coding/Game"
+                "/home/user/unity/Editor/Unity",
+                "-projectPath", "/home/user/my-game"
             };
 
             Assert.IsFalse(EnvironmentUtils.IsAssetImportWorker(args));
@@ -335,12 +337,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
         [Test]
         public void IsAssetImportWorker_FalseWhenOnlyThePathContainsTheWord()
         {
-            // A substring scan of the whole command line would disable log collection in the MAIN
-            // Editor of any project stored under a folder with this name.
+            // Detection reads the VALUE of -name, never a path. Were it a substring scan of the
+            // whole command line, -projectPath would match too and log collection would switch off
+            // in the MAIN Editor of any project whose folder happens to contain the word.
             var args = new[]
             {
-                "D:/UnityEditor/6000.3.21f1/Editor/Unity.exe",
-                "-projectPath", "D:/Repro/AssetImportWorkerRepro"
+                "/home/user/unity/Editor/Unity",
+                "-projectPath", "/home/user/AssetImportWorkerRepro"
             };
 
             Assert.IsFalse(EnvironmentUtils.IsAssetImportWorker(args));

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Console/TestFileLogStorageShared.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Console/TestFileLogStorageShared.cs
@@ -1,0 +1,123 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// Regression cover for #855 — Console/ClearLogs failing with
+    /// "The process cannot access the file ... because it is being used by another process".
+    ///
+    /// Unity launches Asset Import Workers as headless Editor processes sharing the main Editor's
+    /// <c>-projectPath</c>, so each resolves the SAME <c>Temp/mcp-server/ai-editor-logs.txt</c> and
+    /// keeps a write handle on it. <see cref="UnityMcpPlugin.AddUnityLogCollectorIfNeeded"/> now skips
+    /// workers, but any second holder must still not be able to wedge <see cref="FileLogStorage.Clear"/> —
+    /// that is what these tests pin.
+    /// </summary>
+    public class TestFileLogStorageShared : BaseTest
+    {
+        const string FileName = "test-file-log-storage-shared.txt";
+
+        FileLogStorage? _primary;
+        FileLogStorage? _foreign;
+
+        [TearDown]
+        public void TestTearDown()
+        {
+            _foreign?.Dispose();
+            _primary?.Dispose();
+            _foreign = null;
+            _primary = null;
+        }
+
+        [Test]
+        public void Clear_SucceedsWhileASecondStorageHoldsTheSameFile()
+        {
+            // Two storages over one path stand in for two Unity processes on one project. Before the
+            // FileShare.Delete fix this threw IOException: the primary disposed only ITS OWN stream,
+            // and Windows refuses DeleteFile while any surviving handle omits FILE_SHARE_DELETE.
+            _primary = new FileLogStorage(requestedFileName: FileName);
+            _foreign = new FileLogStorage(requestedFileName: FileName);
+
+            _primary.Append(new LogEntry(LogType.Log, "from primary"));
+            _foreign.Append(new LogEntry(LogType.Log, "from foreign"));
+
+            Assert.DoesNotThrow(() => _primary!.Clear());
+        }
+
+        [Test]
+        public void Clear_RemovesTheCachedEntriesWhileASecondStorageHoldsTheSameFile()
+        {
+            // Not-throwing is not enough: the point of Clear is that the cache is actually emptied,
+            // so a later console-get-logs cannot resurrect pre-Clear entries.
+            _primary = new FileLogStorage(requestedFileName: FileName);
+            _foreign = new FileLogStorage(requestedFileName: FileName);
+
+            _primary.Append(new LogEntry(LogType.Log, "before clear"));
+            Assert.IsNotEmpty(_primary.Query(), "Precondition: the appended entry must be queryable.");
+
+            _primary.Clear();
+
+            Assert.IsEmpty(_primary.Query(), "Clear must leave no queryable entries behind.");
+        }
+
+        [Test]
+        public void Clear_LeavesTheStorageWritableAfterwards()
+        {
+            // Clear disposes the write stream and nulls it; AppendInternal is expected to lazily
+            // recreate it. A regression here would silently stop log collection after the first Clear.
+            _primary = new FileLogStorage(requestedFileName: FileName);
+            _foreign = new FileLogStorage(requestedFileName: FileName);
+
+            _primary.Clear();
+            _primary.Append(new LogEntry(LogType.Warning, "after clear"));
+
+            var entries = _primary.Query();
+            Assert.AreEqual(1, entries.Length, "Exactly the post-Clear entry should be present.");
+            Assert.AreEqual("after clear", entries[0].Message);
+        }
+
+        [Test]
+        public void SecondStorage_SharesTheSamePathRatherThanForkingANewFile()
+        {
+            // Pins the assumption the tests above rest on: the two storages really do collide on one
+            // file. CreateWriteStream carries a uniquifying retry loop ("-2", "-3", ...) that only runs
+            // when the open THROWS, and the share mode lets a second writer straight in — so the loop
+            // never fires and no sibling appears. Should that ever change, the collision these tests
+            // model would vanish and they would start passing vacuously.
+            _primary = new FileLogStorage(requestedFileName: FileName);
+            _foreign = new FileLogStorage(requestedFileName: FileName);
+
+            _primary.Append(new LogEntry(LogType.Log, "primary"));
+            _foreign.Append(new LogEntry(LogType.Log, "foreign"));
+
+            var forks = FindForkedFiles();
+            Assert.IsEmpty(forks,
+                "Both storages must land on one file for this fixture to be meaningful. " +
+                $"Unexpected uniquified sibling(s): {string.Join(", ", forks)}");
+        }
+
+        static string[] FindForkedFiles()
+        {
+            var directory = Path.GetFullPath(
+                $"{Path.GetDirectoryName(Application.dataPath)}/Temp/mcp-server");
+            if (!Directory.Exists(directory))
+                return System.Array.Empty<string>();
+
+            var baseName = Path.GetFileNameWithoutExtension(FileName);
+            var extension = Path.GetExtension(FileName);
+            return Directory.GetFiles(directory, $"{baseName}-*{extension}");
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Console/TestFileLogStorageShared.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/Tool/Console/TestFileLogStorageShared.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 012b0ca1a8414290be322632d85b63b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #855.

## The other process is an Asset Import Worker

`Console/ClearLogs` throws `The process cannot access the file '<project>/Temp/mcp-server/ai-editor-logs.txt' because it is being used by another process.`

I asked Windows who the holder was, via the Restart Manager API (`RmRegisterResources` / `RmGetList`) on that exact path:

```
LOCK HOLDER: 51040 Unity
LOCK HOLDER: 28760 Unity
```

Their command lines:

```
Unity.exe -adb2 -batchMode -noUpm -name AssetImportWorker0 -projectPath D:/Coding/LTM/Ironfront_Reborn
          -logFile Logs/AssetImportWorker0.log -srvPort 64973 -parentPid 44868
Unity.exe -adb2 -batchMode -noUpm -name AssetImportWorker1 -projectPath D:/Coding/LTM/Ironfront_Reborn ...
```

Asset Import Workers are headless Editor processes on the **same `-projectPath`**. They load the Editor assemblies, so `[InitializeOnLoad] Startup` runs in each of them, calls `AddUnityLogCollectorIfNeeded(() => new BufferedFileLogStorage())`, and resolves `Application.dataPath` to the same folder as the main Editor. Every worker therefore opens the *same* `ai-editor-logs.txt` and holds a write handle for its whole lifetime.

`Clear()` disposes only the calling process's stream, then calls `File.Delete`. Windows refuses `DeleteFile` while any surviving handle omits `FILE_SHARE_DELETE`, and `CreateWriteStream` passes `FileShare.ReadWrite`. So the delete fails.

## Not a race

The issue title says race condition. On my machine it is deterministic: 5 of 5 calls failed on a freshly opened, idle Editor. It looks intermittent because it tracks *worker lifetime*, not timing. Workers persist after an import finishes, so:

| State | `Console/ClearLogs` |
|---|---|
| Any worker alive | fails, every time |
| No worker alive | succeeds, every time |

Killing both workers and calling the tool again is the whole repro loop:

```
taskkill /PID 51040 /F ; taskkill /PID 28760 /F
→ Restart Manager: no holders
→ console-clear-logs: success, 1.9 MB log file deleted, console-get-logs returns []
```

Before that, same Editor, same session: `isError: true` on every call.

The mechanism in isolation, same message byte for byte:

```
FileShare.ReadWrite         → "The process cannot access the file ... used by another process."
FileShare.ReadWrite|Delete  → DELETE OK
```

## What this changes

**1. `AddUnityLogCollectorIfNeeded` returns early in a worker.**

All seven call sites (`Startup`, `Startup.Editor` ×3, `MainWindowEditor`, `McpListWindowBase`, `AssistedReauthService`) funnel through that one method, so a single guard covers them. This is the root-cause half: a worker serves no MCP client, so its import chatter was only diluting the cache that `console-get-logs` reads.

I used `-name AssetImportWorker*` rather than `Application.isBatchMode`, deliberately. `isBatchMode` is also true for CI and for anyone running the Editor headless on purpose, and I did not want to silently disable log collection for them. And it matches on the *value* of `-name`, not on a substring of the whole command line, so a project stored under a folder called `AssetImportWorkerRepro` does not disable collection in its main Editor. There is a test for exactly that.

**2. The log `FileStream` opens with `FileShare.Delete`.**

Defence in depth for the general case. Asset Import Workers are the common second holder, not the only possible one, and any of them wedges `Clear()` today. With the flag on both the write and read opens, `Clear()` survives a foreign handle whatever opened it.

## Two things I noticed but did not change

**The uniquifying retry loop in `CreateWriteStream` is unreachable.** It renames to `-2`, `-3`, up to 1000 attempts, but only when the open *throws*. `FileShare.ReadWrite` lets the second writer straight in, so the loop has never fired. Its intent (one file per process) would fix this class of problem at the source, but tightening the share mode to force it is a design call that belongs to you, not to a bug-fix PR. `SecondStorage_SharesTheSamePathRatherThanForkingANewFile` pins the current behaviour so the change is visible if you ever make it.

**Concurrent appenders can overwrite each other.** `FileMode.Append` in .NET seeks to end at *open*, not per write, so two processes that opened the file when it was empty both write from position 0. Garbled lines are then silently dropped by the `catch` in `DeserializeLogEntry`. The guard in change 1 removes the usual source of concurrency, so I left this alone.

## Verification

Ran on Unity 6000.3.21f1, Windows 11, plugin 0.90.0, server 9.2.5:

- Restart Manager identifying the two workers as the holders
- kill workers → `console-clear-logs` succeeds → `console-get-logs` returns `[]` → the 1.9 MB file is gone
- the `FileShare` mechanism reproduced standalone, both directions

Not run locally: the new tests. The package's test assembly is not compiled in a consumer project without a `testables` entry, and I did not want to reshape a working project to get there. They are written to fail before this patch by construction (`Clear_SucceedsWhileASecondStorageHoldsTheSameFile` throws the reported `IOException` without change 2), but CI is the first place they actually execute.
