### PR TITLE
fix: agent-initiated destroys register with the Editor undo stack

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/CHANGELOG.md
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Fixed
 
+- **Agent-initiated destroys register with the Editor undo stack.**
+  `gameobject-destroy` and `gameobject-component-destroy` both carry
+  `DestructiveHint = true`, yet called `UnityEngine.Object.DestroyImmediate`, so
+  the destroyed subtree or component never reached the undo stack and the
+  editor's undo shortcut could not bring it back. `Undo.` appeared nowhere in
+  the plugin. Both tools — and both sides of the `UNITY_6000_5_OR_NEWER` split
+  for `gameobject-destroy` — now call `UnityEditor.Undo.DestroyObjectImmediate`.
+  The transient `DestroyImmediate` calls in `Screenshot.*`,
+  `Assets.Prefab.Create` and `MainThreadDispatcher` are unchanged: they release
+  temporary objects that do not belong on a user's undo stack.
+
 - **`EntityId` wire format moved from JSON number to JSON string of decimal digits**
   (Unity 6.5+ paths only). Closes #759, resolves #754. JS-based MCP clients
   (Claude Agent SDK, etc.) parse JSON numbers as IEEE-754 doubles, so any

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Destroy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Component.Destroy.cs
@@ -85,7 +85,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                     if (destroyComponentRefs.Any(cr => cr.Matches(component)))
                     {
                         var destroyedComponentRef = new ComponentRef(component);
-                        UnityEngine.Object.DestroyImmediate(component);
+                        UnityEditor.Undo.DestroyObjectImmediate(component);
                         destroyCounter++;
                         response.DestroyedComponents ??= new ComponentRefList();
                         response.DestroyedComponents.Add(destroyedComponentRef);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.cs
@@ -59,7 +59,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 logger.LogInformation("Destroying GameObject '{Name}' (InstanceID: {InstanceId}) at path '{Path}'",
                     destroyedName, destroyedInstanceId, destroyedPath);
 
-                UnityEngine.Object.DestroyImmediate(go);
+                UnityEditor.Undo.DestroyObjectImmediate(go);
 
                 logger.LogInformation("Successfully destroyed GameObject '{Name}' (InstanceID: {InstanceId})",
                     destroyedName, destroyedInstanceId);

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.pre-Unity.6.5.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/API/Tool/GameObject.Destroy.pre-Unity.6.5.cs
@@ -59,7 +59,7 @@ namespace com.IvanMurzak.Unity.MCP.Editor.API
                 logger.LogInformation("Destroying GameObject '{Name}' (InstanceID: {InstanceId}) at path '{Path}'",
                     destroyedName, destroyedInstanceId, destroyedPath);
 
-                UnityEngine.Object.DestroyImmediate(go);
+                UnityEditor.Undo.DestroyObjectImmediate(go);
 
                 logger.LogInformation("Successfully destroyed GameObject '{Name}' (InstanceID: {InstanceId})",
                     destroyedName, destroyedInstanceId);


### PR DESCRIPTION
Thanks — all three taken, and you caught something I had wrong.

The description edits are gone entirely. You are right about `Ctrl+Z`: it is `Cmd+Z` on macOS, so
the line was false for half your users, and the token cost was not buying anything either way.

On the third comment — the reason the pre-6.5 file only had a description change is that I had
missed `GameObject.Destroy.pre-Unity.6.5.cs` completely. So the previous version fixed the code on
the 6.5+ side and the wording on the pre-6.5 side, which is backwards. That is now the code on both
sides and no description changes anywhere.

## What changed

Three call sites, nothing else:

- `GameObject.Destroy.cs:62` (`#if UNITY_6000_5_OR_NEWER`)
- `GameObject.Destroy.pre-Unity.6.5.cs:62` (`#if !UNITY_6000_5_OR_NEWER`)
- `GameObject.Component.Destroy.cs:88` (shared, no `#if`)

`UnityEngine.Object.DestroyImmediate` → `UnityEditor.Undo.DestroyObjectImmediate`, fully qualified
to match the existing `UnityEditor.EditorUtility.SetDirty` style in that folder, plus a `CHANGELOG`
entry under `[Unreleased] → Fixed`.

The other `DestroyImmediate` calls are untouched — `Screenshot.Isolated`, `Screenshot.SceneView`,
`Screenshot.Camera`, `Screenshot.GameView`, `Assets.Prefab.Create` and `MainThreadDispatcher` all
release temporary objects that do not belong on a user's undo stack.

## Verification, and its limits

Compiled against **Unity 6000.5.6f1**, zero `error CS`, and
`ToolThreadSafetyTests.GameObjectDestroy_BothThreads` and `GameObjectComponentDestroy_BothThreads`
pass there. `Undo.PerformUndo()` restores the destroyed object after the new call and does not after
the old one, which is the behaviour the change is for.

⚠ **6000.5.6f1 is the only editor on this machine, so the `#if !UNITY_6000_5_OR_NEWER` branch was
never compiled.** It is the same one-line substitution as its 6.5+ twin, fully qualified so it needs
no new `using`, but I have not built it and I would rather say so than imply I had.

## Two things I did not decide for you

**A `Transform` can now be destroyed where it previously could not.** `gameobject-component-destroy`
iterates `go.GetComponents<Component>()` with no `Transform` guard, and the schema text points at
index 0. `Object.DestroyImmediate` refuses a Transform and logs an error; `Undo.DestroyObjectImmediate`
destroys and replaces it silently — the GameObject survives with a new Transform, and any serialized
reference to the old one becomes missing, with the tool still reporting success. It is undoable, but
it is a real behaviour change on an input the tool accepts. Happy to add a `Transform`/`RectTransform`
skip, or to leave it and note it, whichever you prefer.

**Play mode.** `editor-application-set-state` can put the editor into play mode, where `Undo` is not
meaningful. The call is unconditional here; a fallback to `Object.DestroyImmediate` while
`EditorApplication.isPlaying` is two lines if you want it.
