### PR TITLE
ci: make fork PRs legible, and give the licensed suite a way to reach them (#543)

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -10,6 +10,10 @@ name: test-cli
 
 on:
   workflow_call:
+    inputs:
+      # Optional git ref to test. Empty (the default) checks out the ref the
+      # caller ran on.
+      ref: { required: false, type: string, default: "" }
 
 jobs:
   test-cli:
@@ -20,6 +24,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          # When a ref was passed in, this tree is a pull request's code and may
+          # come from a fork: do not leave a usable token in its .git/config.
+          persist-credentials: ${{ inputs.ref == '' }}
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/test_pull_request_manual.yml
+++ b/.github/workflows/test_pull_request_manual.yml
@@ -10,10 +10,79 @@ name: test-pull-request-manual
 
 on:
   workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to test (empty = test the branch this run was dispatched on)"
+        required: false
+        type: string
+
+# Nothing on this path needs to write: this run checks out a pull request's
+# code, which may come from a fork, and the default token on this repository
+# is write-scoped. Set here as well as per job so a job added later inherits it.
+permissions:
+  contents: read
 
 jobs:
+  # Resolve what to test. A PR opened from a fork lives in THIS repository as
+  # refs/pull/<n>/merge, so dispatching this workflow on a branch here and
+  # naming the PR number runs the full licensed suite against a fork's code
+  # without granting that code access to the secrets on any other trigger.
+  resolve:
+    name: resolve ref
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - id: resolve
+        env:
+          PR: ${{ inputs.pr }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PR:-}" ]; then
+            echo "ref=" >> "$GITHUB_OUTPUT"
+            echo "Testing ${{ github.ref }} (no PR number given)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          case "$PR" in
+            ''|*[!0-9]*) echo "::error::pr must be a pull request number"; exit 1 ;;
+          esac
+          remote="${{ github.server_url }}/${{ github.repository }}"
+          # Resolve to a commit SHA, not to refs/pull/<n>/merge. That ref is
+          # mutable: a push to the PR moves it, and the fourteen jobs below
+          # resolve it independently over several minutes. Pinning here means
+          # every job tests the one commit you looked at before dispatching.
+          name="merge"
+          line=$(git ls-remote "$remote" "refs/pull/$PR/merge")
+          if [ -z "$line" ]; then
+            name="head"
+            line=$(git ls-remote "$remote" "refs/pull/$PR/head")
+            [ -n "$line" ] && echo "::warning::PR #$PR has no merge ref (conflicts, or it is closed) - testing its head instead."
+          fi
+          if [ -z "$line" ]; then
+            echo "::error::No refs/pull/<n>/* found for that number on ${{ github.repository }}."
+            exit 1
+          fi
+          ref=${line%%[!0-9a-f]*}
+          if [ ${#ref} -ne 40 ]; then
+            echo "::error::Could not read a commit SHA for PR #$PR."
+            exit 1
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Testing PR #$PR at \`$ref\` (its $name commit)." >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+
   test-cli:
+    needs: resolve
+    # This run checks out code from a pull request, which may come from a fork.
+    # The default token on this repository is write-scoped; nothing here needs
+    # more than read, so it does not get more than read.
+    permissions:
+      contents: read
     uses: ./.github/workflows/test_cli.yml
+    with:
+      ref: ${{ needs.resolve.outputs.ref }}
 
   # --- UNITY TESTS ---
   # -------------------
@@ -21,24 +90,36 @@ jobs:
   # --- EDIT MODE ---
 
   test-unity-2022-3-62f3-editmode:
+    needs: resolve
+    permissions:
+      contents: read
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
+      ref: ${{ needs.resolve.outputs.ref }}
       projectPath: "./Unity-Tests/2022.3.62f3"
       unityVersion: "2022.3.62f3"
       testMode: "editmode"
     secrets: inherit
 
   test-unity-2023-2-22f1-editmode:
+    needs: resolve
+    permissions:
+      contents: read
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
+      ref: ${{ needs.resolve.outputs.ref }}
       projectPath: "./Unity-Tests/2023.2.22f1"
       unityVersion: "2023.2.22f1"
       testMode: "editmode"
     secrets: inherit
 
   test-unity-6000-3-1f1-editmode:
+    needs: resolve
+    permissions:
+      contents: read
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
+      ref: ${{ needs.resolve.outputs.ref }}
       projectPath: "./Unity-Tests/6000.3.1f1"
       unityVersion: "6000.3.1f1"
       testMode: "editmode"
@@ -73,24 +154,36 @@ jobs:
   # --- STANDALONE ---
 
   test-unity-2022-3-62f3-standalone:
+    needs: resolve
+    permissions:
+      contents: read
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
+      ref: ${{ needs.resolve.outputs.ref }}
       projectPath: "./Unity-Tests/2022.3.62f3"
       unityVersion: "2022.3.62f3"
       testMode: "standalone"
     secrets: inherit
 
   test-unity-2023-2-22f1-standalone:
+    needs: resolve
+    permissions:
+      contents: read
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
+      ref: ${{ needs.resolve.outputs.ref }}
       projectPath: "./Unity-Tests/2023.2.22f1"
       unityVersion: "2023.2.22f1"
       testMode: "standalone"
     secrets: inherit
 
   test-unity-6000-3-1f1-standalone:
+    needs: resolve
+    permissions:
+      contents: read
     uses: ./.github/workflows/test_unity_plugin.yml
     with:
+      ref: ${{ needs.resolve.outputs.ref }}
       projectPath: "./Unity-Tests/6000.3.1f1"
       unityVersion: "6000.3.1f1"
       testMode: "standalone"

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -17,6 +17,10 @@ on:
       projectPath: { required: true, type: string }
       unityVersion: { required: true, type: string }
       testMode: { required: true, type: string }
+      # Optional git ref to test. Empty (the default) checks out the ref the
+      # caller ran on. test_pull_request_manual.yml passes refs/pull/<n>/merge
+      # so a maintainer can run this suite against a fork PR's code.
+      ref: { required: false, type: string, default: "" }
     secrets:
       # Stored Unity Personal license (.ulf XML). Generated once via the
       # generate-unity-activation-file workflow + https://license.unity3d.com/manual
@@ -41,16 +45,64 @@ jobs:
 
     steps:
       # --------------------------------------------------------------------- #
+      # 2-a1. Is a Unity license reachable from this run?
+      #
+      # GitHub withholds repository secrets from pull_request runs raised by a
+      # fork, so on a fork PR every step below would fail inside game-ci at
+      # license activation. Decide here instead, where the reason can be said
+      # out loud, and never print the secret itself.
+      # --------------------------------------------------------------------- #
+      - name: Check Unity license availability
+        id: license
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        run: |
+          if [ -n "$UNITY_LICENSE" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          # Not "head.repo.fork": that field says whether the head repository is
+          # itself a fork of anything, which is true for every PR raised inside a
+          # fork. The question here is whether the head is a DIFFERENT repository
+          # from this one, because that is what makes GitHub withhold the secret.
+          head_repo="${{ github.event.pull_request.head.repo.full_name }}"
+          if [ "${{ github.event_name }}" != "pull_request" ] || \
+             [ -z "$head_repo" ] || [ "$head_repo" = "${{ github.repository }}" ]; then
+            echo "::error::UNITY_LICENSE is empty on a run that should have it. See docs/claude/ci-unity-license.md."
+            exit 1
+          fi
+          echo "::notice::Unity tests not run: UNITY_LICENSE is unavailable to a fork PR. See the job summary."
+          {
+            echo "### Unity tests not run: no license in a fork PR"
+            echo ""
+            echo "GitHub withholds repository secrets from \`pull_request\` runs raised by a fork,"
+            echo "so \`UNITY_LICENSE\` is empty here and game-ci cannot activate an editor."
+            echo ""
+            echo "Two ways to get these tests run:"
+            echo "- Set your own \`UNITY_LICENSE\`, \`UNITY_EMAIL\` and \`UNITY_PASSWORD\` secrets on your fork"
+            echo "  (see \`docs/claude/ci-unity-license.md\`) and this suite runs on your fork's PRs."
+            echo "- Ask a maintainer to run **test-pull-request-manual** with this PR's number."
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+
+      # --------------------------------------------------------------------- #
       # 2-a. Checkout repository
       # --------------------------------------------------------------------- #
       - uses: actions/checkout@v6
+        if: steps.license.outputs.available == 'true'
         with:
           lfs: false
+          ref: ${{ inputs.ref }}
+          # When a ref was passed in, this tree is a pull request's code and may
+          # come from a fork: do not leave a usable token in its .git/config.
+          persist-credentials: ${{ inputs.ref == '' }}
 
       # --------------------------------------------------------------------- #
       # 2-b. Free disk space
       # --------------------------------------------------------------------- #
       - name: Free disk space
+        if: steps.license.outputs.available == 'true'
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
@@ -67,6 +119,7 @@ jobs:
       # (see the env block on the test-runner step below). No per-run web scraping.
       # --------------------------------------------------------------------- #
       - name: Generate cache key
+        if: steps.license.outputs.available == 'true'
         id: cache_key
         run: |
           # Sanitize projectPath: replace /, \, :, and spaces with underscores
@@ -75,6 +128,7 @@ jobs:
         shell: bash
 
       - uses: actions/cache@v5
+        if: steps.license.outputs.available == 'true'
         with:
           path: |
             ${{ inputs.projectPath }}/Library
@@ -83,11 +137,13 @@ jobs:
 
       # --------------------------------------------------------------------- #
       - name: Generate custom image name
+        if: steps.license.outputs.available == 'true'
         id: custom_image
         run: echo "image=unityci/editor:ubuntu-${{ inputs.unityVersion }}-${{ matrix.platform }}-3" >> $GITHUB_OUTPUT
         shell: bash
 
       - uses: game-ci/unity-test-runner@08fd329f00a18efa297140b14ac28ebce742759e # node24 runtime (PR #304); revert to @v4 once game-ci moves the tag
+        if: steps.license.outputs.available == 'true'
         id: tests
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -104,7 +160,7 @@ jobs:
 
       # --------------------------------------------------------------------- #
       - uses: actions/upload-artifact@v6
-        if: always()
+        if: always() && steps.license.outputs.available == 'true'
         with:
           name: Test results for ${{ inputs.unityVersion }} ${{ inputs.testMode }} on ${{ matrix.platform }}
           path: ${{ steps.tests.outputs.artifactsPath }}


### PR DESCRIPTION
Follow-up to #968, as asked. Three changes under `.github/workflows/`, no plugin code.

**1. `test_unity_plugin.yml` decides whether a license is reachable before it starts anything.** A first step reads `UNITY_LICENSE` from that step's env:

* present → nothing changes, the suite runs as it does today;
* absent, on a pull request whose head is a different repository → the job writes a summary saying why and passes, with every later step skipped: about six seconds instead of the 1m23s–3m13s the twelve checks on #968 each burn today, and an explanation instead of a wall of red;
* absent anywhere else — your own branches, `workflow_dispatch` → **fails loudly**, so a secret that goes missing on your side is still a red build.

**2. `test_cli.yml` and `test_unity_plugin.yml` take an optional `ref`.** Empty by default, which is today's behaviour.

**3. `test-pull-request-manual` takes a PR number.** A pull request lives in *this* repository as `refs/pull/<n>/…` even when it comes from a fork — `git ls-remote https://github.com/IvanMurzak/Unity-MCP.git 'refs/pull/968/*'` returns both refs for #968, which is a fork PR — so dispatching that workflow on `main` or `dev` with `pr: 968` runs the licensed suite against that PR's code. `resolve` turns the number into a commit SHA **once**, and every job checks out that SHA: the `merge` ref is mutable, and fourteen jobs resolving it independently over several minutes could otherwise test different trees, including one pushed after you looked at the diff. If a PR has no merge ref (conflicts, or it is closed) it falls back to the head commit with a warning. A push during the run does not move the pin: a commit stays fetchable by SHA after a ref moves off it — #968's superseded merge commit `5a0ca1d3` still fetches today, 66 hours after its ref moved, against the widest job-start spread I measured, 157 seconds in run `33248588098` — so a late job gets the tree you approved, and if it were not fetchable it would fail outright rather than quietly test something else.

**The decision this hands you.** A fork PR cannot merge into this repository today: your ruleset *Required status checks (no bypass)* requires all twelve `test-unity-*` contexts, and a fork can satisfy none of them. After this change it satisfies all twelve with jobs that compiled nothing. That is what makes outside contributions mergeable again, and it is also the loss of your only mechanical guarantee that a fork's code builds on three Unity versions — change 3 is how you get that guarantee back, on demand and on a commit you chose. If you would rather the checks stay red, dropping the summary branch and keeping the `exit 1` is a one-line change, but then nothing from a fork can land while that ruleset stays as it is.

**What that path runs, since it is the part worth arguing with.** It executes a pull request's code: `npm ci` and `npm test` run its lockfile and its lifecycle scripts (`cli/package.json` has a `pretest` that fires `npm run build`), and the Unity runner compiles and runs its C# with `UNITY_LICENSE`, `UNITY_EMAIL` and `UNITY_PASSWORD` in the environment. Two of the three things that made that sharp — a write-scoped token, a credential left in the tree, and the license — are closed here: those jobs declare `contents: read`, because this repository's default workflow token is write-scoped (`Contents: write`, `Packages: write`, `Statuses: write`, … — the block [run 32789998955](https://github.com/IvanMurzak/Unity-MCP/actions/runs/32789998955) prints) and none of them needs it; and a checkout that was handed a ref does not persist credentials into the tree it just fetched. What is left is the license itself, and that part is inherent — you cannot run a contributor's tests without running a contributor's code. It is why this is a maintainer action on a commit you picked, and not a trigger.

It is also what I would flag about the `pull_request_target` route from #543. The answer you got there was that with `pull_request_target` "contributors from forks never touch them". That holds only while the workflow checks out the base; once it checks out the PR head, which it must in order to test it, the fork's code runs *with* those three secrets — the workflow-file guard in that design stops YAML changes, not C#. The `ci-ok` label is what turns that into a decision, which is the same protection dispatch gets from being manual. If you would rather have that label gate, so results post as checks automatically, the `ref` plumbing here is what it needs.

**What I ran**, in my own fork:

* A same-repository pull request with no license, which is the loud branch: the twelve Unity jobs stop at the new step in six seconds and fail, every later step skipped, `test-cli` and the nuget gate green ([run 33250003038](https://github.com/zorionarrillaga/Unity-MCP/actions/runs/33250003038), on the commit in this PR).
* `test-pull-request-manual` with `pr: 2`: `resolve` produced a SHA and the checkout logged `ref: e2c5d4a5fb23c619acc6c7c66ab1032aa3d6797b` — that PR's merge commit exactly — with `persist-credentials: false` under a `Contents: read` token, and the CLI suite ran on that tree: 38 files, 581 passed, 6 skipped ([run 33249448967](https://github.com/zorionarrillaga/Unity-MCP/actions/runs/33249448967) — its twelve Unity jobs are red because that run predates the placeholder license, and stopped at the gate). A Unity leg reaches the same checkout with the same two settings, which I confirmed separately by putting a placeholder in `UNITY_LICENSE` so the licensed path would be taken ([run 33249806403](https://github.com/zorionarrillaga/Unity-MCP/actions/runs/33249806403)). I cancelled both runs once the checkouts had shown what I needed, so both read as cancelled; a placeholder license gets a Unity leg no further than game-ci's activation anyway.
* The `permissions:` block reaches the token inside the reusable workflows, not only the calling job: `Packages: read` is in the job's scope list before the change ([run 33248588098](https://github.com/zorionarrillaga/Unity-MCP/actions/runs/33248588098)) and gone after it ([run 33249448967](https://github.com/zorionarrillaga/Unity-MCP/actions/runs/33249448967)), with `Contents: read` in both — the reduction from a write-scoped default is not what those logs show, since my fork's default is already read-only; what they show is that the block reaches inside the reusable workflow.
* The fork-PR branch is the one I cannot raise in my own fork, having one account — but **this pull request is that event**. A `pull_request` run resolves `uses: ./…` at the merge commit, which already carries this change, so approving run `33250121859` executes the pass-with-summary branch here, on your repository, before anything is merged. Expect those twelve Unity checks to go green having compiled nothing: on this PR that is the demonstration. The outcome half of that I have watched rather than predicted: with the predicate inverted so a same-repository PR selects the same branch — one line, nothing else changed, commit `25897da6` — [run 33251907887](https://github.com/zorionarrillaga/Unity-MCP/actions/runs/33251907887) in my fork is green across all sixteen jobs, each Unity job passing at the license step with every later step skipped. The harness cannot select the branch the way a real fork PR does, which is why the sentence below still says replay. Until you approve it, that branch rests on a replay — I ran the step's script against the values GitHub recorded in the event payload of run `32992648441`, the red run on #968, where the head repository is `zorionarrillaga/Unity-MCP` and the base is yours.
* Not tested: anything that needs a real Unity license.

Refs #543.
