### PR TITLE
docs(ci): the red test-unity legs are fork PRs with no secrets, not a regression

### DIFF
--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -24,12 +24,12 @@ on:
       #
       # A pull request from a FORK receives none of these three: GitHub withholds
       # repository secrets from a `pull_request` run whose head repository differs
-      # from the base, so `secrets: inherit` passes empty strings and the
-      # game-ci step below fails in under a second on every leg. That is the
-      # expected behaviour of an unlicensed run, not a broken license or a broken
-      # workflow -- see the "Fork pull requests get no secrets" section of
-      # docs/claude/ci-unity-license.md for how to run the licensed suite against
-      # a fork PR's code.
+      # from the base, so the caller's `secrets: inherit` (test_pull_request.yml)
+      # passes empty strings and the game-ci step below fails in under a second on
+      # every leg. That is the expected behaviour of an unlicensed run, not a broken
+      # license or a broken workflow — see the "Fork pull requests get no secrets"
+      # section of docs/claude/ci-unity-license.md for how to run the licensed suite
+      # against a fork PR's code.
       UNITY_LICENSE: { required: false }
       UNITY_EMAIL: { required: false }
       UNITY_PASSWORD: { required: false }

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -21,6 +21,15 @@ on:
       # Stored Unity Personal license (.ulf XML). Generated once via the
       # generate-unity-activation-file workflow + https://license.unity3d.com/manual
       # and stored as the UNITY_LICENSE secret. See docs/claude/ci-unity-license.md.
+      #
+      # A pull request from a FORK receives none of these three: GitHub withholds
+      # repository secrets from a `pull_request` run whose head repository differs
+      # from the base, so `secrets: inherit` passes empty strings and the
+      # game-ci step below fails in under a second on every leg. That is the
+      # expected behaviour of an unlicensed run, not a broken license or a broken
+      # workflow -- see the "Fork pull requests get no secrets" section of
+      # docs/claude/ci-unity-license.md for how to run the licensed suite against
+      # a fork PR's code.
       UNITY_LICENSE: { required: false }
       UNITY_EMAIL: { required: false }
       UNITY_PASSWORD: { required: false }

--- a/docs/claude/ci-unity-license.md
+++ b/docs/claude/ci-unity-license.md
@@ -41,7 +41,8 @@ gh secret set UNITY_PASSWORD --repo IvanMurzak/Unity-MCP
 GitHub withholds repository secrets from a `pull_request` run whose head repository is a
 **fork**. `secrets: inherit` still resolves — to empty strings. So on a fork PR
 `game-ci/unity-test-runner` receives an empty `UNITY_LICENSE` and aborts before it pulls an
-image or contacts Unity, and **all 12 `test-unity-*` legs go red at once**.
+image or contacts Unity, and **all 12 `test-unity-*` legs go red at once** (6 caller jobs in
+`test_pull_request.yml` × the 2-way `platform: [base, windows-mono]` matrix).
 
 **This is the expected behaviour of an unlicensed run.** The license, the secrets and the
 workflow are all fine; a fork simply cannot see them. Nothing here needs fixing, and
@@ -53,13 +54,19 @@ The tell is **duration**, and it survives log expiry — job metadata outlives l
 `gh api repos/IvanMurzak/Unity-MCP/actions/runs/<run-id>/jobs` answers it even when the log
 download returns HTTP 410:
 
-- **No secrets (fork PR)** — the `Run game-ci/unity-test-runner@…` step starts and completes
-  **in the same second**, while `Free disk space` and `actions/cache` before it succeed. The
-  whole job is 1–3 minutes, nearly all of it disk cleanup.
-- **A genuinely bad `.ulf`** — the step runs for minutes: it pulls the editor image first and
-  only then fails inside the container on activation.
+- **No secrets (fork PR)** — the `Run game-ci/unity-test-runner@…` step completes **within a
+  second** of starting (usually the same second; at a boundary, the next one), while
+  `Free disk space` and `actions/cache` before it succeed. The whole job is 1–4 minutes,
+  nearly all of it disk cleanup.
+- **A genuinely bad `.ulf`** — the step runs for **minutes**. For scale, on the licensed run
+  `33757559794` the same step takes 9–13 minutes per leg before it succeeds. (Why it takes that
+  long — image pull, then activation inside the container — is unverified here: no bad-`.ulf`
+  run is on record. If you hit one, record its run id in this section.)
 
-Check the head repository directly rather than inferring from the branch name:
+Duration separates *empty* from *bad*. It does **not** separate a fork PR from a
+same-repository run whose `UNITY_LICENSE` was deleted or never set — the secret is declared
+`required: false`, so both deliver an empty string and both fail identically. Settle that with
+the head-repository check, not the clock:
 
 ```bash
 gh api repos/IvanMurzak/Unity-MCP/actions/runs/<run-id> \
@@ -67,6 +74,11 @@ gh api repos/IvanMurzak/Unity-MCP/actions/runs/<run-id> \
 ```
 
 A `full_name` other than `IvanMurzak/Unity-MCP` means the run had no secrets.
+
+One more fork-PR shape to expect, with a different signature: a run stuck at
+`action_required` has **not started at all** — GitHub holds a first-time contributor's workflow
+for maintainer approval. There is then no red to diagnose and `conclusion` comes back `null`.
+Approve the run first; the no-secrets shape above is what you should see once it does start.
 
 ### How to run the licensed suite against a fork PR's code
 
@@ -77,22 +89,28 @@ gh workflow run test_pull_request_manual.yml --repo IvanMurzak/Unity-MCP --ref m
 ```
 
 Reviewing a fork PR's actual code this way needs a ref the maintainer picks — a fork PR's
-commits are fetchable from this repository as `refs/pull/<n>/head` and `refs/pull/<n>/merge`.
+commits are fetchable from this repository as `refs/pull/<n>/head` (always) and
+`refs/pull/<n>/merge` (only while GitHub can compute a clean test-merge, so absent on a
+conflicting PR). Neither is fetched by default — `git fetch origin refs/pull/<n>/head` — and
+neither can be dispatched: `workflow_dispatch` takes only a branch or tag as its ref, so
+`--ref refs/pull/<n>/head` is rejected.
 Wiring that into the dispatch (and deciding whether a fork's Unity checks should be allowed to
-pass at all, given the required-status-check ruleset) is a **policy decision**, tracked in
-issue #543 and PR #971 — deliberately not settled by this document.
+pass at all, given the required-status-check ruleset) is a **policy decision** — deliberately not
+settled by this document. It is open in **PR #971**; issue #543, which first asked for it, was
+closed as completed back in 2026-03, so follow the PR, not the issue.
 
 ### Measured, 2026-09-03 (issue #973)
 
-Every `test-pull-request` run between 2026-08-25 and 2026-08-29 came from a fork
-(`Nghaiz`, `akimaleo`, `zorionarrillaga`) and was red; the last same-repository run before them,
+All seven `test-pull-request` runs between 2026-08-25 and 2026-08-29 came from a fork
+(`Nghaiz`, `akimaleo`, `zorionarrillaga`) and none went green — 3 `failure`, 2 `cancelled` and
+2 `action_required`, the last being the approval gate above. The last same-repository run before them,
 `32788655839` (2026-08-24), was green, and there was no same-repository PR in between. Read as a
 time series that looks exactly like a CI regression, and it was not one. Three runs pin it:
 
 | run | what it was | result |
 |---|---|---|
 | [`32992648441`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/32992648441) | fork PR, secrets withheld | 12/12 legs red; test-runner step `04:57:53Z -> 04:57:53Z` |
-| [`33758511822`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33758511822) | dispatch of this same workflow with `secrets: inherit` removed — the one variable | red, same instant-failure shape |
+| [`33758511822`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33758511822) | `test_pull_request_manual.yml` dispatched from a throwaway branch with one Unity job's `secrets: inherit` removed — the one variable | red, same instant-failure shape |
 | [`33757559794`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33757559794) | dispatch on `main`, secrets present, same commit `91e2472a` the fork PRs branched from | green |
 
 ## The one machine-binding gotcha (why a desktop `.ulf` fails)
@@ -116,7 +134,9 @@ does exactly this).
 5. Re-run any failed Unity workflow — it now uses the stored license.
 
 Personal `.ulf` files carry `ValidTo="9999-12-31"` and effectively don't expire; if a
-run ever reports the license as invalid, repeat steps 1–4 to refresh it.
+run ever reports the license as invalid, repeat steps 1–4 to refresh it — but rule out a fork
+PR first ("Fork pull requests get no secrets" above), which reports the same thing and is not
+fixed by refreshing.
 
 ## Security note
 

--- a/docs/claude/ci-unity-license.md
+++ b/docs/claude/ci-unity-license.md
@@ -36,6 +36,65 @@ gh secret set UNITY_EMAIL    --repo IvanMurzak/Unity-MCP
 gh secret set UNITY_PASSWORD --repo IvanMurzak/Unity-MCP
 ```
 
+## Fork pull requests get no secrets (read this before "the license is broken")
+
+GitHub withholds repository secrets from a `pull_request` run whose head repository is a
+**fork**. `secrets: inherit` still resolves — to empty strings. So on a fork PR
+`game-ci/unity-test-runner` receives an empty `UNITY_LICENSE` and aborts before it pulls an
+image or contacts Unity, and **all 12 `test-unity-*` legs go red at once**.
+
+**This is the expected behaviour of an unlicensed run.** The license, the secrets and the
+workflow are all fine; a fork simply cannot see them. Nothing here needs fixing, and
+re-issuing the `.ulf` will not change it.
+
+### How to tell it apart from a real license failure
+
+The tell is **duration**, and it survives log expiry — job metadata outlives logs, so
+`gh api repos/IvanMurzak/Unity-MCP/actions/runs/<run-id>/jobs` answers it even when the log
+download returns HTTP 410:
+
+- **No secrets (fork PR)** — the `Run game-ci/unity-test-runner@…` step starts and completes
+  **in the same second**, while `Free disk space` and `actions/cache` before it succeed. The
+  whole job is 1–3 minutes, nearly all of it disk cleanup.
+- **A genuinely bad `.ulf`** — the step runs for minutes: it pulls the editor image first and
+  only then fails inside the container on activation.
+
+Check the head repository directly rather than inferring from the branch name:
+
+```bash
+gh api repos/IvanMurzak/Unity-MCP/actions/runs/<run-id> \
+  --jq '"\(.event) \(.head_repository.full_name) \(.conclusion)"'
+```
+
+A `full_name` other than `IvanMurzak/Unity-MCP` means the run had no secrets.
+
+### How to run the licensed suite against a fork PR's code
+
+`test_pull_request_manual.yml` is `workflow_dispatch`-only, so it runs with full secrets:
+
+```bash
+gh workflow run test_pull_request_manual.yml --repo IvanMurzak/Unity-MCP --ref main
+```
+
+Reviewing a fork PR's actual code this way needs a ref the maintainer picks — a fork PR's
+commits are fetchable from this repository as `refs/pull/<n>/head` and `refs/pull/<n>/merge`.
+Wiring that into the dispatch (and deciding whether a fork's Unity checks should be allowed to
+pass at all, given the required-status-check ruleset) is a **policy decision**, tracked in
+issue #543 and PR #971 — deliberately not settled by this document.
+
+### Measured, 2026-09-03 (issue #973)
+
+Every `test-pull-request` run between 2026-08-25 and 2026-08-29 came from a fork
+(`Nghaiz`, `akimaleo`, `zorionarrillaga`) and was red; the last same-repository run before them,
+`32788655839` (2026-08-24), was green, and there was no same-repository PR in between. Read as a
+time series that looks exactly like a CI regression, and it was not one. Three runs pin it:
+
+| run | what it was | result |
+|---|---|---|
+| [`32992648441`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/32992648441) | fork PR, secrets withheld | 12/12 legs red; test-runner step `04:57:53Z -> 04:57:53Z` |
+| [`33758511822`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33758511822) | dispatch of this same workflow with `secrets: inherit` removed — the one variable | red, same instant-failure shape |
+| [`33757559794`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33757559794) | dispatch on `main`, secrets present, same commit `91e2472a` the fork PRs branched from | green |
+
 ## The one machine-binding gotcha (why a desktop `.ulf` fails)
 
 A `.ulf` binds to the **HardwareId** of the machine whose `.alf` produced it.


### PR DESCRIPTION
## Summary

- **The 12 red `test-unity-*` legs are not a CI regression.** Every `test-pull-request` run
  between 2026-08-25 and 2026-08-29 came from a **fork**, and GitHub withholds repository
  secrets from a `pull_request` run whose head repository is a fork — so `secrets: inherit`
  hands `test_unity_plugin.yml` an empty `UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD` and
  `game-ci/unity-test-runner` aborts before it pulls an image. The licensed path is healthy and
  no secret needs re-issuing.
- Documents the mechanism in `docs/claude/ci-unity-license.md` — including the **duration tell**
  that separates it from a bad `.ulf` and that survives log expiry, because job *metadata*
  outlives logs — and points at it from a comment on `test_unity_plugin.yml`'s `secrets:` block.
- **No behavioural change.** 68 insertions, 0 deletions, both files documentation-only.

## Cause class

Not (a) license/activation, not (b) action/runtime, not (c) test-project content, not (d)
`Editor/` product code. It is a **fifth class the diagnosis had to add: fork PRs receive no
secrets.** It presents *license-shaped* — game-ci's error names `UNITY_LICENSE` — but is not
credential-shaped: the stored secrets are valid and untouched, so the owner gate **G-P0 is not
exercised** and `Editor/` was never involved.

### Evidence line (verbatim, run `33758511822`, job `100658764301`)

```
##[error]Missing Unity License File and no Serial was found. If this
is a personal license, make sure to follow the activation
steps and set the UNITY_LICENSE GitHub secret or enter a Unity
serial number inside the UNITY_SERIAL GitHub secret.
```

Its `env:` block in that same log reads `UNITY_LICENSE:`, `UNITY_EMAIL:` and `UNITY_PASSWORD:`
with nothing after the colon.

## Why the premise was wrong

Head repository of every run in the window (`gh api repos/IvanMurzak/Unity-MCP/actions/runs/<id>`):

| run | created | head repository | conclusion |
|---|---|---|---|
| `32788655839` | 2026-08-24T23:17Z | `IvanMurzak/Unity-MCP` (same repo) | **success** |
| `32822206166` | 2026-08-25T07:33Z | `Nghaiz/Unity-MCP` (fork) | failure |
| `32989259890` | 2026-08-26T16:35Z | `akimaleo/Unity-MCP` (fork) | failure |
| `32992648441` | 2026-08-26T17:11Z | `zorionarrillaga/Unity-MCP` (fork) | failure |
| `33250121859` | 2026-08-29T11:26Z | `zorionarrillaga/Unity-MCP` (fork) | action_required |

The last green run is the last same-repository run, and there was no same-repository PR in
between — so the red sample contains fork PRs and nothing else. Read as a time series it looks
exactly like a regression; it is a sampling artefact.

Two independent checks rule the alternatives out. Nothing in the repo changed: the only commit
touching `.github/` between the last green and the first red is `91e2472a` (release 0.90.0),
whose entire `.github/` diff is three lines of `.github/nuget-gate.lock`, and
`test_unity_plugin.yml` was last modified 2026-07-20 (`06ca3e1a`). Nothing upstream changed
either: the action is SHA-pinned, and the pinned editor images `ubuntu-2022.3.62f3-base-3`,
`ubuntu-2022.3.62f3-windows-mono-3` and `ubuntu-6000.3.1f1-base-3` were last pushed 2026-04-13,
2026-04-13 and 2026-03-19 respectively — four months before the break.

The original logs are expired (HTTP 410), but job metadata is not. In `32992648441` every Unity
leg's `Run game-ci/unity-test-runner@08fd329f…` step **started and completed in the same
second** (`04:57:53Z -> 04:57:53Z`) with `Free disk space` and `actions/cache` succeeding before
it. An action that rejects its inputs immediately never reached an activation attempt.

## Discriminator — both halves, one variable, same commit

Both dispatches ran `test_pull_request_manual.yml` against `91e2472a`, the commit the fork PRs
branched from. The only difference between them is whether the Unity job received the secrets.

| half | run | result |
|---|---|---|
| secrets **present** — dispatch on `main`, workflow unmodified | [`33757559794`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33757559794) | **green** |
| secrets **withheld** — same dispatch from a throwaway branch whose `test_pull_request_manual.yml` kept one Unity job and dropped its `secrets: inherit` line | [`33758511822`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33758511822) | **red**, with the error line above |

The red half reproduces the historical fingerprint rather than merely failing: step 7
`13:01:37Z -> 13:01:38Z`, `upload-artifact` failing straight after it on
`Input required and not supplied: path` (nothing was produced to upload), and step numbering
jumping 8 → 14 — the same shape `32992648441` recorded. The throwaway branch has been deleted;
its harness was one deletion of `secrets: inherit`, so it reproduces from this description.

**Caveat stated plainly:** the 2026-08-25..27 logs are gone, so the error *text* cannot be
compared byte-for-byte against them. What is compared is the structural fingerprint, which the
API still serves for both.

## What this PR deliberately does not do

Making a fork's Unity checks *pass* would satisfy the required-status-check ruleset with jobs
that compiled nothing — a leg that stops failing because it stopped running is worse than a red
one, and it trades away the only mechanical guarantee that a fork's code builds. That is a
policy decision for the owner, open in PR #971 — issue #543, which first asked for it, was closed as completed in
2026-03 — and is out of scope here.

## Test plan

- [x] `python .github/scripts/check_nuget_gate.py` locally → `NuGet gate OK: 15 pins, generation UNITY_MCP_DEPS_3, propagation consistent.` (exit 0)
- [x] `test_unity_plugin.yml` re-parses as YAML with its three `secrets:` keys intact (the edit is comment-only)
- [x] No Unity or CLI suite applies — the diff touches nothing under `Unity-MCP-Plugin/**` or `cli/**`
- [x] Diff grepped for `<?xml`, `LicenseVersion`, `UNITY_PASSWORD=` → 0 hits; no secret value appears in this PR, its commits, or its logs
- [x] This PR's own `test_pull_request.yml` run green on all jobs — nuget gate, `test-cli` (20 + 22) and all 12 `test-unity-*` legs actually running and passing: run
[`33758936539`](https://github.com/IvanMurzak/Unity-MCP/actions/runs/33758936539), 17/17 checks
green, the twelve Unity legs 3m43s—15m44s — the band of the last green run, not the
1.3—3.2 min fail-fast band.

Closes #973

