### PR TITLE
feat: honour UNITY_MCP_SERVER_PATH — launch a given server binary, skip download + version match

### DIFF
--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/CHANGELOG.md
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`UNITY_MCP_SERVER_PATH` — dev/CI override for the launched MCP server binary.** When the
+  variable resolves to a file that exists, the Editor launches that binary instead of the
+  `GameDev-MCP-Server` release pinned by `McpServerManager.ServerVersion`, and skips both the
+  download and the version match; the override also becomes the `command` written into generated
+  AI-agent configs. Set-but-missing falls through to the pinned release, matching Unreal-MCP's
+  `UNREAL_MCP_SERVER_PATH`. Resolved through `DevControlEnv.Resolve`, so it layers
+  process env > `<projectRoot>/.env` and therefore works for a GUI/IDE-launched Editor.
+  `Tools/AI Game Developer/Server/Download Binaries` still downloads into `Library/mcp-server/<rid>/`
+  regardless of the override. See `docs/mcp-server.md`.
+
 ### Fixed
 
 - **`EntityId` wire format moved from JSON number to JSON string of decimal digits**

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -112,18 +112,21 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         static McpServerManager()
         {
+            // Register for editor quit to clean up the server process
+            EditorApplication.quitting += OnEditorQuitting;
+
+            // Check if server process is still running (e.g., after domain reload)
+            EditorApplication.update += CheckExistingProcess;
+
+            // Announced AFTER the two registrations above on purpose: resolving the override reads
+            // <projectRoot>/.env from disk, and nothing added to this class initializer should be able to
+            // leave the editor-quit cleanup unregistered.
             var serverPathOverride = ResolveServerPathOverride();
             if (serverPathOverride != null)
                 _logger.LogInformation(
                     "{envVar} override active: launching {path} — server download and version check are skipped.",
                     ServerPathEnvVar,
                     serverPathOverride);
-
-            // Register for editor quit to clean up the server process
-            EditorApplication.quitting += OnEditorQuitting;
-
-            // Check if server process is still running (e.g., after domain reload)
-            EditorApplication.update += CheckExistingProcess;
 
             DownloadServerBinaryIfNeeded(unattended: true)
                 .ContinueWith(task =>
@@ -263,22 +266,26 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             }
         }
 
-        // Full path to the server executable
+        // The executable INSIDE the download cache — what DownloadAndUnpackBinary publishes and must verify.
+        // Never redirected by ServerPathEnvVar, so it stays usable as the download path's own ground truth
+        // while ExecutableFullPath (the LAUNCH target, below) follows the override. Not public: the launch
+        // target is the only path a caller outside this class has ever needed.
+        // Sample (mac linux): ../Library/mcp-server/osx-x64/gamedev-mcp-server
+        // Sample   (windows): ../Library/mcp-server/win-x64/gamedev-mcp-server.exe
+        static string CachedExecutableFullPath
+            => Path.GetFullPath(
+                Path.Combine(
+                    CachedExecutableFolderPath,
+                    ExecutableFullName
+                )
+            );
+
+        // Full path to the server executable the editor LAUNCHES: the ServerPathEnvVar override when one
+        // resolves, otherwise the pinned release in the download cache.
         // Sample (mac linux): ../Library/mcp-server/osx-x64/gamedev-mcp-server
         // Sample   (windows): ../Library/mcp-server/win-x64/gamedev-mcp-server.exe
         public static string ExecutableFullPath
-        {
-            get
-            {
-                var overridePath = ResolveServerPathOverride();
-                return overridePath ?? Path.GetFullPath(
-                    Path.Combine(
-                        CachedExecutableFolderPath,
-                        ExecutableFullName
-                    )
-                );
-            }
-        }
+            => ResolveServerPathOverride() ?? CachedExecutableFullPath;
 
         public static string VersionFullPath
             => Path.GetFullPath(
@@ -339,12 +346,27 @@ namespace com.IvanMurzak.Unity.MCP.Editor
             return File.ReadAllText(VersionFullPath);
         }
 
+        // The `version` marker inside the download cache — what a download just published. Distinct from
+        // GetBinaryVersion(), which follows ExecutableFolderPath and therefore reports the OVERRIDE directory
+        // (where no marker normally sits) whenever ServerPathEnvVar is active. The download path must ask
+        // this one, or it reports the launch target's version for a payload it wrote somewhere else.
+        public static string? GetCachedBinaryVersion()
+        {
+            var cachedVersionPath = Path.Combine(CachedExecutableFolderPath, "version");
+            if (!File.Exists(cachedVersionPath))
+                return null;
+
+            return File.ReadAllText(cachedVersionPath);
+        }
+
         public static bool IsVersionMatches()
         {
             // Under the ServerPathEnvVar override the launched binary is NOT a pinned GameDev-MCP-Server
             // release and carries no `version` marker beside it, so the pinned-version comparison does not
-            // apply. Reporting a match is what lets IsBinaryReadyToStart(), DownloadServerBinaryIfNeeded()
-            // and the post-publish check short-circuit instead of downloading over the developer's binary.
+            // apply. Reporting a match is what lets IsBinaryReadyToStart() and DownloadServerBinaryIfNeeded()
+            // short-circuit instead of downloading over the developer's binary. It deliberately does NOT
+            // stand in for DownloadAndUnpackBinary's post-publish verification: that check runs on a path
+            // where a download really happened, so it asks the cache directly (GetCachedBinaryVersion).
             if (ResolveServerPathOverride() != null)
                 return true;
 
@@ -629,12 +651,17 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                         // replace the developer's own override directory.
                         PublishStagedBinary(payloadFolder, CachedExecutableFolderPath);
 
-                        if (!File.Exists(ExecutableFullPath))
+                        // Verify the CACHE this publish actually targeted, NOT ExecutableFullPath /
+                        // IsBinaryExists() / IsVersionMatches(): under an active ServerPathEnvVar override
+                        // those three describe the developer's own binary, which exists and reports a match
+                        // by construction — so they would pass however the publish went, and the one path
+                        // that still downloads (the manual menu item) would lose its verification entirely.
+                        if (!File.Exists(CachedExecutableFullPath))
                         {
-                            publishFailReason = $"Server binary missing after publish at: {ExecutableFullPath}";
+                            publishFailReason = $"Server binary missing after publish at: {CachedExecutableFullPath}";
                             return false;
                         }
-                        if (!(IsBinaryExists() && IsVersionMatches()))
+                        if (GetCachedBinaryVersion() != ServerVersion)
                         {
                             publishFailReason = "The published server binary failed the post-publish version check.";
                             return false;
@@ -660,7 +687,9 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 if (outcome == ServerUpdateRestartOutcome.PublishFailed)
                     return FailDownload(publishFailReason ?? "The published server binary failed verification.", unattended);
 
-                UnityEngine.Debug.Log($"Downloaded and unpacked GameDev-MCP-Server binary to: <color=green>{ExecutableFullPath}</color>");
+                // CachedExecutableFullPath, not ExecutableFullPath: this line reports where the DOWNLOAD
+                // landed, which under a ServerPathEnvVar override is not the file the editor will launch.
+                UnityEngine.Debug.Log($"Downloaded and unpacked GameDev-MCP-Server binary to: <color=green>{CachedExecutableFullPath}</color>");
                 UnityEngine.Debug.Log($"MCP server version file created at: <color=green><b>COMPLETED</b></color>");
 
                 // Restart is handled inside the orchestrator when restartAfterPublish is true. When it is false,
@@ -871,8 +900,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 minHeight: 235,
                 title: success ? "Server Binary Updated" : "Server Binary Update Failed",
                 message: success
+                    // GetCachedBinaryVersion(), not GetBinaryVersion(): this popup describes the DOWNLOAD, and
+                    // the launch-target marker it would otherwise read sits in the ServerPathEnvVar override's
+                    // own directory, where there is normally no marker at all.
                     ? "The MCP server binary was successfully downloaded and updated. \n\n" +
-                        $"Version: {GetBinaryVersion()}\n\n" +
+                        $"Version: {GetCachedBinaryVersion()}\n\n" +
                         "You may need to restart your AI agent to reconnect to the updated server."
                     : "Failed to download and update the MCP server binary. Please check the logs for details.");
         }
@@ -1337,7 +1369,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                         CreateNoWindow = true,
                         RedirectStandardOutput = true,
                         RedirectStandardError = true,
-                        WorkingDirectory = ExecutableFolderPath
+                        // Derived from executablePath rather than read from ExecutableFolderPath again: both
+                        // re-resolve ServerPathEnvVar independently, so a second read could hand the process
+                        // a working directory belonging to a different binary than FileName.
+                        WorkingDirectory = Path.GetDirectoryName(executablePath)!
                     };
 
                     // Set executable permissions on Unix-like systems

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor/Scripts/McpServerManager.cs
@@ -22,6 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using com.IvanMurzak.McpPlugin.ServerLaunch;
 using com.IvanMurzak.ReflectorNet.Utils;
+using com.IvanMurzak.Unity.MCP.Editor.DevControl;
 using com.IvanMurzak.Unity.MCP.Editor.UI;
 using com.IvanMurzak.Unity.MCP.Editor.Utils;
 using com.IvanMurzak.Unity.MCP.Runtime.Utils;
@@ -111,6 +112,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         static McpServerManager()
         {
+            var serverPathOverride = ResolveServerPathOverride();
+            if (serverPathOverride != null)
+                _logger.LogInformation(
+                    "{envVar} override active: launching {path} — server download and version check are skipped.",
+                    ServerPathEnvVar,
+                    serverPathOverride);
+
             // Register for editor quit to clean up the server process
             EditorApplication.quitting += OnEditorQuitting;
 
@@ -179,6 +187,41 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 ? ".exe"
                 : string.Empty);
 
+        /// <summary>
+        /// DEV / CI-ONLY override: an absolute path to an EXISTING <c>gamedev-mcp-server(.exe)</c> that the
+        /// editor must launch INSTEAD of the pinned <see cref="ServerVersion"/> GitHub release. When it
+        /// resolves, the download and the version match are skipped entirely, so a workspace-built server
+        /// binary can be driven end-to-end without cutting a release. Mirrors Unreal's
+        /// <c>UNREAL_MCP_SERVER_PATH</c> semantics: the override wins when set AND the file exists, and a
+        /// set-but-missing value FALLS THROUGH to the normal pinned-release behaviour.
+        /// </summary>
+        public const string ServerPathEnvVar = "UNITY_MCP_SERVER_PATH";
+
+        /// <summary>
+        /// Resolve <see cref="ServerPathEnvVar"/> for the current Unity project, or null when it is unset,
+        /// blank, or points at a file that does not exist.
+        /// </summary>
+        public static string? ResolveServerPathOverride()
+            => ResolveServerPathOverride(UnityMcpPluginEditor.ProjectRootPath);
+
+        /// <summary>
+        /// <paramref name="projectRootPath"/>-scoped overload (also the unit-test seam). Reads through
+        /// <see cref="DevControlEnv.Resolve"/> so the lookup layers process-env &gt;
+        /// <c>&lt;projectRoot&gt;/.env</c> — a GUI/IDE-launched editor inherits no shell exports, so a bare
+        /// <c>Environment.GetEnvironmentVariable</c> would be unusable for exactly the developer this
+        /// override exists for. Returns the FULL path when the target exists, else null.
+        /// </summary>
+        public static string? ResolveServerPathOverride(string? projectRootPath)
+        {
+            var raw = DevControlEnv.Resolve(ServerPathEnvVar, projectRootPath);
+            if (string.IsNullOrEmpty(raw))
+                return null;
+
+            return File.Exists(raw)
+                ? Path.GetFullPath(raw)
+                : null;
+        }
+
         // Full path to the server executable
         // Sample (mac linux): ../Library/mcp-server
         // Sample   (windows): ../Library/mcp-server
@@ -191,10 +234,12 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 )
             );
 
-        // Full path to the server executable
+        // The per-RID DOWNLOAD CACHE folder. The ServerPathEnvVar override deliberately does NOT redirect
+        // this: a manual "Download server" menu run must always publish into Library/, never overwrite the
+        // developer's own binary that the override points at.
         // Sample (mac linux): ../Library/mcp-server/osx-x64
         // Sample   (windows): ../Library/mcp-server/win-x64
-        public static string ExecutableFolderPath
+        public static string CachedExecutableFolderPath
             => Path.GetFullPath(
                 Path.Combine(
                     ExecutableFolderRootPath,
@@ -202,16 +247,38 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                 )
             );
 
+        // Folder the server is LAUNCHED from (StartServer's WorkingDirectory) and the folder VersionFullPath
+        // sits in. Equals CachedExecutableFolderPath unless ServerPathEnvVar overrides the binary, in which
+        // case it is the override's own directory.
+        // Sample (mac linux): ../Library/mcp-server/osx-x64
+        // Sample   (windows): ../Library/mcp-server/win-x64
+        public static string ExecutableFolderPath
+        {
+            get
+            {
+                var overridePath = ResolveServerPathOverride();
+                return overridePath != null
+                    ? Path.GetDirectoryName(overridePath)!
+                    : CachedExecutableFolderPath;
+            }
+        }
+
         // Full path to the server executable
         // Sample (mac linux): ../Library/mcp-server/osx-x64/gamedev-mcp-server
         // Sample   (windows): ../Library/mcp-server/win-x64/gamedev-mcp-server.exe
         public static string ExecutableFullPath
-            => Path.GetFullPath(
-                Path.Combine(
-                    ExecutableFolderPath,
-                    ExecutableFullName
-                )
-            );
+        {
+            get
+            {
+                var overridePath = ResolveServerPathOverride();
+                return overridePath ?? Path.GetFullPath(
+                    Path.Combine(
+                        CachedExecutableFolderPath,
+                        ExecutableFullName
+                    )
+                );
+            }
+        }
 
         public static string VersionFullPath
             => Path.GetFullPath(
@@ -274,6 +341,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor
 
         public static bool IsVersionMatches()
         {
+            // Under the ServerPathEnvVar override the launched binary is NOT a pinned GameDev-MCP-Server
+            // release and carries no `version` marker beside it, so the pinned-version comparison does not
+            // apply. Reporting a match is what lets IsBinaryReadyToStart(), DownloadServerBinaryIfNeeded()
+            // and the post-publish check short-circuit instead of downloading over the developer's binary.
+            if (ResolveServerPathOverride() != null)
+                return true;
+
             var binaryVersion = GetBinaryVersion();
             if (binaryVersion == null)
                 return false;
@@ -550,7 +624,10 @@ namespace com.IvanMurzak.Unity.MCP.Editor
                     {
                         // Atomic publish: a single same-volume rename of the fully-prepared payload into the
                         // per-RID cache folder. Either it lands complete or not at all.
-                        PublishStagedBinary(payloadFolder, ExecutableFolderPath);
+                        // CachedExecutableFolderPath, NOT ExecutableFolderPath: a manual menu-driven download
+                        // must land in Library/ even when ServerPathEnvVar is set, so it can never delete and
+                        // replace the developer's own override directory.
+                        PublishStagedBinary(payloadFolder, CachedExecutableFolderPath);
 
                         if (!File.Exists(ExecutableFullPath))
                         {

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerPathOverrideTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerPathOverrideTests.cs
@@ -1,0 +1,251 @@
+/*
+┌──────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)             │
+│  Repository: GitHub (https://github.com/IvanMurzak/Unity-MCP)    │
+│  Copyright (c) 2025 Ivan Murzak                                  │
+│  Licensed under the Apache License, Version 2.0.                 │
+│  See the LICENSE file in the project root for more information.  │
+└──────────────────────────────────────────────────────────────────┘
+*/
+
+#nullable enable
+using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace com.IvanMurzak.Unity.MCP.Editor.Tests
+{
+    /// <summary>
+    /// EditMode unit tests for the <c>UNITY_MCP_SERVER_PATH</c> dev/CI override
+    /// (<see cref="McpServerManager.ServerPathEnvVar"/>): when it points at an EXISTING file that file is
+    /// what the editor launches, and both the GitHub-release download and the pinned-version match are
+    /// skipped. Mirrors Unreal's <c>UNREAL_MCP_SERVER_PATH</c> rule — including the fall-through when the
+    /// override is set but the file is missing.
+    ///
+    /// <para>Deterministic and editor-state-free: every fixture file lives in an isolated OS temp
+    /// directory, nothing touches the network, and the two override SOURCES are both neutralised in
+    /// <c>[SetUp]</c> and restored in <c>[TearDown]</c> — the process env var AND
+    /// <c>&lt;projectRoot&gt;/.env</c> — so the unset baseline really is unset and the <c>.env</c>-layer
+    /// test really does run with no process env.</para>
+    /// </summary>
+    public class McpServerPathOverrideTests
+    {
+        string _tempRoot = string.Empty;
+        string? _originalProcessEnv;
+        string? _originalProjectEnvFile; // content of <projectRoot>/.env; null when the file was absent
+
+        static string ProjectEnvFilePath
+            => Path.Combine(UnityMcpPluginEditor.ProjectRootPath, ".env");
+
+        // The NO-OVERRIDE (pinned release) locations, re-derived here INDEPENDENTLY of the members under
+        // test, so the no-override assertions pin `Library/mcp-server/<rid>/` as a positive artifact rather
+        // than comparing a value with itself.
+        static string ExpectedCacheFolder
+            => Path.GetFullPath(Path.Combine(
+                Application.dataPath, "..", "Library", "mcp-server", McpServerManager.PlatformName));
+
+        static string ExpectedCacheExecutable
+            => Path.GetFullPath(Path.Combine(ExpectedCacheFolder, McpServerManager.ExecutableFullName));
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tempRoot = Path.Combine(Path.GetTempPath(), "mcp-server-path-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempRoot);
+
+            _originalProcessEnv = Environment.GetEnvironmentVariable(McpServerManager.ServerPathEnvVar);
+            Environment.SetEnvironmentVariable(McpServerManager.ServerPathEnvVar, null);
+
+            _originalProjectEnvFile = File.Exists(ProjectEnvFilePath)
+                ? File.ReadAllText(ProjectEnvFilePath)
+                : null;
+            if (_originalProjectEnvFile != null)
+                File.Delete(ProjectEnvFilePath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Environment.SetEnvironmentVariable(McpServerManager.ServerPathEnvVar, _originalProcessEnv);
+
+            try
+            {
+                if (_originalProjectEnvFile != null)
+                    File.WriteAllText(ProjectEnvFilePath, _originalProjectEnvFile);
+                else if (File.Exists(ProjectEnvFilePath))
+                    File.Delete(ProjectEnvFilePath);
+            }
+            catch { /* best effort */ }
+
+            try { if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, recursive: true); }
+            catch { /* best effort */ }
+        }
+
+        /// <summary>A stand-in for a chain-built server binary. Only its PATH is under test here.</summary>
+        string CreateFakeServerBinary()
+        {
+            var dir = Path.Combine(_tempRoot, "chain-build");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, McpServerManager.ExecutableFullName);
+            File.WriteAllText(path, "stand-in for a chain-built gamedev-mcp-server; only its path is asserted");
+            return path;
+        }
+
+        // ── (a) override set to an existing file ────────────────────────────────────
+
+        [Test]
+        public void Override_ExistingFile_IsWhatGetsLaunched()
+        {
+            var exe = CreateFakeServerBinary();
+            var exeFolder = Path.GetFullPath(Path.GetDirectoryName(exe)!);
+            Environment.SetEnvironmentVariable(McpServerManager.ServerPathEnvVar, exe);
+
+            Assert.AreEqual(Path.GetFullPath(exe), McpServerManager.ResolveServerPathOverride());
+            Assert.AreEqual(Path.GetFullPath(exe), McpServerManager.ExecutableFullPath,
+                "ExecutableFullPath (StartServer's FileName, and the generated agent configs' `command`) must be the override");
+            Assert.AreEqual(exeFolder, Path.GetFullPath(McpServerManager.ExecutableFolderPath),
+                "ExecutableFolderPath is StartServer's WorkingDirectory — it must follow the override's own directory");
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(exeFolder, "version")),
+                Path.GetFullPath(McpServerManager.VersionFullPath),
+                "VersionFullPath is derived from ExecutableFolderPath, so it follows the override too");
+            Assert.IsTrue(McpServerManager.IsBinaryExists());
+
+            // The override directory carries NO `version` marker, so IsVersionMatches() can only be true via
+            // the override short-circuit: delete that short-circuit and GetBinaryVersion() returns null.
+            Assert.IsFalse(File.Exists(McpServerManager.VersionFullPath),
+                "fixture precondition: no `version` marker sits beside the override");
+            Assert.IsNull(McpServerManager.GetBinaryVersion(),
+                "fixture precondition: without the short-circuit there is no version to compare");
+            Assert.IsTrue(McpServerManager.IsVersionMatches(),
+                "the override must skip the pinned-release version match");
+            Assert.IsTrue(McpServerManager.IsBinaryReadyToStart(),
+                "IsBinaryReadyToStart() gates the Start button and DownloadServerBinaryIfNeeded()");
+
+            Assert.AreNotEqual(ExpectedCacheExecutable, McpServerManager.ExecutableFullPath,
+                "the pinned Library/mcp-server binary must NOT be the launch target while the override is active");
+        }
+
+        [Test]
+        public void Override_SkipsVersionMatch_EvenWithAMismatchedVersionMarkerBesideIt()
+        {
+            var exe = CreateFakeServerBinary();
+            File.WriteAllText(Path.Combine(Path.GetDirectoryName(exe)!, "version"), "0.0.0-not-the-pinned-version");
+            Environment.SetEnvironmentVariable(McpServerManager.ServerPathEnvVar, exe);
+
+            // Positive artifact: the marker IS readable and DISAGREES with the pin, so a version check that
+            // still ran would return false.
+            Assert.AreEqual("0.0.0-not-the-pinned-version", McpServerManager.GetBinaryVersion());
+            Assert.AreNotEqual(McpServerManager.ServerVersion, McpServerManager.GetBinaryVersion());
+
+            Assert.IsTrue(McpServerManager.IsVersionMatches(),
+                "the override short-circuit must win over a mismatched `version` marker");
+            Assert.IsTrue(McpServerManager.IsBinaryReadyToStart());
+        }
+
+        // ── (b) override set to a path that does not exist ──────────────────────────
+
+        [Test]
+        public void Override_SetButMissingFile_FallsThroughToThePinnedRelease()
+        {
+            // Baseline captured with the override genuinely unset (SetUp neutralised both sources).
+            var unsetExecutable = McpServerManager.ExecutableFullPath;
+            var unsetFolder = McpServerManager.ExecutableFolderPath;
+            var unsetVersionPath = McpServerManager.VersionFullPath;
+            var unsetBinaryExists = McpServerManager.IsBinaryExists();
+            var unsetVersionMatches = McpServerManager.IsVersionMatches();
+            var unsetReady = McpServerManager.IsBinaryReadyToStart();
+
+            var missing = Path.Combine(_tempRoot, "no-such-dir", McpServerManager.ExecutableFullName);
+            Assert.IsFalse(File.Exists(missing), "fixture precondition: the override target must NOT exist");
+            Environment.SetEnvironmentVariable(McpServerManager.ServerPathEnvVar, missing);
+
+            Assert.IsNull(McpServerManager.ResolveServerPathOverride(),
+                "a set-but-missing override must not resolve (the Unreal rule)");
+            Assert.AreEqual(unsetExecutable, McpServerManager.ExecutableFullPath);
+            Assert.AreEqual(unsetFolder, McpServerManager.ExecutableFolderPath);
+            Assert.AreEqual(unsetVersionPath, McpServerManager.VersionFullPath);
+            Assert.AreEqual(unsetBinaryExists, McpServerManager.IsBinaryExists());
+            Assert.AreEqual(unsetVersionMatches, McpServerManager.IsVersionMatches());
+            Assert.AreEqual(unsetReady, McpServerManager.IsBinaryReadyToStart());
+
+            // Positive artifact: the fall-through target is the pinned per-RID cache, not merely "unchanged".
+            Assert.AreEqual(ExpectedCacheExecutable, McpServerManager.ExecutableFullPath);
+            Assert.AreNotEqual(Path.GetFullPath(missing), McpServerManager.ExecutableFullPath);
+        }
+
+        // ── (c) override unset (pinned-release behaviour, pinned so it cannot regress) ──
+
+        [Test]
+        public void NoOverride_KeepsThePinnedLibraryCache_AndTheVersionMarkerCheck()
+        {
+            Assert.IsNull(McpServerManager.ResolveServerPathOverride(),
+                "fixture precondition: neither the process env nor <projectRoot>/.env carries the override");
+
+            Assert.AreEqual(ExpectedCacheFolder, Path.GetFullPath(McpServerManager.ExecutableFolderPath),
+                "with no override the launch folder stays Library/mcp-server/<rid>/");
+            Assert.AreEqual(ExpectedCacheFolder, Path.GetFullPath(McpServerManager.CachedExecutableFolderPath),
+                "the download cache folder is Library/mcp-server/<rid>/ and the override never redirects it");
+            Assert.AreEqual(ExpectedCacheExecutable, McpServerManager.ExecutableFullPath);
+            Assert.AreEqual(Path.GetFullPath(Path.Combine(ExpectedCacheFolder, "version")),
+                Path.GetFullPath(McpServerManager.VersionFullPath));
+
+            // IsVersionMatches() is still driven by the on-disk `version` marker, not short-circuited.
+            var marker = File.Exists(McpServerManager.VersionFullPath)
+                ? File.ReadAllText(McpServerManager.VersionFullPath)
+                : null;
+            Assert.AreEqual(marker, McpServerManager.GetBinaryVersion());
+            Assert.AreEqual(marker == McpServerManager.ServerVersion, McpServerManager.IsVersionMatches());
+            Assert.AreEqual(
+                McpServerManager.IsBinaryExists() && McpServerManager.IsVersionMatches(),
+                McpServerManager.IsBinaryReadyToStart());
+        }
+
+        // ── (d) the <projectRoot>/.env layer ────────────────────────────────────────
+
+        [Test]
+        public void Override_ResolvesFromProjectDotEnv_WhenTheProcessEnvIsUnset()
+        {
+            var exe = CreateFakeServerBinary();
+
+            Assert.IsNull(Environment.GetEnvironmentVariable(McpServerManager.ServerPathEnvVar),
+                "fixture precondition: the process env must be EMPTY — this test exercises the .env layer alone");
+            Assert.IsNull(McpServerManager.ResolveServerPathOverride(),
+                "fixture precondition: nothing resolves before the .env file is written");
+
+            File.WriteAllText(
+                ProjectEnvFilePath,
+                "# written by McpServerPathOverrideTests\n" +
+                McpServerManager.ServerPathEnvVar + "=" + exe + "\n");
+
+            Assert.AreEqual(Path.GetFullPath(exe), McpServerManager.ResolveServerPathOverride(),
+                "a GUI/IDE-launched editor inherits no shell exports, so the override MUST also resolve from <projectRoot>/.env");
+            Assert.AreEqual(Path.GetFullPath(exe), McpServerManager.ExecutableFullPath);
+            Assert.AreEqual(Path.GetFullPath(Path.GetDirectoryName(exe)!),
+                Path.GetFullPath(McpServerManager.ExecutableFolderPath));
+            Assert.IsTrue(McpServerManager.IsBinaryExists());
+            Assert.IsTrue(McpServerManager.IsVersionMatches());
+            Assert.IsTrue(McpServerManager.IsBinaryReadyToStart());
+            Assert.AreNotEqual(ExpectedCacheExecutable, McpServerManager.ExecutableFullPath);
+        }
+
+        [Test]
+        public void ProcessEnv_OutranksProjectDotEnv()
+        {
+            var fromProcess = CreateFakeServerBinary();
+            var envFileDir = Path.Combine(_tempRoot, "from-env-file");
+            Directory.CreateDirectory(envFileDir);
+            var fromEnvFile = Path.Combine(envFileDir, McpServerManager.ExecutableFullName);
+            File.WriteAllText(fromEnvFile, "stand-in");
+
+            File.WriteAllText(
+                ProjectEnvFilePath,
+                McpServerManager.ServerPathEnvVar + "=" + fromEnvFile + "\n");
+            Environment.SetEnvironmentVariable(McpServerManager.ServerPathEnvVar, fromProcess);
+
+            Assert.AreEqual(Path.GetFullPath(fromProcess), McpServerManager.ExecutableFullPath,
+                "process env > .env file, per DevControlEnv.Resolve precedence");
+            Assert.AreNotEqual(Path.GetFullPath(fromEnvFile), McpServerManager.ExecutableFullPath);
+        }
+    }
+}

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerPathOverrideTests.cs
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerPathOverrideTests.cs
@@ -23,20 +23,31 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
     /// skipped. Mirrors Unreal's <c>UNREAL_MCP_SERVER_PATH</c> rule — including the fall-through when the
     /// override is set but the file is missing.
     ///
-    /// <para>Deterministic and editor-state-free: every fixture file lives in an isolated OS temp
+    /// <para>Deterministic and editor-state-free: every fixture BINARY lives in an isolated OS temp
     /// directory, nothing touches the network, and the two override SOURCES are both neutralised in
     /// <c>[SetUp]</c> and restored in <c>[TearDown]</c> — the process env var AND
     /// <c>&lt;projectRoot&gt;/.env</c> — so the unset baseline really is unset and the <c>.env</c>-layer
     /// test really does run with no process env.</para>
+    ///
+    /// <para>That second source is the one piece of REAL project state these tests touch, and it is MOVED
+    /// ASIDE rather than deleted: <c>.env</c> is gitignored, user-owned config that this very feature's
+    /// documentation tells developers to create, so git holds no copy and a run killed before
+    /// <c>[TearDown]</c> must still leave the bytes recoverable on disk rather than only in a field.</para>
     /// </summary>
     public class McpServerPathOverrideTests
     {
         string _tempRoot = string.Empty;
         string? _originalProcessEnv;
-        string? _originalProjectEnvFile; // content of <projectRoot>/.env; null when the file was absent
+        bool _projectEnvFileMovedAside;
 
         static string ProjectEnvFilePath
             => Path.Combine(UnityMcpPluginEditor.ProjectRootPath, ".env");
+
+        // Where the real <projectRoot>/.env is parked while a test owns that path. An on-disk name rather
+        // than an in-memory copy, for the reason the class docblock gives: the file is unrecoverable if a
+        // run dies mid-test holding the only copy in a field.
+        static string ProjectEnvFileAsidePath
+            => ProjectEnvFilePath + ".McpServerPathOverrideTests-aside";
 
         // The NO-OVERRIDE (pinned release) locations, re-derived here INDEPENDENTLY of the members under
         // test, so the no-override assertions pin `Library/mcp-server/<rid>/` as a positive artifact rather
@@ -57,11 +68,19 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             _originalProcessEnv = Environment.GetEnvironmentVariable(McpServerManager.ServerPathEnvVar);
             Environment.SetEnvironmentVariable(McpServerManager.ServerPathEnvVar, null);
 
-            _originalProjectEnvFile = File.Exists(ProjectEnvFilePath)
-                ? File.ReadAllText(ProjectEnvFilePath)
-                : null;
-            if (_originalProjectEnvFile != null)
-                File.Delete(ProjectEnvFilePath);
+            // Recover from an earlier run killed before its [TearDown]: the project's own .env is still
+            // parked under the aside name, so put it back before this run parks it again.
+            if (!File.Exists(ProjectEnvFilePath) && File.Exists(ProjectEnvFileAsidePath))
+                File.Move(ProjectEnvFileAsidePath, ProjectEnvFilePath);
+
+            _projectEnvFileMovedAside = false;
+            if (File.Exists(ProjectEnvFilePath))
+            {
+                if (File.Exists(ProjectEnvFileAsidePath))
+                    File.Delete(ProjectEnvFileAsidePath);
+                File.Move(ProjectEnvFilePath, ProjectEnvFileAsidePath);
+                _projectEnvFileMovedAside = true;
+            }
         }
 
         [TearDown]
@@ -71,24 +90,37 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             try
             {
-                if (_originalProjectEnvFile != null)
-                    File.WriteAllText(ProjectEnvFilePath, _originalProjectEnvFile);
-                else if (File.Exists(ProjectEnvFilePath))
+                // Drop whatever fixture .env a test wrote at the real path, then unpark the developer's own.
+                if (File.Exists(ProjectEnvFilePath))
                     File.Delete(ProjectEnvFilePath);
+                if (_projectEnvFileMovedAside)
+                    File.Move(ProjectEnvFileAsidePath, ProjectEnvFilePath);
             }
-            catch { /* best effort */ }
+            catch (Exception ex)
+            {
+                // Deliberately NOT best-effort-silent: on failure the project's own .env is still sitting
+                // under the aside name and the next Editor launch would read no .env at all. Debug.LogError
+                // fails the test, which is the correct loudness for losing a developer's config.
+                Debug.LogError(
+                    $"{nameof(McpServerPathOverrideTests)}: failed to restore {ProjectEnvFilePath}"
+                    + (_projectEnvFileMovedAside ? $" from {ProjectEnvFileAsidePath}" : string.Empty)
+                    + $": {ex}");
+            }
 
             try { if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, recursive: true); }
             catch { /* best effort */ }
         }
 
-        /// <summary>A stand-in for a chain-built server binary. Only its PATH is under test here.</summary>
+        /// <summary>
+        /// A stand-in for a server binary built from source — the case the override exists for. Only its
+        /// PATH is under test here, so the contents are irrelevant.
+        /// </summary>
         string CreateFakeServerBinary()
         {
-            var dir = Path.Combine(_tempRoot, "chain-build");
+            var dir = Path.Combine(_tempRoot, "built-from-source");
             Directory.CreateDirectory(dir);
             var path = Path.Combine(dir, McpServerManager.ExecutableFullName);
-            File.WriteAllText(path, "stand-in for a chain-built gamedev-mcp-server; only its path is asserted");
+            File.WriteAllText(path, "stand-in for a gamedev-mcp-server built from source; only its path is asserted");
             return path;
         }
 
@@ -109,6 +141,11 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.AreEqual(Path.GetFullPath(Path.Combine(exeFolder, "version")),
                 Path.GetFullPath(McpServerManager.VersionFullPath),
                 "VersionFullPath is derived from ExecutableFolderPath, so it follows the override too");
+
+            // This assertion and the IsBinaryReadyToStart() one below are ENTAILED by the ExecutableFullPath
+            // equality above plus the resolver's own File.Exists gate: no mutation of this feature can redden
+            // them. They are kept as executable documentation of the contract callers rely on, and must not
+            // be counted as independent evidence that the override works.
             Assert.IsTrue(McpServerManager.IsBinaryExists());
 
             // The override directory carries NO `version` marker, so IsVersionMatches() can only be true via
@@ -124,6 +161,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
 
             Assert.AreNotEqual(ExpectedCacheExecutable, McpServerManager.ExecutableFullPath,
                 "the pinned Library/mcp-server binary must NOT be the launch target while the override is active");
+
+            // The other half of that split, and the one nothing else pins: the DOWNLOAD CACHE tier is not
+            // redirected by the override. `Download Binaries` must keep publishing into Library/ rather than
+            // deleting and replacing the developer's own folder, and the post-publish verification reads this
+            // tier precisely because the launch-target members report the override and so cannot fail.
+            Assert.AreEqual(ExpectedCacheFolder, Path.GetFullPath(McpServerManager.CachedExecutableFolderPath),
+                "an active override must NOT move the download cache");
         }
 
         [Test]
@@ -141,6 +185,13 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.IsTrue(McpServerManager.IsVersionMatches(),
                 "the override short-circuit must win over a mismatched `version` marker");
             Assert.IsTrue(McpServerManager.IsBinaryReadyToStart());
+
+            // The DOWNLOAD path reads a different marker than the LAUNCH path, and this is the contrast that
+            // makes DownloadAndUnpackBinary's post-publish verification able to fail at all while an override
+            // is active: GetBinaryVersion() above returned the mismatched marker sitting beside the override,
+            // so a cache read that followed the override would return it too.
+            Assert.AreNotEqual("0.0.0-not-the-pinned-version", McpServerManager.GetCachedBinaryVersion(),
+                "the download-cache version read must NOT follow the override");
         }
 
         // ── (b) override set to a path that does not exist ──────────────────────────
@@ -191,14 +242,16 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
                 Path.GetFullPath(McpServerManager.VersionFullPath));
 
             // IsVersionMatches() is still driven by the on-disk `version` marker, not short-circuited.
+            // Deliberately ONE assertion: re-deriving GetBinaryVersion()'s own body from the same path
+            // expression, and restating IsBinaryReadyToStart() as IsBinaryExists() && IsVersionMatches(),
+            // are both true by construction. The second is the sharper trap — the only mutation it could
+            // catch is `&&` to `||`, and its two operands are EQUAL in both environments this suite runs in
+            // (a clean runner: false/false; a box holding the pinned release: true/true), so it stays green
+            // even then. Neither was kept, so nothing here reads as coverage it does not provide.
             var marker = File.Exists(McpServerManager.VersionFullPath)
                 ? File.ReadAllText(McpServerManager.VersionFullPath)
                 : null;
-            Assert.AreEqual(marker, McpServerManager.GetBinaryVersion());
             Assert.AreEqual(marker == McpServerManager.ServerVersion, McpServerManager.IsVersionMatches());
-            Assert.AreEqual(
-                McpServerManager.IsBinaryExists() && McpServerManager.IsVersionMatches(),
-                McpServerManager.IsBinaryReadyToStart());
         }
 
         // ── (d) the <projectRoot>/.env layer ────────────────────────────────────────
@@ -227,6 +280,35 @@ namespace com.IvanMurzak.Unity.MCP.Editor.Tests
             Assert.IsTrue(McpServerManager.IsVersionMatches());
             Assert.IsTrue(McpServerManager.IsBinaryReadyToStart());
             Assert.AreNotEqual(ExpectedCacheExecutable, McpServerManager.ExecutableFullPath);
+        }
+
+        /// <summary>
+        /// The <c>projectRootPath</c>-scoped overload is PUBLIC and documented as the unit-test seam, so it
+        /// gets a test of its own — the sibling test above proves the same layer end-to-end through the real
+        /// project root, which is what the wiring needs, but leaves the overload itself unexercised. Reading
+        /// an arbitrary root also pins the property the overload exists for: the root is an ARGUMENT, not the
+        /// live project, so the resolver has no hidden dependence on <c>UnityMcpPluginEditor</c>.
+        /// </summary>
+        [Test]
+        public void ResolveServerPathOverride_ReadsTheDotEnvOfTheGivenProjectRoot()
+        {
+            var exe = CreateFakeServerBinary();
+            var otherProjectRoot = Path.Combine(_tempRoot, "another-project-root");
+            Directory.CreateDirectory(otherProjectRoot);
+
+            Assert.IsNull(Environment.GetEnvironmentVariable(McpServerManager.ServerPathEnvVar),
+                "fixture precondition: the process env must be EMPTY — this test exercises the .env layer alone");
+            Assert.IsNull(McpServerManager.ResolveServerPathOverride(otherProjectRoot),
+                "fixture precondition: that root carries no .env yet");
+
+            File.WriteAllText(
+                Path.Combine(otherProjectRoot, ".env"),
+                McpServerManager.ServerPathEnvVar + "=" + exe + "\n");
+
+            Assert.AreEqual(Path.GetFullPath(exe), McpServerManager.ResolveServerPathOverride(otherProjectRoot),
+                "the overload must read the .env of the root it was HANDED");
+            Assert.IsNull(McpServerManager.ResolveServerPathOverride(),
+                "and the no-arg overload must still see nothing: that .env belongs to a different root");
         }
 
         [Test]

--- a/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerPathOverrideTests.cs.meta
+++ b/Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Tests/Editor/McpServerPathOverrideTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d2a478515ecdc8428209c7a99f9aaf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -40,9 +40,11 @@ The **Unity Plugin** automatically downloads and runs the appropriate server bin
 Intended for developing the server itself and for CI chains that build the server from source — not for everyday use. Details:
 
 - The value is read through the same `process env` → `<projectRoot>/.env` → unset chain as `UNITY_MCP_DEV_CONTROL`, so an Editor launched from the GUI or an IDE (which inherits no shell exports) can still pick it up from a `.env` file at the Unity project root.
-- **Set-but-missing falls through**: if the path does not exist, the plugin behaves exactly as if the variable were unset. This matches Unreal-MCP's `UNREAL_MCP_SERVER_PATH`.
+- **Set-but-missing falls through**: if the path does not exist, the plugin behaves exactly as if the variable were unset. This matches Unreal-MCP's `UNREAL_MCP_SERVER_PATH`. That fall-through is silent, so confirm from the Editor console rather than assuming: the `Starting MCP server: <path> …` line names the binary that was actually launched, every time. The `UNITY_MCP_SERVER_PATH override active: …` notice is emitted only when the override already resolves as the domain loads, so it is absent if you write the `.env` afterwards — the launch line is the one to trust.
+- Use an **absolute** path. A relative value is resolved against the Editor process's working directory, not against the Unity project root. The filename itself is not constrained: whatever file the path names is the file that gets launched.
 - The override also becomes the `command` written into generated AI-agent configs, so the agent launches the same binary the Editor does.
 - `Tools/AI Game Developer/Server/Download Binaries` (the manual menu item) still downloads into `Library/mcp-server/<rid>/` regardless of the override; the override still wins at launch.
+- `Tools/AI Game Developer/Server/Open Server Logs` follows the override, because the server's working directory is the folder its binary sits in — so the logs you open are the ones the overridden server actually wrote.
 
 ### 2. Docker
 See **[Docker Deployment](DOCKER_DEPLOYMENT.md)**. Best for cloud hosting or isolated environments.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -31,6 +31,19 @@ The **MCP Server** acts as the bridge between the **AI Client** (Claude, Cursor,
 ### 1. Local Automatic (Recommended)
 The **Unity Plugin** automatically downloads and runs the appropriate server binary for your OS. No manual setup required. Configuration is done via the Unity Editor window.
 
+#### Overriding the launched binary — `UNITY_MCP_SERVER_PATH` (dev / CI only)
+
+| Environment Variable    | Value                                                                        | Effect                                                                                                                              |
+| :---------------------- | :--------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+| `UNITY_MCP_SERVER_PATH` | Absolute path to an **existing** `gamedev-mcp-server` (`.exe` on Windows)     | The Editor launches **that** file instead of the release pinned by `ServerVersion`, and skips both the download and the version match. |
+
+Intended for developing the server itself and for CI chains that build the server from source — not for everyday use. Details:
+
+- The value is read through the same `process env` → `<projectRoot>/.env` → unset chain as `UNITY_MCP_DEV_CONTROL`, so an Editor launched from the GUI or an IDE (which inherits no shell exports) can still pick it up from a `.env` file at the Unity project root.
+- **Set-but-missing falls through**: if the path does not exist, the plugin behaves exactly as if the variable were unset. This matches Unreal-MCP's `UNREAL_MCP_SERVER_PATH`.
+- The override also becomes the `command` written into generated AI-agent configs, so the agent launches the same binary the Editor does.
+- `Tools/AI Game Developer/Server/Download Binaries` (the manual menu item) still downloads into `Library/mcp-server/<rid>/` regardless of the override; the override still wins at launch.
+
 ### 2. Docker
 See **[Docker Deployment](DOCKER_DEPLOYMENT.md)**. Best for cloud hosting or isolated environments.
 


### PR DESCRIPTION
## Summary

- Adds **`UNITY_MCP_SERVER_PATH`**. When it resolves to a file that **exists**, that file is the
  binary the Editor launches, and both the GitHub-release download and the pinned-version match are
  skipped. When it is unset — or set to a path that does not exist — nothing changes: the plugin
  keeps using `Library/mcp-server/<rid>/` and the release pinned by `ServerVersion` (`9.2.5`, which
  this PR does **not** touch). Same rule as Unreal-MCP's `UNREAL_MCP_SERVER_PATH`, fall-through
  included.
- Resolved through the **existing `DevControlEnv.Resolve` layer** (`process env` →
  `<projectRoot>/.env` → unset) rather than a bare `Environment.GetEnvironmentVariable`, so an
  Editor launched from the GUI or an IDE — which inherits no shell exports — can still pick the
  override up from a `.env` at the Unity project root.
- The override splits the two tiers that used to be one: the **launch target** follows it, the
  **download cache** never does. Everything that describes or verifies a *download* reads the cache
  tier explicitly, so a manual `Download Binaries` run still verifies and reports the file it
  actually wrote.
- Scope: **one** product file, one new EditMode test file, one docs subsection.
  `git diff --stat origin/main -- Unity-MCP-Plugin/Packages/com.ivanmurzak.unity.mcp/Editor` lists
  only `Scripts/McpServerManager.cs`; `git diff --stat origin/main -- .github` is **empty**.

### What the override changes, member by member

| Member | Override inactive (unset, or set-but-missing) | Override active |
| :-- | :-- | :-- |
| `ResolveServerPathOverride()` | `null` | the full path |
| `ExecutableFullPath` | `Library/mcp-server/<rid>/gamedev-mcp-server(.exe)` | the override |
| `ExecutableFolderPath` (`StartServer`'s `WorkingDirectory`) | `Library/mcp-server/<rid>/` | the override's directory |
| `VersionFullPath` | `Library/mcp-server/<rid>/version` | `<override dir>/version` |
| `IsVersionMatches()` | reads the `version` marker and compares to `ServerVersion` | `true` (there is no marker beside a workspace-built binary) |
| `CachedExecutableFolderPath` | `Library/mcp-server/<rid>/` | `Library/mcp-server/<rid>/` — **never redirected** |
| `CachedExecutableFullPath` | `Library/mcp-server/<rid>/gamedev-mcp-server(.exe)` | unchanged — **never redirected** |
| `GetCachedBinaryVersion()` | `Library/mcp-server/<rid>/version` | unchanged — **never redirected** |

`IsBinaryReadyToStart()`, the `DownloadServerBinaryIfNeeded` gate and the editor-startup /
package-update paths all short-circuit off `IsBinaryExists() && IsVersionMatches()`, so under an
override `DownloadAndUnpackBinary` is never entered from either automatic path.

**The manual menu item is the one download path that stays live under an override**, and the bottom
three rows of that table are what keep it honest. `MenuItems.DownloadServer` calls
`DownloadAndUnpackBinary` *directly*, bypassing that gate, so with an override set it still runs —
and every member that describes the *launch target* is, by construction, true about the developer's
own binary. So the download path publishes to `CachedExecutableFolderPath`, **verifies**
`CachedExecutableFullPath` + `GetCachedBinaryVersion()`, and **reports** the same, rather than
`ExecutableFullPath` / `IsBinaryExists()` / `IsVersionMatches()` / `GetBinaryVersion()`. Had it kept
reading the launch tier, `Download Binaries` would have reported success however the publish went
(the override file exists because the resolver only returns it after `File.Exists` passed, and
`IsVersionMatches()` short-circuits to `true`), logged the override path as the download
destination, and shown a blank `Version:` in the result popup. This is the same reasoning that moved
`PublishStagedBinary` off `ExecutableFolderPath`: without it, a manual download would have deleted
and replaced the developer's own override directory, and the documented sentence *"downloads into
`Library/` regardless of the override; the override still wins at launch"* would have been false.

## Evidence

### 1. Behavioural proof against the real launch path

Unity **2022.3.62f3**, this repo's own `Unity-MCP-Plugin` project in a fresh worktree whose
`Library/` did not exist. Override target: a locally published server —
`dotnet publish shared/GameDev-MCP-Server/com.IvanMurzak.GameDev.MCP.Server.csproj -c Release
-r win-x64 --self-contained true -p:PublishSingleFile=true` → `ProductVersion 9.2.6+62a6b7d1`,
i.e. deliberately **not** the pinned `9.2.5`, at a path outside `Library/`.

**Half 1 — `UNITY_MCP_SERVER_PATH` set** (`Editor.log`, verbatim, colour tags stripped):

```
info: [13:53:11:2855] [AI] McpServerManager UNITY_MCP_SERVER_PATH override active: launching
  ...\.agent-scratch\chain-server\gamedev-mcp-server.exe — server download and version check are skipped.
info: [13:53:15:0678] [AI] McpServerManager Starting MCP server:
  ...\.agent-scratch\chain-server\gamedev-mcp-server.exe port=5780 plugin-timeout=1800000
  client-transport=streamableHttp auth=none
```

- `grep -c 'Downloaded and unpacked' Editor.log` → **0**
- `grep -c 'Deleted existing MCP server folder' Editor.log` → **0**
- `Unity-MCP-Plugin/Library/mcp-server` → **does not exist**
- live process: `gamedev-mcp-server.exe` `ExecutablePath = ...\.agent-scratch\chain-server\gamedev-mcp-server.exe`
- the plugin reached READY through it (`wait-for-ready` exit 0, SignalR `negotiate` returned 200 with a `connectionId`).

**Half 2 — the plant the brief asks for: same Editor, variable unset.**

```
info: [13:54:39:7257] [AI] McpServerManager Starting MCP server:
  ...\Unity-MCP-Plugin\Library\mcp-server\win-x64\gamedev-mcp-server.exe port=5780 ...
Downloaded and unpacked GameDev-MCP-Server binary to:
  ...\Unity-MCP-Plugin\Library\mcp-server\win-x64\gamedev-mcp-server.exe
```

`Library/mcp-server/win-x64/` now exists with a `version` marker reading `9.2.5`, and the
`override active` line is **absent** from that run. So the launch target moved with the variable in
both directions, and the download only happened when the override was gone.

### 2. Plant rounds — six plants, each RED attributed from its own run

Applied with the `Edit` tool, each confirmed live in `git diff` before the run and reverted after;
`assets-refresh` between every plant and its run. Every round ran
`tests-run --input {"testMode":"EditMode","testClass":"McpServerPathOverrideTests",...}` and the
verdict is read **per test from the run's own JSON** — `unity-mcp-cli` exits `0` even when tests
fail, so an exit status could not have told these apart.

| Plant | Mutation | Result |
| :-- | :-- | :-- |
| baseline | none | 7 passed / 0 failed |
| **P1** | delete the `IsVersionMatches()` override short-circuit | **3 failed**: `Override_ExistingFile_IsWhatGetsLaunched` (*"the override must skip the pinned-release version match"*), `Override_SkipsVersionMatch_EvenWithAMismatchedVersionMarkerBesideIt`, `Override_ResolvesFromProjectDotEnv_WhenTheProcessEnvIsUnset` |
| **P2** | delete the `File.Exists(raw)` check in `ResolveServerPathOverride` | **1 failed**: `Override_SetButMissingFile_FallsThroughToThePinnedRelease` (*"a set-but-missing override must not resolve (the Unreal rule)"*) |
| **P3** | `ExecutableFolderRootPath` literal `"mcp-server"` → `"mcp-server-planted"` | **3 failed**: `NoOverride_KeepsThePinnedLibraryCache_AndTheVersionMarkerCheck`, the pinned-cache assertion in `Override_SetButMissingFile_FallsThroughToThePinnedRelease`, and the cache assertion in `Override_ExistingFile_IsWhatGetsLaunched` |
| **P4** | `DevControlEnv.Resolve(...)` → `Environment.GetEnvironmentVariable(...)` | **2 failed**: `Override_ResolvesFromProjectDotEnv_WhenTheProcessEnvIsUnset` and `ResolveServerPathOverride_ReadsTheDotEnvOfTheGivenProjectRoot` (both `But was: null`) |
| **P5** | make `CachedExecutableFolderPath` follow the override | **2 failed**: *"an active override must NOT move the download cache"* and *"the download-cache version read must NOT follow the override"* — while the **no-override test stays green**, which is what proves the mutation bites only under an override |
| **P6** | `GetCachedBinaryVersion()` reads `VersionFullPath` instead of `<cache>/version` | **1 failed**: *"the download-cache version read must NOT follow the override"* (`But was: "0.0.0-not-the-pinned-version"`) |
| final | all plants reverted, no residue | 7 passed / 0 failed, `Logs: []` |

P1 and P2 are the two the brief mandates. P3 and P4 exist because two other claims would otherwise
have been unfalsifiable: P3 proves the *no-override* test really pins `Library/mcp-server/<rid>/`
rather than comparing a value with itself, and P4 proves the `.env` layer is load-bearing rather
than incidental. P5 and P6 cover the download/launch tier split — they are the plants for behaviour
this PR changed in production code, derived from the change rather than from an existing test.

**P5 and P6 attack one claim at two sites and share a red with identical text.** Both redden
*"the download-cache version read must NOT follow the override"* verbatim. They are told apart by
their failure SET, not by that line: P5 additionally reddens the cache-**folder** assertion in
`Override_ExistingFile_IsWhatGetsLaunched`; P6 reddens the version assertion alone. Stated rather
than papered over, because a future red on that marker alone means P6's site, not P5's.

**What makes each assertion able to fail** (stated because a check that cannot fail scores green
with the feature deleted):

- The override fixture directory contains **no `version` marker**, and the test asserts that
  (`Assert.IsFalse(File.Exists(VersionFullPath))`, `Assert.IsNull(GetBinaryVersion())`) before
  asserting `IsVersionMatches()` is `true` — so that `true` can only come from the short-circuit.
  A sibling test goes further and puts a marker reading `0.0.0-not-the-pinned-version` beside the
  override, asserts the marker is readable and disagrees with `ServerVersion`, and still requires
  `IsVersionMatches()` to be `true`. That same fixture is what makes P6 discriminate: with the
  mismatched marker beside the override, a cache read that followed the override returns it.
- The fall-through test captures the genuinely-unset baseline first (`[SetUp]` neutralises **both**
  sources — the process env var *and* `<projectRoot>/.env` — and `[TearDown]` restores them), then
  asserts equality with it **and** equality with an independently re-derived
  `Library/mcp-server/<rid>/gamedev-mcp-server.exe`, so "unchanged" cannot be satisfied by nothing
  having been read at all.
- The `.env` tests assert the process env var is empty and that nothing resolves *before* the file
  is written, so neither can pass on a process-env read.

**Environment-conditional assertions — four of them, not one.** Corrected here after the review
pass measured it; the earlier revision of this section understated the count.

| Assertion | Discriminates on a clean CI runner (no `Library/` cache) | Discriminates on a box holding the pinned release |
| :-- | :-- | :-- |
| `NoOverride…`: `IsVersionMatches() == (marker == ServerVersion)` | yes (no marker ⇒ `false == false`, and an unconditional `true` reddens) | no (both sides `true`) |
| `SetButMissing…`: `IsBinaryExists()` unchanged | no | yes |
| `SetButMissing…`: `IsVersionMatches()` unchanged | yes | no |
| `SetButMissing…`: `IsBinaryReadyToStart()` unchanged | no | yes |

The suite is sound regardless, because the **path equalities** in those same tests — and the
cache-folder assertions P3 and P5 redden — discriminate in *every* environment. No assertion is
relied on where it cannot fail, and the two assertions that could not discriminate anywhere
(`GetBinaryVersion()` re-derived from its own body, and `IsBinaryReadyToStart()` restated as
`IsBinaryExists() && IsVersionMatches()`) were removed rather than left reading as coverage.

### 3. Local suites

- **Suite 1 — Unity EditMode**, full chunked run against `Unity-MCP-Plugin` (2022.3.62f3): see the
  "Suites" line below.
- **Suite 2 — PlayMode: not applicable.** The diff touches only `Editor/` (Editor-only assembly)
  and `docs/`; nothing is compiled into a player.
- **Suite 3 — CLI: not applicable.** No file under `cli/` changed.
- **Suite 4 — CI surface: not applicable** (no `.github/**` change), but
  `python .github/scripts/check_nuget_gate.py` was run anyway and exits **0**:
  `NuGet gate OK: 15 pins, generation UNITY_MCP_DEPS_3, propagation consistent.`

## Review pass (`/code-review` + `/simplify`)

Three report-only reviewers over the full diff, plus an in-context pass. Everything below was
verified from source before it was applied; findings whose *prescription* was wrong are recorded as
such rather than followed.

**Applied — three real defects, all on the manual-download path, all invisible unless the override
is active** (detailed in the member table above): the post-publish verification was vacuous, the
success log named the override instead of the download destination, and the result popup read the
version marker from the override's directory. Plus one consistency fix: `StartServer` now derives
`WorkingDirectory` from the `executablePath` local instead of re-resolving `ExecutableFolderPath`,
so `FileName` and `WorkingDirectory` cannot describe different binaries.

**Applied — test hardening.** `[SetUp]` used to `File.Delete` the real `<projectRoot>/.env` with the
only copy in a managed field. That file is gitignored, user-owned config that *this feature's own
docs* tell developers to create, so git holds no copy and a run killed before `[TearDown]` — a
domain reload, a cancelled run, an editor crash — would have destroyed it. It is now **moved aside**
to a sibling path and moved back, `[SetUp]` recovers a file left parked by an earlier killed run,
and a failed restore is a `Debug.LogError` (which fails the test) instead of a silent
`catch { /* best effort */ }`.

**Applied — one new test.** `ResolveServerPathOverride(string? projectRootPath)` is public and
documented as the unit-test seam, and no test used it. It has one now, reading an arbitrary root's
`.env` from a temp directory — which also pins that the root is an *argument* rather than the live
project.

**Not applied, recorded instead:**
- Moving the override resolution beside `DevControlEnv`, where the two sibling dev-only vars and
  their resolvers live. Genuinely the better home; out of bounds, since the brief fixes
  `McpServerManager.cs` as the only product file.
- Rewriting the `.env` tests to use the seam against a temp root *instead of* the real project root.
  That would drop the end-to-end coverage of `ExecutableFullPath` following `<projectRoot>/.env`,
  which is exactly what the brief asks the `.env` case to prove. The seam got its own test instead.
- Logging a warning when `UNITY_MCP_SERVER_PATH` is set but the file is missing. The silent
  fall-through is the ruled Unreal semantics; a new unverified log line late in review is not worth
  it. The docs now point at the `Starting MCP server: <path>` line as the reliable confirmation
  instead — which is also why the `override active` notice is no longer described as authoritative:
  it is emitted once per domain load, so it is absent if you write the `.env` afterwards even though
  the override still applies.
- Caching the resolution per domain load. It would break the tests and change behaviour; no caller
  is on a per-frame path (checked: no `EditorApplication.update` subscriber reads these members
  without self-unsubscribing, no `OnGUI`, no `schedule.Execute` loop).

## Not done, on purpose

- `ServerVersion` (`McpServerManager.cs`) is unchanged.
- `MenuItems.DownloadServer` still downloads into `Library/`, which is documented.
- `Editor/DependencyResolver/**`, `NuGetConfig.cs`, the `Assets/Plugins/NuGet` drops, `cli/**`,
  `Runtime/**`, `UpdateChecker` and every UI file are untouched.
- No version field in any `package.json` was bumped.
- `DownloadAndUnpackBinary`'s own body has **no** EditMode coverage — it downloads — so the
  post-publish fix is verified through the members it now reads (`CachedExecutableFolderPath`,
  `GetCachedBinaryVersion()`, planted P5/P6) rather than by exercising the download itself.

## Test plan

- [x] EditMode suite `McpServerPathOverrideTests` — **7 tests**, 0 failures, `Logs: []`.
- [x] Six plant rounds, each RED attributed per test from its own run log; all reverted; residue-checked; final run green.
- [x] Behavioural proof on the real launch path, both directions.
- [x] `check_nuget_gate.py` exit 0.
- [x] Target-specific local tests passed (see profile `test.md`).

## CI

- **Authoritative CI run for this PR's current head** (`test-pull-request`) on
  `05be00d2f137907414582d362e9836f8322e5dcc`: **id `33815830447`** —
  <https://github.com/IvanMurzak/Unity-MCP/actions/runs/33815830447> — **17/17 checks green**:
  `nuget gate`, `test-cli (20)`, `test-cli (22)`, the twelve licensed `test-unity-*` legs
  (2022.3.62f3 / 2023.2.22f1 / 6000.3.1f1 x editmode/standalone x base/windows-mono),
  `Test Results` and `save-event-file`. SHA-tied: that run's `headSha` equals this PR's
  current `headRefOid`, so it covers the refine commit as well as the implement commit.
- SUPERSEDED — PR run on the pre-refine head `80143639`: id `33807352185` —
  <https://github.com/IvanMurzak/Unity-MCP/actions/runs/33807352185> — all 17 checks green
  (SHA-tied: `801436398b953ad345e454b3f719fdc5b96a65c9`). Retained for history only; it does
  NOT cover the refine commit. The authoritative run above is the one this PR is gated on.
  This is a same-repository branch, so the twelve licensed `test-unity-*` legs
  receive the repository secrets (the late-August red runs on this repo were fork PRs, per #974).

