### PR TITLE
chore(gitignore): ignore __pycache__/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Unity-MCP.wiki
 # Claude Code subagent memory can leak here when an agent runs with its cwd inside this repo.
 # Canonical agent memory lives ONLY in the top-level infra repo; ignore it everywhere here.
 **/.claude/agent-memory/
+
+# Python bytecode (e.g. .github/scripts/ generates __pycache__/*.pyc when CI gates run locally).
+__pycache__/


### PR DESCRIPTION
Untracked agent/pipeline residue made this submodule show as permanently
modified in the `software` superproject. This adds the narrowest ignore rules
for it. **One file changed: `.gitignore`.**

Nothing ignored here is source:
- `.claude/worktrees/` — ephemeral host-created subagent checkouts.
- `.pipeline/.runtime/`, `.pipeline/.stats/` — machine-generated pipeline run
  state. `.pipeline/.hooks/` stays tracked.
- `__pycache__/` — Python bytecode.

Verified both directions with `git check-ignore --no-index -v`: every offending
path matches the new rule, and tracked source (`.pipeline/.hooks/`,
`.claude/settings.json`, `.github/scripts/*.py`, `src/`) does **not** match — so
the rule is neither inert nor over-broad.

No pipeline `.runtime/` content was deleted; those files are run forensics and
were left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKGcRJUSkMBZ3DLmR51aDM